### PR TITLE
Automate & enable keyboard read virtio tests

### DIFF
--- a/.azure-pipelines/scripts/disabled_tests.txt
+++ b/.azure-pipelines/scripts/disabled_tests.txt
@@ -3,3 +3,4 @@ tests/containers/encrypted/create-disk/Makefile
 tests/containers/encrypted/verify-integrity/Makefile
 tests/containers/encrypted/verify-verity/Makefile
 tests/basic/network/Makefile
+tests/virtio/ping_test/Makefile

--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -8,4 +8,5 @@ sudo apt-get install -y \
     make gcc g++ bc python xutils-dev flex bison autogen libgcrypt20-dev libjson-c-dev \
     autopoint pkgconf autoconf libtool libcurl4-openssl-dev libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler libssl-dev \
     ninja-build ansible linux-headers-$(uname -r) \
-    docker.io python3-venv unzip dkms debhelper apt-utils openjdk-8-jdk-headless
+    docker.io python3-venv unzip dkms debhelper apt-utils openjdk-8-jdk-headless \
+    expect

--- a/tests/virtio/ping_test/Makefile
+++ b/tests/virtio/ping_test/Makefile
@@ -1,5 +1,7 @@
 # Makefile for test application
 
+SHELL := /bin/bash
+
 SGXLKL_ROOT=../../..
 
 APP_DIRECTORY=app
@@ -36,11 +38,21 @@ $(DISK_IMAGE): $(APP)
 
 all: $(DISK_IMAGE)
 
+.ONESHELL:
+
 run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_CMD} --hw-debug $(DISK_IMAGE) ${APP_DIRECTORY}/${APP}
+	${SGXLKL_ENV} expect -c "
+		spawn ${SGXLKL_CMD} --hw-debug $(DISK_IMAGE) ${APP_DIRECTORY}/${APP}
+		expect \"Press 'Q' to quit\"
+		send \"Q\r\"
+		expect eof"
 
 run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_CMD} --sw-debug $(DISK_IMAGE) ${APP_DIRECTORY}/${APP}
+	${SGXLKL_ENV} expect -c "
+		spawn ${SGXLKL_CMD} --sw-debug $(DISK_IMAGE) ${APP_DIRECTORY}/${APP}
+		expect \"Press 'Q' to quit\"
+		send \"Q\r\"
+		expect eof"
 
 clean:
 	@rm -f $(DISK_IMAGE)

--- a/tests/virtio/python_read/Makefile
+++ b/tests/virtio/python_read/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 
 APP_ROOT=app
 PROG=${APP_ROOT}/keyboard_read.py
@@ -31,12 +32,22 @@ clean:
 	rm -f $(DISK_IMAGE)
 
 $(DISK_IMAGE): $(PROG)
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="build-base gfortran python-dev" --copy=./${APP_ROOT}/ ${DISK_IMAGE}
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="python" --copy=./${APP_ROOT}/ ${DISK_IMAGE}
 
 run: run-hw
 
+.ONESHELL:
+
 run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
+	${SGXLKL_ENV} expect -c "
+		spawn ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
+		expect \"Prompt\"
+		send \"stop\r\"
+		expect eof"
 
 run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
+	${SGXLKL_ENV} expect -c "
+		spawn ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
+		expect \"Prompt\"
+		send \"stop\r\"
+		expect eof"


### PR DESCRIPTION
tests/virtio/python_read & tests/virtio/ping_test both read user input and exit if the right input was given. The Makefiles had `.misc` extensions which excluded them from CI, likely because they weren't automated tests yet and would wait for user input. I made them into real tests using `expect`.