### PR TITLE
Remove musl-gcc dependency from tests

### DIFF
--- a/tests/basic/abort/Dockerfile
+++ b/tests/basic/abort/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD abort.c .
+ADD *.c /
 RUN gcc -fPIE -pie -o abort -O0 -ggdb3 abort.c
 
 FROM alpine:3.6

--- a/tests/basic/abort/Dockerfile
+++ b/tests/basic/abort/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD abort.c .
+RUN gcc -fPIE -pie -o abort -O0 -ggdb3 abort.c
+
+FROM alpine:3.6
+
+COPY --from=builder abort .

--- a/tests/basic/abort/Makefile
+++ b/tests/basic/abort/Makefile
@@ -3,12 +3,11 @@ PROG=abort
 PROG_C=abort.c
 
 DISK_IMAGE=sgxlkl-abort.img
-IMAGE_SIZE=100M
+IMAGE_SIZE=5M
 
 EXECUTION_TIMEOUT=60
 
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
 SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
@@ -24,11 +23,8 @@ endif
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-$(PROG): $(PROG_C)
-	${MUSL_CC} -fPIE -pie -o $@ $(PROG_C)
-
-$(DISK_IMAGE): $(PROG)
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --copy=${PROG} ${DISK_IMAGE}
+$(DISK_IMAGE): $(PROG_C)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${DISK_IMAGE}
 
 gettimeout:
 	@echo ${EXECUTION_TIMEOUT}
@@ -58,4 +54,4 @@ run-sw-gdb: $(DISK_IMAGE)
 	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(PROG)
 
 clean:
-	rm -f $(DISK_IMAGE) $(PROG)
+	rm -f $(DISK_IMAGE)

--- a/tests/basic/exit/Dockerfile
+++ b/tests/basic/exit/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD *.c /
+RUN gcc -fPIE -pie -o exit-test exit-test.c
+RUN gcc -fPIE -pie -o segfault-test segfault-test.c
+RUN gcc -fPIE -pie -o raise-test raise-test.c
+
+FROM alpine:3.6
+
+COPY --from=builder *-test /

--- a/tests/basic/exit/Makefile
+++ b/tests/basic/exit/Makefile
@@ -1,17 +1,15 @@
 # Makefile for test application
 
-BUILDDIR=apps
-
-TEST1=$(BUILDDIR)/exit-test
-TEST2=$(BUILDDIR)/segfault-test
-TEST3=$(BUILDDIR)/raise-test
+TEST1=exit-test
+TEST2=segfault-test
+TEST3=raise-test
 
 SRCS=$(wildcard *.c)
+
 DISK_IMAGE=sgxlkl-exit-test.img
-IMAGE_SIZE=16M
+IMAGE_SIZE=5M
 
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
 SGXLKL_CMD=${SGXLKL_ROOT}/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 
@@ -22,15 +20,10 @@ SHELL := /bin/bash
 .DELETE_ON_ERROR:
 .PHONY: clean
 
-$(BUILDDIR)/%: %.c
-	@mkdir -p $(BUILDDIR)
-	${MUSL_CC} -fPIE -pie -o $@ $<
-
 run: run-hw run-sw
 
-$(DISK_IMAGE): $(TEST1) $(TEST2) $(TEST3)
-	rm -f ${DISK_IMAGE}
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="busybox" --copy=$(BUILDDIR) ${DISK_IMAGE}
+$(DISK_IMAGE): $(SRCS)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${DISK_IMAGE}
 
 run-hw: $(DISK_IMAGE)
 	@${SGXLKL_ENV} ${SGXLKL_CMD} --hw-debug ${DISK_IMAGE} $(TEST1); \
@@ -78,4 +71,3 @@ run-sw: $(DISK_IMAGE)
 
 clean:
 	rm -f $(DISK_IMAGE)
-	rm -rf $(BUILDDIR)

--- a/tests/basic/global_vars_test/Dockerfile
+++ b/tests/basic/global_vars_test/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD global_vars_test.c .
+ADD *.c /
 RUN gcc -g -o global_vars_test global_vars_test.c
 
 FROM alpine:3.6

