### PR TITLE
Update deploy syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ After SGX-LKL has been built, it is possible to deploy the container with the
 Java HelloWorld example on the local (or a remote) machine:
 
 ```
-./sgx-lkl-docker.sh deploy-jvm-helloworld -s
+./sgx-lkl-docker.sh deploy -a jvm-helloworld -s
 ```
 
 (Deployment on a remote Docker machine requires `docker-machine` to be set up.)


### PR DESCRIPTION
After [this](https://github.com/lsds/sgx-lkl/commit/ae248127099281a979d637329f5f0e9e1d5431b5#diff-f1ef8690eec8fceabbe4c435e9b556f2L83) commit deploy-jvm-helloworld is not longer a valid argument.