### PR TITLE
Use the correct target name for liblkl to make tools build depend on lkl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lkl ${LIBLKL} ${LKL_BUILD}/include: ${HOST_MUSL_CC} | ${LKL}/.git ${LKL_BUILD} $
 tools: ${TOOLS_OBJ}
 
 # Generic tool rule (doesn't actually depend on lkl_lib, but on LKL headers)
-${TOOLS_BUILD}/%: ${TOOLS}/%.c ${HOST_MUSL_CC} ${LKL_LIB} | ${TOOLS_BUILD}
+${TOOLS_BUILD}/%: ${TOOLS}/%.c ${HOST_MUSL_CC} ${LIBLKL} | ${TOOLS_BUILD}
 	${HOST_MUSL_CC} ${SGXLKL_CFLAGS} --static -I${LKL_BUILD}/include/ -o $@ $<
 
 # More headers required by SGX-Musl not exported by LKL, given by a custom tool's output


### PR DESCRIPTION
I recently learned about this project and wanted to check it out (cool stuff!)

I did hit a small hiccup when building though. The build for the tools target does not properly depend on liblkl as it uses a nonexistent variable name in the Makefile. So if you run `make -j$(nproc) tools`, the lkl headers are missing. If you rune make with one processor, this problem does not manifest.