### PR TITLE
Add CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.deb.yml
+++ b/.azure-pipelines/azure-pipelines.deb.yml
@@ -6,47 +6,35 @@ pr:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
-# A variable group must be defined in Library section with name "SGX-Vars"
 variables:
-  - group: SGX-Vars
   - name: SGXLKL_ROOT
     value: $(Build.SourcesDirectory)
   - name: SGXLKL_PREFIX
     value: $(Build.SourcesDirectory)/build/install
+  # For some reason $USER is undefined in the scale set agents (Ubuntu stock image)
+  - name: USER
+    value: root
 
 jobs:  
 - job: Build
   displayName: Build
 
   pool:
-    name: "sgx-vms-2"
+    name: "scaleset-sgx"
 
   steps:
     - checkout: self
       submodules: false
       clean: true
 
-    - task: InstallSSHKey@0
-      displayName: "Install an SSH key"
-      inputs:
-        knownHostsEntry: "*"
-        # Public key of 'github_ssh_private_key' (mentioned below) must be declared as variable name in 'SGX-Vars' variable group.
-        # Variable Name - GitHubPublicKey
-        # Variable Value - <your public key data in string format>
-        sshPublicKey: "$(GitHubPublicKey)"
-        # A github private key must be uploaded to "Secure files" Section in Azure Pipelines.
-        # This key must have read access to private repositories.
-        # Once uploaded to secure files, you can rename it to below name.
-        sshKeySecureFile: "github_ssh_private_key"
-
     - bash: .azure-pipelines/scripts/checkout_submodules.sh
       displayName: Checkout Submodules
 
+    - bash: .azure-pipelines/scripts/install_prerequisites.sh
+      displayName: Install pre-requisites
+
     - bash: .azure-pipelines/scripts/install_openenclave.sh
       displayName: Install Open Enclave
-
-    - bash: .azure-pipelines/scripts/cleanup_docker_images.sh
-      displayName: Cleanup untagged Docker images
 
     - bash: .azure-pipelines/scripts/build_docker.sh
       displayName: Compile and Build via Docker (debug)
@@ -91,7 +79,6 @@ jobs:
 
     - task: PublishBuildArtifacts@1
       displayName: Publish APT repository as build artifact
-      condition: always()
       inputs:
         pathtoPublish: build/deb-apt-repo
         artifactName: deb
@@ -103,7 +90,7 @@ jobs:
         pathtoPublish: report
         artifactName: logs
 
-# If you want to publish the .deb packages to the release package feed and APT repository,
+# If you want to publish the .deb packages to the release APT repository,
 # then start the build with variable:
 # Name = PUBLISH_RELEASE
 # Value = 1
@@ -115,8 +102,8 @@ jobs:
   # Don't publish for PR builds.
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
-  # Note: We use a hosted agent for the publish job mostly because it has
-  # the Azure CLI package installed (see below).
+  # A free hosted agent is good enough for the publish job.
+  # It also has the Azure CLI installed already.
   pool:
     vmImage: ubuntu-latest
 
@@ -145,16 +132,6 @@ jobs:
       inputs:
         artifactName: deb
 
-    - task: UniversalPackages@0
-      displayName: Publish APT repository to package feed
-      inputs:
-        command: publish
-        publishDirectory: $(System.ArtifactsDirectory)/deb
-        vstsFeedPublish: ConfidentialLinuxContainers/$(PKG_FEED)
-        vstsFeedPackagePublish: clc
-        versionOption: custom
-        versionPublish: $(SGXLKL_VERSION)
-      
     - task: AzureCLI@2
       displayName: Publish APT repository to Blob container
       inputs:
@@ -163,9 +140,6 @@ jobs:
         azureSubscription: pkg-storage
         scriptType: bash
         scriptLocation: inlineScript
-        # APT does not support repository URLs with query parameters.
-        # Because of that we cannot use SAS URLs and have to "protect" the repository
-        # by using a known random prefix.
         inlineScript: |
           az storage blob upload-batch \
             --account-name clcpackages -d $(BLOB_CONTAINER) \

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,19 +1,20 @@
 trigger:
-  - 'master'
+  - 'oe_port'
 
 pr:
   branches:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string
 
-# A variable group must be defined in Library section with name "SGX-Vars"
 variables:
-  - group: SGX-Vars
   - name: SGXLKL_ROOT
     value: $(Build.SourcesDirectory)
+  # For some reason $USER is undefined in the scale set agents (Ubuntu stock image)
+  - name: USER
+    value: root
 
 pool:
-  name: "sgx-vms-2"
+  name: "scaleset-sgx"
 
 jobs:  
 - job: Build
@@ -51,37 +52,23 @@ jobs:
       submodules: false
       clean: true
 
