### PR TITLE
[CI] Remove *.lock files in .git folder before submodule update

### DIFF
--- a/.azure-pipelines/scripts/checkout_submodules.sh
+++ b/.azure-pipelines/scripts/checkout_submodules.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+set -ex
+
 mkdir -p ~/.ssh > /dev/null
 chmod 700 ~/.ssh
 ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+find .git -type f -name '*.lock' -exec rm -v {} +
 git reset --hard
 git submodule sync
 git submodule update --init --force --recursive


### PR DESCRIPTION
I saw this once in CI where a VM was essentially "broken" because there was a lock file from git which prevented running some git commands. This file was left-over from a previous build for unknown reasons. This is not an issue when fresh VMs are used for each build but this is not the case (yet).
This PR simply cleans up old git lock files. Note that I tested this PR when the situation occurred and it resolved the block.