--- a/tests/basic/global_vars_test/Dockerfile
+++ b/tests/basic/global_vars_test/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD global_vars_test.c .
+RUN gcc -g -o global_vars_test global_vars_test.c
+
+FROM alpine:3.6
+
+COPY --from=builder global_vars_test .
+RUN echo "Hello World!" > /helloworld.txt

--- a/tests/basic/global_vars_test/Makefile
+++ b/tests/basic/global_vars_test/Makefile
@@ -1,58 +1,44 @@
-
 PROG=global_vars_test
-PROG_C=$(PROG).c
+PROG_SRC=$(PROG).c
+PROG_ARGS=-a -b -c hello
+IMAGE_SIZE=5M
 
-MOUNTPOINT=/media/ext4disk
+EXECUTION_TIMEOUT=60
+SGXLKL_ROOT=../../..
+SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
+SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-DISK=sgxlkl-disk.img
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
 
-SGXLKL_RUN_CMD=../../../build/sgx-lkl-run-oe
-
-PROG_ARGS = -a -b -c hello
-
-SGXLKL_ENV=\
-   SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=0\
-   SGXLKL_TRACE_HOST_SYSCALL=0 SGXLKL_TRACE_LKL_SYSCALL=0 SGXLKL_TRACE_MMAP=0
-
-LOOP_DEVICE=loop9
-IMAGE_SIZE_MB=100
-
-ESCALATE_CMD=sudo
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-$(PROG): $(PROG_C)
-	../../../build/host-musl/bin/musl-gcc -g -o $@ $(PROG_C)
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
-$(DISK): $(PROG) 
-	dd if=/dev/zero of="$@" count=$(IMAGE_SIZE_MB) bs=1M
-	mkfs.ext4 "$@"
-	@$(ESCALATE_CMD) /bin/bash -euxo pipefail -c '\
-		mkdir -p $(MOUNTPOINT); \
-		mount -t ext4 -o loop "$@" $(MOUNTPOINT); \
-		mkdir -p $(MOUNTPOINT)/app; \
-		echo "Hello World!" > $(MOUNTPOINT)/app/helloworld.txt; \
-		cp $(PROG)  $(MOUNTPOINT)/app; \
-		umount $(MOUNTPOINT); \
-		chown $(USER) "$@"; \
-	'
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 run: run-hw run-sw
 
-run-hw: $(DISK)
-	@echo "\n________Running ${PROG} in --hw-debug mode _______\n"
-	${SGXLKL_ENV} ${SGXLKL_RUN_CMD} --hw-debug $(DISK) app/$(PROG) $(PROG_ARGS)
+run-gdb: run-hw-gdb
 
-run-hw-gdb: $(DISK)
-	${SGXLKL_ENV} ${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb --args ${SGXLKL_RUN_CMD} --hw-debug $(DISK) app/$(PROG) $(PROG_ARGS)
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG) $(PROG_ARGS)
 
-run-sw: $(DISK)
-	@echo "\n________Running ${PROG} in --sw-debug mode _______\n"
-	${SGXLKL_ENV} ${SGXLKL_RUN_CMD} --sw-debug $(DISK) app/$(PROG) $(PROG_ARGS)
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG) $(PROG_ARGS)
 
-run-sw-gdb: $(DISK)
-	${SGXLKL_ENV} ${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb --args ${SGXLKL_RUN_CMD} --sw-debug $(DISK) app/$(PROG) $(PROG_ARGS)
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG) $(PROG_ARGS)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG) $(PROG_ARGS)
 
 clean:
-	@rm -f $(DISK) $(PROG)
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/global_vars_test/global_vars_test.c
+++ b/tests/basic/global_vars_test/global_vars_test.c
@@ -90,7 +90,7 @@ void perform_errno_test(void)
         prog_exec_status |= (1 << en_test_errno_fail_index);
 
     // reset the errno to verify the valid scenario
