### PR TITLE
Remove extraneous libc dependencies from lthread.c.

### DIFF
--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -181,7 +181,6 @@ struct lthread_sched
     void* stack;
     size_t stack_size;
     uint64_t default_timeout;
-    int page_size;
     /* convenience data maintained by lthread_resume */
     struct lthread* current_lthread;
 };

--- a/src/include/openenclave/corelibc/oemalloc.h
+++ b/src/include/openenclave/corelibc/oemalloc.h
@@ -1,0 +1,9 @@
+#ifndef __OE_MALLOC_INCLUDED__
+#define __OE_MALLOC_INCLUDED__
+
+void *oe_malloc(size_t size);
+void oe_free(void *ptr);
+void *oe_calloc(size_t nmemb, size_t size);
+void *oe_realloc(void *ptr, size_t size);
+
+#endif


### PR DESCRIPTION
The dependencies that are part of the lack of separation between pthread
and lthread implementations are still there, and we still depend on
free-standing C functions (memset, memcpy, and so on), but this is
sufficient until we do the cleanup to decouple the pthread and lthread
implementations.