### PR TITLE
Fix for umount01

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -32,6 +32,7 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
 	$(ESCALATE_CMD) cp ltp_fork_disable.patch $(MOUNTPOINT)/
+	$(ESCALATE_CMD) cp patches/umount.patch $(MOUNTPOINT)/
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -30,6 +30,7 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
 	$(ESCALATE_CMD) cp ../ltp_fork_disable.patch $(MOUNTPOINT)/
+	$(ESCALATE_CMD) cp ../patches/umount.patch $(MOUNTPOINT)/
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/buildenv.sh
+++ b/tests/ltp/buildenv.sh
@@ -5,6 +5,7 @@ test_directory=$2
 
 LTP_GIT_TAG="20190930"
 FORK_DISABLE_PATCH="/ltp_fork_disable.patch"
+UMOUNT_PATCH="/umount.patch"
 
 if [ -z $test_directory ]; then
     echo "Please provide ltp tests directory. Example: ltp.sh 'testcases/kernel/syscalls'"
@@ -45,6 +46,10 @@ if [[ "$mode" == "build" ]]; then
         git apply $FORK_DISABLE_PATCH
     fi
 
+    if [ -f $UMOUNT_PATCH ];then
+        echo applying patch "$UMOUNT_PATCH"
+        git apply $UMOUNT_PATCH
+    fi
     echo "Running make clean..."
     make autotools
     ./configure

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -994,7 +994,7 @@
 /ltp/testcases/kernel/syscalls/truncate/truncate03
 #/ltp/testcases/kernel/syscalls/ulimit/ulimit01
 #/ltp/testcases/kernel/syscalls/umask/umask01
-/ltp/testcases/kernel/syscalls/umount/umount01
+#/ltp/testcases/kernel/syscalls/umount/umount01
 /ltp/testcases/kernel/syscalls/umount/umount02
 /ltp/testcases/kernel/syscalls/umount/umount03
 /ltp/testcases/kernel/syscalls/umount2/umount2_01

--- a/tests/ltp/patches/umount.patch
+++ b/tests/ltp/patches/umount.patch
@@ -1,0 +1,68 @@
+diff --git a/testcases/kernel/syscalls/umount/umount01.c b/testcases/kernel/syscalls/umount/umount01.c
+index fb5384434..8e257595a 100644
+--- a/testcases/kernel/syscalls/umount/umount01.c
++++ b/testcases/kernel/syscalls/umount/umount01.c
+@@ -13,36 +13,42 @@
+ 
+ #define MNTPOINT	"mntpoint"
+ 
+-static int mount_flag;
++static int mount_flag = 0;
+ 
+ static void verify_umount(void)
+ {
+-	if (mount_flag != 1) {
+-		SAFE_MOUNT(tst_device->dev, MNTPOINT,
+-			tst_device->fs_type, 0, NULL);
+-		mount_flag = 1;
+-	}
+-
+ 	TEST(umount(MNTPOINT));
+ 
+ 	if (TST_RET != 0 && TST_ERR == EBUSY) {
+-		tst_res(TINFO, "umount() Failed with EBUSY "
++		tst_res(TINFO, "umount() TEST_FAILED with EBUSY "
+ 			"possibly some daemon (gvfsd-trash) "
+ 			"is probing newly mounted dirs");
+ 	}
+ 
+ 	if (TST_RET != 0) {
+-		tst_res(TFAIL | TTERRNO, "umount() Failed");
++		tst_res(TFAIL | TTERRNO, "umount() TEST_FAILED");
+ 		return;
+ 	}
+ 
+-	tst_res(TPASS, "umount() Passed");
++	tst_res(TPASS, "umount() PASSED ");
+ 	mount_flag = 0;
+ }
+ 
+ static void setup(void)
+ {
+ 	SAFE_MKDIR(MNTPOINT, 0775);
++
++	const char* src  = "/dev/vda";
++	const char* type = "ext4";
++	const unsigned long mntflags = 0;
++	const char* opts = "mode=0777";   
++	int result = mount(src, MNTPOINT, type, mntflags, opts);
++
++	if (result != 0) {
++		TST_RET = result;
++		tst_res(TFAIL, "umount()- setup TEST_FAILED");
++		return;
++	}
+ }
+ 
+ static void cleanup(void)
+@@ -53,8 +59,8 @@ static void cleanup(void)
+ 
+ static struct tst_test test = {
+ 	.needs_root = 1,
+-	.needs_tmpdir = 1,
+-	.format_device = 1,
++	.needs_tmpdir = 0,
++	.format_device = 0,
+ 	.setup = setup,
+ 	.cleanup = cleanup,
+ 	.test_all = verify_umount,


### PR DESCRIPTION
This PR addresses issue 67 in LTP tests:
Issue Description: Currently the test tries to test the umount api. For this it was using a test device using loop device and make a filesystem and then unmount. But this was failing due to the memory limit of SGX at 32 MB.
Solution: With this PR we are mounting the root file system and verifying the mount functionality.
Reference:https://dev.azure.com/ConfidentialContainers/ConfidentialLinuxContainers/_workitems/edit/67/