### PR TITLE
Add SGXLKL_TRACE_DISK

### DIFF
--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -38,6 +38,7 @@ extern int sgxlkl_verbose;
 extern int sgxlkl_trace_thread;
 extern int sgxlkl_trace_mmap;
 extern int sgxlkl_trace_signal;
+extern int sgxlkl_trace_disk;
 extern int sgxlkl_trace_lkl_syscall;
 extern int sgxlkl_trace_internal_syscall;
 extern int sgxlkl_trace_ignored_syscall;
@@ -108,6 +109,12 @@ extern int sgxlkl_trace_redirect_syscall;
         oe_host_printf("[[  SIGNAL  ]] " x, ##__VA_ARGS__); \
     }
 
+#define SGXLKL_TRACE_DISK(x, ...)                         \
+    if (sgxlkl_trace_disk)                                \
+    {                                                       \
+        oe_host_printf("[[   DISK   ]] " x, ##__VA_ARGS__); \
+    }
+
 #else
 #define SGXLKL_ASSERT(EXPR)
 #define SGXLKL_VERBOSE(x, ...)
@@ -115,6 +122,7 @@ extern int sgxlkl_trace_redirect_syscall;
 #define SGXLKL_TRACE_THREAD(x, ...)
 #define SGXLKL_TRACE_MMAP(x, ...)
 #define SGXLKL_TRACE_SIGNAL(x, ...)
+#define SGXLKL_TRACE_DISK(x, ...)
 #define SGXLKL_TRACE_SYSCALL(x, ...)
 #endif
 

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -65,6 +65,7 @@ int sgxlkl_trace_redirect_syscall = 0;
 int sgxlkl_trace_mmap = 0;
 int sgxlkl_trace_signal = 0;
 int sgxlkl_trace_thread = 0;
+int sgxlkl_trace_disk = 0;
 int sgxlkl_use_host_network = 0;
 int sgxlkl_mtu = 0;
 
@@ -662,6 +663,7 @@ static void lkl_mount_disk(
 
     if (disk->roothash != NULL)
     {
+        SGXLKL_VERBOSE("Activating verity disk\n");
         dev_str_verity[sizeof dev_str_verity - 2] = device;
         lkl_cd.crypt_name = dev_str_verity + offset_dev_str_crypt_name;
         lkl_run_in_kernel_stack(
@@ -820,6 +822,11 @@ void lkl_mount_disks(
     size_t _num_disks,
     const char* cwd)
 {
+#ifdef DEBUG
+    if (sgxlkl_trace_disk)
+        crypt_set_debug_level(CRYPT_LOG_DEBUG);
+#endif
+
     num_disks = _num_disks;
     if (num_disks <= 0)
         sgxlkl_fail("No root disk provided. Aborting...\n");
@@ -1296,6 +1303,9 @@ void lkl_start_init()
 
     if (getenv_bool("SGXLKL_TRACE_THREAD", 0))
         sgxlkl_trace_thread = 1;
+
+    if (getenv_bool("SGXLKL_TRACE_DISK", 0))
+        sgxlkl_trace_disk = 1;
 
     if (sgxlkl_enclave->hostnet)
         sgxlkl_use_host_network = 1;

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -379,6 +379,10 @@ static void help_config()
         "%-35s %s",
         "  SGXLKL_TRACE_THREAD",
         "Trace in-enclave user level thread scheduling.\n");
+    printf(
+        "%-35s %s",
+        "  SGXLKL_TRACE_DISK",
+        "Trace in-enclave disk setup.\n");
     printf("%-35s %s", "  SGXLKL_TRACE_SYSCALL", "Trace all system calls.\n");
     printf(
         "%-35s %s",


### PR DESCRIPTION
This PR adds SGXLKL_TRACE_DISK which is currently only used to enable trace output from cryptsetup. It may be used in more/different places in the future.