### PR TITLE
Fix for umount03

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -32,6 +32,7 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
 	$(ESCALATE_CMD) cp ltp_fork_disable.patch $(MOUNTPOINT)/
+	$(ESCALATE_CMD) cp patches/umount03.patch $(MOUNTPOINT)/
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -30,6 +30,7 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
 	$(ESCALATE_CMD) cp ../ltp_fork_disable.patch $(MOUNTPOINT)/
+	$(ESCALATE_CMD) cp ../patches/umount03.patch $(MOUNTPOINT)/
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/buildenv.sh
+++ b/tests/ltp/buildenv.sh
@@ -5,6 +5,7 @@ test_directory=$2
 
 LTP_GIT_TAG="20190930"
 FORK_DISABLE_PATCH="/ltp_fork_disable.patch"
+UMOUNT03_PATCH="/umount03.patch"
 
 if [ -z $test_directory ]; then
     echo "Please provide ltp tests directory. Example: ltp.sh 'testcases/kernel/syscalls'"
@@ -45,6 +46,10 @@ if [[ "$mode" == "build" ]]; then
         git apply $FORK_DISABLE_PATCH
     fi
 
+    if [ -f $UMOUNT03_PATCH ];then
+        echo applying patch "$UMOUNT03_PATCH"
+        git apply $UMOUNT03_PATCH
+    fi
     echo "Running make clean..."
     make autotools
     ./configure

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -996,7 +996,7 @@
 #/ltp/testcases/kernel/syscalls/umask/umask01
 /ltp/testcases/kernel/syscalls/umount/umount01
 /ltp/testcases/kernel/syscalls/umount/umount02
-/ltp/testcases/kernel/syscalls/umount/umount03
+#/ltp/testcases/kernel/syscalls/umount/umount03
 /ltp/testcases/kernel/syscalls/umount2/umount2_01
 /ltp/testcases/kernel/syscalls/umount2/umount2_02
 /ltp/testcases/kernel/syscalls/umount2/umount2_03

--- a/tests/ltp/patches/umount03.patch
+++ b/tests/ltp/patches/umount03.patch
@@ -1,0 +1,44 @@
+diff --git a/testcases/kernel/syscalls/umount/umount03.c b/testcases/kernel/syscalls/umount/umount03.c
+index 28309a305..d279273e6 100644
+--- a/testcases/kernel/syscalls/umount/umount03.c
++++ b/testcases/kernel/syscalls/umount/umount03.c
+@@ -23,16 +23,16 @@ static void verify_umount(void)
+ 	TEST(umount(MNTPOINT));
+ 
+ 	if (TST_RET != -1) {
+-		tst_res(TFAIL, "umount() succeeds unexpectedly");
++		tst_res(TFAIL, "umount() succeeds unexpectedly. TEST_FAILED");
+ 		return;
+ 	}
+ 
+ 	if (TST_ERR != EPERM) {
+-		tst_res(TFAIL | TTERRNO, "umount() should fail with EPERM");
++		tst_res(TFAIL | TTERRNO, "umount() should fail with EPERM. TEST_FAILED");
+ 		return;
+ 	}
+ 
+-	tst_res(TPASS | TTERRNO, "umount() fails as expected");
++	tst_res(TPASS | TTERRNO, "umount() fails as expected. PASSED");
+ }
+ 
+ static void setup(void)
+@@ -40,7 +40,7 @@ static void setup(void)
+ 	struct passwd *pw;
+ 
+ 	SAFE_MKDIR(MNTPOINT, 0775);
+-	SAFE_MOUNT(tst_device->dev, MNTPOINT, tst_device->fs_type, 0, NULL);
++	SAFE_MOUNT("/dev/vda", MNTPOINT, "ext4", 0, NULL);
+ 	mount_flag = 1;
+ 
+ 	pw = SAFE_GETPWNAM("nobody");
+@@ -58,8 +58,8 @@ static void cleanup(void)
+ 
+ static struct tst_test test = {
+ 	.needs_root = 1,
+-	.needs_tmpdir = 1,
+-	.format_device = 1,
++	.needs_tmpdir = 0,
++	.format_device = 0,
+ 	.setup = setup,
+ 	.cleanup = cleanup,
+ 	.test_all = verify_umount,


### PR DESCRIPTION
Issue Description: The umount03 test was failing with panic due to lack of space. This was a limitation in SGX with 32MB memory.
Solution: The test now uses root file system