-    _do_file_ops("/app/helloworld.txt");
+    _do_file_ops("/helloworld.txt");
     l_err_no = errno;
     if (l_err_no != 0)
         prog_exec_status |= (1 << en_test_errno_pass_index);

--- a/tests/basic/helloworld/Dockerfile
+++ b/tests/basic/helloworld/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD helloworld.c .
+ADD *.c /
 RUN gcc -g -o helloworld helloworld.c
 
 FROM alpine:3.6

--- a/tests/basic/helloworld/Dockerfile
+++ b/tests/basic/helloworld/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD helloworld.c .
+RUN gcc -g -o helloworld helloworld.c
+
+FROM alpine:3.6
+
+COPY --from=builder helloworld .
+ADD app /app

--- a/tests/basic/helloworld/Makefile
+++ b/tests/basic/helloworld/Makefile
@@ -1,52 +1,43 @@
+PROG=helloworld
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
 
-APP_ROOT=app
-PROG=${APP_ROOT}/helloworld
-PROG_NONPIE=${APP_ROOT}/helloworld-nonpie
-PROG_C=helloworld.c
-
-DISK_IMAGE=sgxlkl-helloworld.img
-IMAGE_SIZE=100M
-
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
 SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-ifeq ($(SGXLKL_VERBOSE),)
-SGXLKL_ENV=\
-   SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=0\
-   SGXLKL_TRACE_HOST_SYSCALL=0 SGXLKL_TRACE_LKL_SYSCALL=0 SGXLKL_TRACE_MMAP=0
-else
-SGXLKL_ENV=
-endif
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-$(PROG): $(PROG_C)
-	${MUSL_CC} -fPIE -pie -o $@ $(PROG_C)
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
-# non-PIE executable are currently unsupported by SGX-LKL-OE
-$(PROG_NONPIE): $(PROG_C)
-	${MUSL_CC} -fno-pie -no-pie -o $@ $(PROG_C)
-
-$(DISK_IMAGE): $(PROG) $(PROG_NONPIE)
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --copy=./${APP_ROOT}/ ${DISK_IMAGE}
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 run: run-hw run-sw
 
-run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(PROG)
+run-gdb: run-hw-gdb
 
-run-hw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(PROG)
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(PROG)
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-sw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(PROG)
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 clean:
-	rm -f $(DISK_IMAGE) $(PROG) $(PROG_NONPIE)
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/illegal_instructions/Dockerfile
+++ b/tests/basic/illegal_instructions/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers
 
-ADD illegal_instructions-test.c .
+ADD *.c /
 RUN gcc -g -o illegal_instructions-test illegal_instructions-test.c
 
 FROM alpine:3.6

--- a/tests/basic/illegal_instructions/Dockerfile
+++ b/tests/basic/illegal_instructions/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev linux-headers
+
+ADD illegal_instructions-test.c .
+RUN gcc -g -o illegal_instructions-test illegal_instructions-test.c
+
+FROM alpine:3.6
+
+COPY --from=builder illegal_instructions-test .

--- a/tests/basic/illegal_instructions/Makefile
+++ b/tests/basic/illegal_instructions/Makefile
@@ -1,36 +1,36 @@
-# Makefile for test application
+PROG=illegal_instructions-test
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
 
-TEST=illegal_instructions-test
-
-SRC=$(TEST).c
-DISK_IMAGE=sgxlkl-${TEST}.img
-IMAGE_SIZE=16M
-
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
-SGXLKL_CMD=${SGXLKL_ROOT}/build/sgx-lkl-run-oe
+SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-SGXLKL_ENV=SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=0
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
-.PHONY: clean
+.PHONY: all clean
+
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
+
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 run: run-hw
 
-$(TEST): $(SRC)
-	${MUSL_CC} -fPIE -pie -o $@ $(SRC)
-
-$(DISK_IMAGE): $(TEST)
-	rm -f ${DISK_IMAGE}
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="busybox" --copy=$(TEST) ${DISK_IMAGE}
-
-run-hw: $(DISK_IMAGE)
+run-hw: ${SGXLKL_ROOTFS}
 	@# Note that the following ! inverts the error code from the enclave
