### PR TITLE
SGXLKL_ETHREAD: Run JVM test with different ethread counts

### DIFF
--- a/tests/languages/java/Makefile
+++ b/tests/languages/java/Makefile
@@ -28,12 +28,28 @@ $(DISK_IMAGE): $(PROG)
 run: run-hw run-sw
 
 run-hw: $(DISK_IMAGE)
-	@echo "sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=1 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=2 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=3 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=4 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=8 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
 
 run-sw: $(DISK_IMAGE)
-	@echo "sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=1 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=2 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=3 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=4 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @echo "SGXLKL_ETHREAD=8 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
 
 clean:
 	rm -f $(DISK_IMAGE) app/${PROG}

--- a/tests/languages/java/Makefile
+++ b/tests/languages/java/Makefile
@@ -28,28 +28,28 @@ $(DISK_IMAGE): $(PROG)
 run: run-hw run-sw
 
 run-hw: $(DISK_IMAGE)
-       @ echo "SGXLKL_ETHREAD=1 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=2 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=3 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=4 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=8 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=1 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=2 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=3 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=4 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=8 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
 
 run-sw: $(DISK_IMAGE)
-       @ echo "SGXLKL_ETHREAD=1 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=2 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=3 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=4 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREAD=8 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=1 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=2 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=3 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=4 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREADS=8 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREADS=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
 
 clean:
 	rm -f $(DISK_IMAGE) app/${PROG}

--- a/tests/languages/java/Makefile
+++ b/tests/languages/java/Makefile
@@ -28,28 +28,28 @@ $(DISK_IMAGE): $(PROG)
 run: run-hw run-sw
 
 run-hw: $(DISK_IMAGE)
-       @echo "SGXLKL_ETHREAD=1 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=2 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=3 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=4 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=8 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=1 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=2 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=3 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=4 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=8 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
 
 run-sw: $(DISK_IMAGE)
-       @echo "SGXLKL_ETHREAD=1 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=2 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=3 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=4 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @echo "SGXLKL_ETHREAD=8 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=1 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=2 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=3 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=4 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+       @ echo "SGXLKL_ETHREAD=8 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+       @ SGXLKL_ETHREAD=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
 
 clean:
 	rm -f $(DISK_IMAGE) app/${PROG}

--- a/tests/languages/java/Makefile
+++ b/tests/languages/java/Makefile
@@ -28,28 +28,28 @@ $(DISK_IMAGE): $(PROG)
 run: run-hw run-sw
 
 run-hw: $(DISK_IMAGE)
-       @ echo "SGXLKL_ETHREADS=1 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=2 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=3 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=4 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=8 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=1 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=2 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=3 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=4 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=8 sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld
 
 run-sw: $(DISK_IMAGE)
-       @ echo "SGXLKL_ETHREADS=1 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=2 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=3 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=4 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
-       @ echo "SGXLKL_ETHREADS=8 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
-       @ SGXLKL_ETHREADS=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=1 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=1 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=2 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=2 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=3 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=3 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=4 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=4 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
+	@echo "SGXLKL_ETHREADS=8 sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
+	@SGXLKL_ETHREADS=8 ${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
 
 clean:
 	rm -f $(DISK_IMAGE) app/${PROG}


### PR DESCRIPTION
This PR addresses the issue: https://github.com/lsds/sgx-lkl/issues/139
ethread count is passed with SGXLKL_ETHREAD env var to sgx-lkl enclave. 
If this is not passed default value is the number of cores available.
