### PR TITLE
Enclave pie

### DIFF
--- a/config.mak
+++ b/config.mak
@@ -89,7 +89,7 @@ LKL                                 ?= $(SGXLKL_ROOT)/lkl
 LKL_BUILD                           ?= ${BUILD_DIR}/lkl
 LIBLKL                              ?= ${LKL_BUILD}/lib/liblkl.a
 LKL_HEADERS                         ?= ${LKL_BUILD}/include/lkl/bits.h ${LKL_BUILD}/include/lkl/syscalls.h
-LKL_CFLAGS_EXTRA                    ?=
+LKL_CFLAGS_EXTRA                    ?= -fPIE
 
 ifeq ($(RELEASE),true)
     SGXLKL_CFLAGS           += -DSGXLKL_RELEASE

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ CROSS_COMPILE =
 RANLIB  = $(CROSS_COMPILE)ranlib
 
 CFLAGS_MAIN = -I$(OE_SDK_INCLUDES)
-CFLAGS_ENCLAVE = -I$(OE_SDK_INCLUDES) -I${OE_SDK_INCLUDES}/openenclave/3rdparty
+CFLAGS_ENCLAVE = -I$(OE_SDK_INCLUDES) -I${OE_SDK_INCLUDES}/openenclave/3rdparty -fPIE
 LINK_MAIN =
 
 GIT_VERSION = "$(shell git describe --dirty --always --tags || echo unknown)"


### PR DESCRIPTION
Compile our enclave code and LKL with -fPIE.  This generates position-independent code without GOT relocations where possible, so most things will work without dynamic relocations.  The Linux kernel contains a number of weak reference (529), which still need relocations.