-	@! ${SGXLKL_ENV} ${SGXLKL_CMD} --hw-debug ${DISK_IMAGE} $(TEST)
+	@! $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 run-sw: 
 	@echo Test not supported in sw mode
 
 clean:
-	rm -f $(DISK_IMAGE) $(TEST)
+	rm -f $(SGXLKL_ROOTFS)

--- a/tests/basic/nonroot_halt_test/Dockerfile
+++ b/tests/basic/nonroot_halt_test/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD nonroot_halt_test.c .
+RUN gcc -g -o nonroot_halt_test nonroot_halt_test.c
+
+FROM alpine:3.6
+
+COPY --from=builder nonroot_halt_test .

--- a/tests/basic/nonroot_halt_test/Dockerfile
+++ b/tests/basic/nonroot_halt_test/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD nonroot_halt_test.c .
+ADD *.c /
 RUN gcc -g -o nonroot_halt_test nonroot_halt_test.c
 
 FROM alpine:3.6

--- a/tests/basic/nonroot_halt_test/Makefile
+++ b/tests/basic/nonroot_halt_test/Makefile
@@ -1,39 +1,43 @@
-# Makefile for test application
+PROG=nonroot_halt_test
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
 
-APP_DIRECTORY=app
-APP=nonroot_halt_test
-SRC=nonroot_halt_test.c
-
-DISK_IMAGE=sgxlkl-${APP}.img
-IMAGE_SIZE=64M
-
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
-SGXLKL_CMD=${SGXLKL_ROOT}/build/sgx-lkl-run-oe
+SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-SGXLKL_ENV=SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
-.PHONY: clean
+.PHONY: all clean
+
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
+
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 run: run-hw run-sw
 
-$(APP): $(SRC)
-	${MUSL_CC} -fPIE -pie -o $@ $(SRC)
-	@mkdir -p ${APP_DIRECTORY}
-	@mv -f $@ ${APP_DIRECTORY}
+run-gdb: run-hw-gdb
 
-$(DISK_IMAGE): $(APP)
-	@rm -f ${DISK_IMAGE}
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="bash shadow sudo" --copy=./${APP_DIRECTORY}/ ${DISK_IMAGE}
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_CMD} --hw-debug ${DISK_IMAGE} $(APP_DIRECTORY)/$(APP)
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_CMD} --sw-debug ${DISK_IMAGE} $(APP_DIRECTORY)/$(APP)
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 clean:
-	rm -f $(DISK_IMAGE) $(APP)
-	@rm -rf $(APP_DIRECTORY)
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/print_lkl_version/Makefile
+++ b/tests/basic/print_lkl_version/Makefile
@@ -6,7 +6,6 @@ DISK_IMAGE=sgxlkl-${TEST}.img
 IMAGE_SIZE=16M
 
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
 SGXLKL_CMD=${SGXLKL_ROOT}/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 

--- a/tests/basic/pthread_join/Dockerfile
+++ b/tests/basic/pthread_join/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD pthread_join-test.c .
+RUN gcc -pthread -g -o pthread_join-test pthread_join-test.c
+
+FROM alpine:3.6
+
+COPY --from=builder pthread_join-test .

--- a/tests/basic/pthread_join/Dockerfile
+++ b/tests/basic/pthread_join/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD pthread_join-test.c .
+ADD *.c /
 RUN gcc -pthread -g -o pthread_join-test pthread_join-test.c
 
 FROM alpine:3.6

--- a/tests/basic/pthread_join/Makefile
+++ b/tests/basic/pthread_join/Makefile
@@ -1,35 +1,43 @@
-# Makefile for test application
+PROG=pthread_join-test
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
 
-TEST=pthread_join-test
-
-SRC=$(TEST).c
-DISK_IMAGE=sgxlkl-${TEST}.img
-IMAGE_SIZE=16M
-
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
-SGXLKL_CMD=${SGXLKL_ROOT}/build/sgx-lkl-run-oe
+SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-SGXLKL_ENV=SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=0
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
-.PHONY: clean
+.PHONY: all clean
 
