### PR TITLE
Disable msys mangling in sgx-lkl-docker, when detected

### DIFF
--- a/sgx-lkl-docker.sh
+++ b/sgx-lkl-docker.sh
@@ -6,6 +6,13 @@
 
 set -e
 
+# Support windows msys environments
+if  [ "${OSTYPE}" == "msys" ]; then
+    # See https://github.com/git-for-windows/msys2-runtime/pull/11 for context
+    export MSYS_NO_PATHCONV=1
+    echo "Detected msys: Disabled msys mangling."
+fi
+
 VOLUME_MOUNTS=$PWD:/sgx-lkl
 SSH_AGENT_WORKAROUND=
 


### PR DESCRIPTION
Hi there - first off, thanks for a great solution for TEE development. This project is great! 🎉

In using this locally, I've found a few issues when running using docker+win10 in non-WSL bash environments (specific msys, via git-for-windows) This PR resolves those issues, by controlling how msys-like environments (and only these) handle path mangling, and informing them to simply not do this. With mangling disabled, paths resolve correctly, and msys doesn't mess with things unnecessarily.

For me, these few lines are the difference between this project working out of the box, and requiring some fiddling, so I thought I'd try and see if you folks were open to landing a quality of life fix like this. 🙏

<details>
<summary>
Background Details 📝
</summary>

By default, these msys environments try to help the user, by converting things like `/bin/bash` to `C:/Program Files/Git/usr/bin/bash`. It's quite smart about when to do this, but you can see it occur with the following example:

```
$ docker run -it ubuntu:18.04 /bin/bash
C:\Program Files\Docker\Docker\Resources\bin\docker.exe: Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"C:/Program Files/Git/usr/bin/bash\": stat C:/Program Files/Git/usr/bin/bash: no such file or directory": unknown.
```

This is because `docker` expands to `docker.exe` (as we don't have docker in msys, only in the windows host itself) and msys detects this difference, and tries to help. It assumes that if we're calling an `exe` and giving a path to something that is also technically an `exe` (in this case, `/bin/bash`, since it knows that locally `/bin/bash` is actually `C:/Program Files/Git/usr/bin/bash.exe`) we want to pass the path to the `exe`, rather than the actual given literal path. So it applies this transformation for us, and when docker runs it gets the `exe` path, not the `/bin/bash` literal.

This fails to execute inside the docker environment, as there is no `C:/Program Files/Git/usr/bin/bash.exe`, there is only `/bin/bash`.

One [workaround](https://stackoverflow.com/a/14189687) is to replace all instances of `/bin/bash` with `//bin/bash`, which prevents this msys behavior and should not cause issues in most linux distros it seems, as that first `/` is ignored. This however, would be a much more significant change.

The proposed workaround here, is to simply set [the flag that msys uses](https://github.com/git-for-windows/msys2-runtime/pull/11) to determine if it should execute this behavior such that it's informed not to. This looks like `MSYS_NO_PATHCONV=1`.

</details>