-    - task: InstallSSHKey@0
-      displayName: "Install an SSH key"
-      inputs:
-        knownHostsEntry: "*"
-        # Public key of 'github_ssh_private_key' (mentioned below) must be declared as variable name in 'SGX-Vars' variable group.
-        # Variable Name - GitHubPublicKey
-        # Variable Value - <your public key data in string format>
-        sshPublicKey: "$(GitHubPublicKey)"
-        # A github private key must be uploaded to "Secure files" Section in Azure Pipelines.
-        # This key must have read access to private repositories.
-        # Once uploaded to secure files, you can rename it to below name.
-        sshKeySecureFile: "github_ssh_private_key"
-
     - task: Bash@3
       displayName: "Checkout Submodules"
       inputs:
         targetType: "FilePath"
         filePath: ".azure-pipelines/scripts/checkout_submodules.sh"
-
+  
+    - task: Bash@3
+      displayName: "Install pre-requisites"
+      inputs:
+        targetType: "FilePath"
+        filePath: ".azure-pipelines/scripts/install_prerequisites.sh"
+    
     - task: Bash@3
       displayName: "Install Openenclave"
       inputs:
         targetType: "FilePath"
         filePath: ".azure-pipelines/scripts/install_openenclave.sh"
-
-    - task: Bash@3
-      displayName: Cleanup untagged Docker images
-      condition: and(succeeded(), eq(variables['use_docker'], 'true'))
-      inputs:
-        targetType: "FilePath"
-        filePath: ".azure-pipelines/scripts/cleanup_docker_images.sh"
 
     - task: Bash@3
       displayName: Compile and Build

--- a/.azure-pipelines/scripts/install_openenclave.sh
+++ b/.azure-pipelines/scripts/install_openenclave.sh
@@ -28,7 +28,7 @@ if [ -f "$openenclave_status_file_path" ]; then
 fi
 
 sudo bash scripts/ansible/install-ansible.sh
-sudo ansible-playbook scripts/ansible/oe-contributors-setup.yml
+sudo ansible-playbook scripts/ansible/oe-contributors-acc-setup-no-driver.yml
 
 mkdir -p build
 cd build

--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    curl wget rsync pv \
+    make gcc g++ bc python xutils-dev flex bison autogen libgcrypt20-dev libjson-c-dev \
+    autopoint pkgconf autoconf libtool libcurl4-openssl-dev libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler libssl-dev \
+    ninja-build ansible linux-headers-$(uname -r) \
+    docker.io python3-venv unzip dkms openjdk-8-jdk-headless

--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -8,4 +8,4 @@ sudo apt-get install -y \
     make gcc g++ bc python xutils-dev flex bison autogen libgcrypt20-dev libjson-c-dev \
     autopoint pkgconf autoconf libtool libcurl4-openssl-dev libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler libssl-dev \
     ninja-build ansible linux-headers-$(uname -r) \
-    docker.io python3-venv unzip dkms openjdk-8-jdk-headless
+    docker.io python3-venv unzip dkms debhelper apt-utils openjdk-8-jdk-headless

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "lkl"]
 	path = lkl
-	url = ssh://git@github.com/lsds/lkl.git
+	url = https://github.com/lsds/lkl.git
 	branch = upstream-refactor
 [submodule "host-musl"]
 	path = host-musl
 	url = https://github.com/lsds/musl.git
 [submodule "sgx-lkl-musl"]
 	path = sgx-lkl-musl
-	url = ssh://git@github.com/lsds/sgx-lkl-musl.git
+	url = https://github.com/lsds/sgx-lkl-musl.git
 	branch = oe_port

--- a/tools/sgx-lkl-disk
+++ b/tools/sgx-lkl-disk
@@ -371,7 +371,8 @@ function create_from_alpine() {
 
     echo "Creating base image from Alpine with packages ${alpine_pkgs}..."
 
-    [[ -z $HOME ]] && alpine_tar_dir="." || alpine_tar_dir="$HOME/.cache/sgxlkl"
+    home=$(echo ~)
+    [[ -z $home ]] && alpine_tar_dir="." || alpine_tar_dir="$home/.cache/sgxlkl"
     mkdir -p ${alpine_tar_dir}
     alpine_tar="${alpine_tar_dir}/alpine-minirootfs-${ALPINE_VERSION}-${ALPINE_ARCH}.tar.gz"
     alpine_url="https://nl.alpinelinux.org/alpine/v${ALPINE_MAJOR}/releases/${ALPINE_ARCH}/alpine-minirootfs-${ALPINE_VERSION}-${ALPINE_ARCH}.tar.gz"


### PR DESCRIPTION
Various changes to the CI scripts to make them work on a stock Ubuntu 18.04 image. Note that the `$USER` work-around is only temporary and is being fixed in Azure Pipelines.

Also, note that I changed the submodule URLs to use http consistently so that it can be cloned without private ssh key being available. This allows to run CI on external PR builds without allowing access to any secrets. If you want to use ssh locally for the submodules then you can still do that without changing the URLs, see https://stackoverflow.com/a/31185110. 