-run: run-hw
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
-$(TEST): $(SRC)
-	${MUSL_CC} -fPIE -pie -pthread -o $@ $(SRC)
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
-$(DISK_IMAGE): $(TEST)
-	rm -f ${DISK_IMAGE}
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="busybox" --copy=$(TEST) ${DISK_IMAGE}
+run: run-hw run-sw
 
-run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_CMD} --hw-debug ${DISK_IMAGE} $(TEST)
+run-gdb: run-hw-gdb
 
-run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_CMD} --sw-debug ${DISK_IMAGE} $(TEST)
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 clean:
-	rm -f $(DISK_IMAGE) $(TEST)
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/signal/Dockerfile
+++ b/tests/basic/signal/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD signal.c .
+ADD *.c /
 RUN gcc -o signal -O0 -ggdb3 signal.c
 
 FROM alpine:3.6

--- a/tests/basic/signal/Dockerfile
+++ b/tests/basic/signal/Dockerfile
@@ -1,3 +1,10 @@
-FROM alpine:3.6
+FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
+
+ADD signal.c .
+RUN gcc -o signal -O0 -ggdb3 signal.c
+
+FROM alpine:3.6
+
+COPY --from=builder signal .

--- a/tests/basic/signal/Makefile
+++ b/tests/basic/signal/Makefile
@@ -1,54 +1,24 @@
 PROG=signal
 PROG_SRC=$(PROG).c
-PROG_PATH=/home
+IMAGE_SIZE=5M
 
-EXECUTION_TIMEOUT=180
-SGXLKL_STARTER=../../../build/sgx-lkl-run-oe
+EXECUTION_TIMEOUT=60
+SGXLKL_ROOT=../../..
+SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
+SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
+
 SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1
 SGXLKL_HW_PARAMS=--hw-debug
 SGXLKL_SW_PARAMS=--sw-debug
 
-ALPINE_URL=https://nl.alpinelinux.org/alpine
-ALPINE_MAJOR=3.9
-ALPINE_VERSION=3.9.0
-ALPINE_ARCH=x86_64
-ALPINE_TAR=alpine-minirootfs.tar.gz
-
-MOUNTPOINT=/media/ext4disk
 SGXLKL_ROOTFS=sgx-lkl-rootfs.img
-
-BUILD_CONTAINER=alpine_sdk
-
-IMAGE_SIZE_MB=100
-
-ESCALATE_CMD=sudo
 
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-$(ALPINE_TAR):
-	curl -L -o "$@" "$(ALPINE_URL)/v$(ALPINE_MAJOR)/releases/$(ALPINE_ARCH)/alpine-minirootfs-$(ALPINE_VERSION)-$(ALPINE_ARCH).tar.gz"
-
-$(SGXLKL_ROOTFS): $(ALPINE_TAR) buildenv.sh $(PROG) $(PROG2)
-	test -f $(SGXLKL_ROOTFS) && rm $(SGXLKL_ROOTFS) || true
-	dd if=/dev/zero of="$@" count=$(IMAGE_SIZE_MB) bs=1M
-	mkfs.ext4 -q "$@"
-	$(ESCALATE_CMD) /bin/bash -euxo pipefail -c '\
-		mkdir -p $(MOUNTPOINT); \
-		mount -t ext4 -o loop "$@" $(MOUNTPOINT); \
-		tar -C $(MOUNTPOINT) -xf $(ALPINE_TAR); \
-		cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf; \
-		mkdir -p $(MOUNTPOINT)/home; \
-		cp $(PROG) $(MOUNTPOINT)$(PROG_PATH); \
-		install buildenv.sh $(MOUNTPOINT)/usr/sbin; \
-		chroot $(MOUNTPOINT) /bin/sh /usr/sbin/buildenv.sh; \
-		umount $(MOUNTPOINT); \
-		chown $(USER) "$@"; \
-	'
-
-$(PROG): $(PROG_SRC)
-	docker build -t $(BUILD_CONTAINER) .
-	docker run --rm -v ${CURDIR}:/src -w /src alpine_sdk gcc -o $(PROG) -O0 -ggdb3 $(PROG_SRC)
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
 gettimeout:
 	@echo ${EXECUTION_TIMEOUT}
@@ -58,18 +28,16 @@ run: run-hw run-sw
 run-gdb: run-hw-gdb
 
 run-hw: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG_PATH)/$(PROG)
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 run-sw: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG_PATH)/$(PROG)
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 run-hw-gdb: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) oegdb --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG_PATH)/$(PROG)
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 run-sw-gdb: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) oegdb --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG_PATH)/$(PROG)
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 clean:
-	test -f $(PROG) && rm -f $(PROG) || true
-	test -f $(SGXLKL_ROOTFS) && rm $(SGXLKL_ROOTFS) || true
-	test -f $(ALPINE_TAR) && rm $(ALPINE_TAR) || true
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/signal/buildenv.sh
+++ b/tests/basic/signal/buildenv.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-PATH=/usr/sbin:/sbin:/usr/bin:/bin
-
-apk update
-apk add iputils iproute2
-apk add device-mapper cryptsetup

--- a/tests/basic/sleep/.gitignore
+++ b/tests/basic/sleep/.gitignore
@@ -1,1 +1,0 @@
-app/sleep

--- a/tests/basic/sleep/Dockerfile
+++ b/tests/basic/sleep/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD sleep-test.c .
+RUN gcc -g -o sleep-test sleep-test.c
+
+FROM alpine:3.6
+
+COPY --from=builder sleep-test .

--- a/tests/basic/sleep/Dockerfile
+++ b/tests/basic/sleep/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD sleep-test.c .
+ADD *.c /
 RUN gcc -g -o sleep-test sleep-test.c
 
 FROM alpine:3.6

--- a/tests/basic/sleep/Makefile
+++ b/tests/basic/sleep/Makefile
@@ -1,47 +1,43 @@
+PROG=sleep-test
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
 
-APP_ROOT=app
-PROG=${APP_ROOT}/sleep
-PROG_C=sleep-test.c
-
-DISK_IMAGE=sgxlkl-sleep.img
-IMAGE_SIZE=100M
-
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
 SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-ifeq ($(SGXLKL_VERBOSE),)
-SGXLKL_ENV=\
-   SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=0\
-   SGXLKL_TRACE_HOST_SYSCALL=0 SGXLKL_TRACE_LKL_SYSCALL=0 SGXLKL_TRACE_MMAP=0
-else
-SGXLKL_ENV=
-endif
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-$(PROG): $(PROG_C)
-	${MUSL_CC} -fPIE -pie -o $@ $(PROG_C)
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
-$(DISK_IMAGE): $(PROG) $(PROG_NONPIE)
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --copy=./${APP_ROOT}/ ${DISK_IMAGE}
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 run: run-hw run-sw
 
-run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(PROG)
+run-gdb: run-hw-gdb
 
-run-hw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(PROG)
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(PROG)
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-sw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(PROG)
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 clean:
-	rm -f $(DISK_IMAGE) $(PROG) $(PROG_NONPIE)
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/stat/Dockerfile
+++ b/tests/basic/stat/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD stat.c .
+RUN gcc -g -o stat stat.c
+
+FROM alpine:3.6
+
+COPY --from=builder stat .
+ADD app /app

--- a/tests/basic/stat/Dockerfile
+++ b/tests/basic/stat/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD stat.c .
+ADD *.c /
 RUN gcc -g -o stat stat.c
 
 FROM alpine:3.6

--- a/tests/basic/stat/Makefile
+++ b/tests/basic/stat/Makefile
@@ -1,52 +1,43 @@
+PROG=stat
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
 
-APP_ROOT=app
-PROG=${APP_ROOT}/stat
-PROG_NONPIE=${APP_ROOT}/stat-nonpie
-PROG_C=stat.c
-
-DISK_IMAGE=sgxlkl-stat.img
-IMAGE_SIZE=100M
-
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
 SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-ifeq ($(SGXLKL_VERBOSE),)
-SGXLKL_ENV=\
-   SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=0\
-   SGXLKL_TRACE_HOST_SYSCALL=0 SGXLKL_TRACE_LKL_SYSCALL=0 SGXLKL_TRACE_MMAP=0
-else
-SGXLKL_ENV=
-endif
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-$(PROG): $(PROG_C)
-	${MUSL_CC} -fPIE -pie -o $@ $(PROG_C)
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
-# non-PIE executable are currently unsupported by SGX-LKL-OE
-$(PROG_NONPIE): $(PROG_C)
-	${MUSL_CC} -fno-pie -no-pie -o $@ $(PROG_C)
-
-$(DISK_IMAGE): $(PROG) $(PROG_NONPIE)
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --copy=./${APP_ROOT}/ ${DISK_IMAGE}
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 run: run-hw run-sw
 
-run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(PROG)
+run-gdb: run-hw-gdb
 
-run-hw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(PROG)
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(PROG)
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
-run-sw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(PROG)
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
 clean:
-	rm -f $(DISK_IMAGE) $(PROG) $(PROG_NONPIE)
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/virtio/ping_test/Dockerfile
+++ b/tests/virtio/ping_test/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD dummy_server.c .
+RUN gcc -g -o dummy_server dummy_server.c
+
+FROM alpine:3.6
+
+COPY --from=builder dummy_server .

--- a/tests/virtio/ping_test/Dockerfile
+++ b/tests/virtio/ping_test/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6 AS builder
 
 RUN apk add --no-cache gcc musl-dev
 
-ADD dummy_server.c .
+ADD *.c /
 RUN gcc -g -o dummy_server dummy_server.c
 
 FROM alpine:3.6

--- a/tests/virtio/ping_test/Makefile
+++ b/tests/virtio/ping_test/Makefile
@@ -1,59 +1,45 @@
-# Makefile for test application
-
 SHELL := /bin/bash
 
+PROG=dummy_server
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
+
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-
-APP_DIRECTORY=app
-APP=dummy_server
-SRC=dummy_server.c
-
-DISK_IMAGE=sgxlkl-ping.img
-IMAGE_SIZE=128M
-
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
-SGXLKL_CMD=${SGXLKL_ROOT}/build/sgx-lkl-run-oe
+SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
-SGXLKL_ENV_OPTS=SGXLKL_GETTIME_VDSO=0
-SGXLKL_NETWORK_SETTING=SGXLKL_TAP=sgxlkl_tap0 SGXLKL_IP4=10.0.1.2
-VERBOSE_OPTS=SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
 
-ifeq ($(SGXLKL_VERBOSE),)
-	SGXLKL_ENV+=${VERBOSE_OPTS}
-endif
-SGXLKL_ENV+=${SGXLKL_ENV_OPTS} ${SGXLKL_NETWORK_SETTING}
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
-.PHONY: clean
+.PHONY: all clean
 
-$(APP): $(SRC)
-	${MUSL_CC} -fPIE -pie -o $@ $(SRC)
-	@mkdir -p ${APP_DIRECTORY}
-	@mv -f $@ ${APP_DIRECTORY}
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
-$(DISK_IMAGE): $(APP)
-	@rm -f ${DISK_IMAGE}
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="bash shadow sudo" --copy=./${APP_DIRECTORY}/ ${DISK_IMAGE}
-
-all: $(DISK_IMAGE)
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 .ONESHELL:
 
-run-hw: $(DISK_IMAGE)
+run-hw: $(SGXLKL_ROOTFS)
 	${SGXLKL_ENV} expect -c "
-		spawn ${SGXLKL_CMD} --hw-debug $(DISK_IMAGE) ${APP_DIRECTORY}/${APP}
+		spawn $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 		expect \"Press 'Q' to quit\"
 		send \"Q\r\"
 		expect eof"
 
-run-sw: $(DISK_IMAGE)
+run-sw: $(SGXLKL_ROOTFS)
 	${SGXLKL_ENV} expect -c "
-		spawn ${SGXLKL_CMD} --sw-debug $(DISK_IMAGE) ${APP_DIRECTORY}/${APP}
+		spawn $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 		expect \"Press 'Q' to quit\"
 		send \"Q\r\"
 		expect eof"
 
 clean:
-	@rm -f $(DISK_IMAGE)
-	@rm -f $(APP_DIRECTORY)/${APP}
+	@rm -f $(SGXLKL_ROOTFS)

--- a/tests/virtio/python_read/Dockerfile
+++ b/tests/virtio/python_read/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache python3
+
+ADD app app

--- a/tests/virtio/python_read/Makefile
+++ b/tests/virtio/python_read/Makefile
@@ -2,52 +2,46 @@ SHELL := /bin/bash
 
 APP_ROOT=app
 PROG=${APP_ROOT}/keyboard_read.py
+IMAGE_SIZE=100M
 
-DISK_IMAGE=sgxlkl-python.img
-IMAGE_SIZE=1024M
-
+EXECUTION_TIMEOUT=60
 SGXLKL_ROOT=../../..
-
-ENCLAVE_CMD=/usr/bin/python ${PROG}
-
 SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
-
-ifeq ($(SGXLKL_VERBOSE),)
-SGXLKL_ENV=\
-   SGXLKL_GETTIME_VDSO=0\
-   SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=0 SGXLKL_TRACE_SIGNAL=0\
-   SGXLKL_TRACE_HOST_SYSCALL=0 SGXLKL_TRACE_LKL_SYSCALL=0 SGXLKL_TRACE_MMAP=0
-else
-SGXLKL_ENV=SGXLKL_GETTIME_VDSO=0
-endif
-
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
+
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+ENCLAVE_CMD=/usr/bin/python3 ${PROG}
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-all: $(DISK_IMAGE)
+$(SGXLKL_ROOTFS): $(PROG)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
-clean:
-	rm -f $(DISK_IMAGE)
-
-$(DISK_IMAGE): $(PROG)
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --alpine="python" --copy=./${APP_ROOT}/ ${DISK_IMAGE}
-
-run: run-hw
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
 
 .ONESHELL:
 
-run-hw: $(DISK_IMAGE)
+run-hw: $(SGXLKL_ROOTFS)
 	${SGXLKL_ENV} expect -c "
-		spawn ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
+		spawn $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(ENCLAVE_CMD)
 		expect \"Prompt\"
 		send \"stop\r\"
 		expect eof"
 
-run-sw: $(DISK_IMAGE)
+run-sw: $(SGXLKL_ROOTFS)
 	${SGXLKL_ENV} expect -c "
-		spawn ${SGXLKL_STARTER} --sw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
+		spawn $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(ENCLAVE_CMD)
 		expect \"Prompt\"
 		send \"stop\r\"
 		expect eof"
+
+clean:
+	@rm -f $(SGXLKL_ROOTFS)

--- a/tests/virtio/python_read/app/keyboard_read.py
+++ b/tests/virtio/python_read/app/keyboard_read.py
@@ -1,10 +1,8 @@
-import readline
-
 def input_loop():
     line = ''
     while line != 'stop':
-        line = raw_input('Prompt ("stop" to quit): ')
-        print 'User input is : %s' % line
+        line = input('Prompt ("stop" to quit): ')
+        print('User input is : %s' % line)
 
 # Prompt the user for text
 input_loop()


### PR DESCRIPTION
This PR prepares the tests to be run from an SGX-LKL installation instead of requiring a build tree by removing the dependency to musl-gcc and instead using Docker images.

Note that I used multi-stage Dockerfiles as otherwise the disk images would be quite large (due to the gcc and musl-dev packages).

Also, note that this PR does not intend to cleanup tests in any way. If that happened it is a coincidence.

cc @hukoyu