### PR TITLE
LTP:Fix failure setresuid syscall test setresuid04

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -854,7 +854,7 @@
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid01
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid02
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid03
-/ltp/testcases/kernel/syscalls/setresuid/setresuid04
+#/ltp/testcases/kernel/syscalls/setresuid/setresuid04
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid05
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid01
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid02

--- a/tests/ltp/patches/fix_setresuid_setresuid04.patch
+++ b/tests/ltp/patches/fix_setresuid_setresuid04.patch
@@ -1,0 +1,191 @@
+diff --git a/testcases/kernel/syscalls/setresuid/setresuid04.c b/testcases/kernel/syscalls/setresuid/setresuid04.c
+index e197476ff..15c3df476 100644
+--- a/testcases/kernel/syscalls/setresuid/setresuid04.c
++++ b/testcases/kernel/syscalls/setresuid/setresuid04.c
+@@ -54,6 +54,7 @@
+ #include "safe_macros.h"
+ #include <pwd.h>
+ #include "compat_16.h"
++#include <pthread.h>
+ 
+ TCID_DEFINE(setresuid04);
+ int TST_TOTAL = 1;
+@@ -65,46 +66,63 @@ int fd = -1;
+ 
+ void setup(void);
+ void cleanup(void);
+-void do_master_child();
++void* do_master_child(void*);
++void* do_sub_child(void*);
+ 
+ int main(int ac, char **av)
+ {
+-	pid_t pid;
++	pthread_t threadid;
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+ 	setup();
+-
+-	pid = FORK_OR_VFORK();
+-	if (pid < 0)
+-		tst_brkm(TBROK, cleanup, "Fork failed");
+-
+-	if (pid == 0)
+-		do_master_child();
+-
+-	tst_record_childstatus(cleanup, pid);
+-
++	if(pthread_create(&threadid, NULL, do_master_child, NULL))
++	{
++		tst_brkm(TBROK, NULL, "TEST_FAILED: Thread creation failed");
++		tst_exit();
++	}
++	/* wait for the thread to join */	
++	pthread_join(threadid, NULL);
+ 	cleanup();
+ 	tst_exit();
+ }
+ 
++void *do_sub_child(void* arg)
++{
++	int tst_fd2;
++
++	/* Test to open the file in son process */
++	TEST(tst_fd2 = open(testfile, O_RDWR));
++
++	if (TEST_RETURN != -1) {
++		tst_resm(TPASS,
++			"PASSED: setresuid() file  opened succeeded in thread2");
++		close(tst_fd2);
++	} else {
++		tst_brkm(TBROK, NULL,
++			"TEST_FAILED open failed unexpectedly in thread2\n");
++	}
++	pthread_exit(NULL);
++}
++
+ /*
+  * do_master_child()
+  */
+-void do_master_child(void)
++void* do_master_child(void* arg)
+ {
+ 	int lc;
+-	int pid;
+-	int status;
++	pthread_t tid;
++	int* result;
+ 
+ 	for (lc = 0; TEST_LOOPING(lc); lc++) {
+ 		int tst_fd;
+ 
+ 		/* Reset tst_count in case we are looping */
+ 		tst_count = 0;
+-
++		
++		/* change effective uid of the process */
+ 		if (SETRESUID(NULL, 0, ltpuser->pw_uid, 0) == -1) {
+-			perror("setresuid failed");
+-			exit(TFAIL);
++			tst_brkm(TBROK, NULL, "TEST_FAILED: setresuid() failed");
++			pthread_exit(NULL);
+ 		}
+ 
+ 		/* Test 1: Check the process with new uid cannot open the file
+@@ -113,78 +131,49 @@ void do_master_child(void)
+ 		TEST(tst_fd = open(testfile, O_RDWR));
+ 
+ 		if (TEST_RETURN != -1) {
+-			printf("open succeeded unexpectedly\n");
++			tst_brkm(TBROK, NULL, "TEST_FAILED: test file open succeeded unexpectedly\n");
+ 			close(tst_fd);
+-			exit(TFAIL);
++			pthread_exit(NULL);
+ 		}
+ 
+ 		if (TEST_ERRNO == EACCES) {
+-			printf("open failed with EACCES as expected\n");
++			tst_resm(TPASS, "PASSED:test file open failed with EACCES as expected after setresuid()\n");
+ 		} else {
+-			perror("open failed unexpectedly");
+-			exit(TFAIL);
++			tst_brkm(TBROK, NULL, "TEST_FAILED: test file open failed unexpectedly after  setresuid()");
++			pthread_exit(NULL);
+ 		}
+ 
+-		/* Test 2: Check a son process cannot open the file
++		/* Test 2: Check new thread  can open the file
+ 		 *         with RDWR permissions.
+ 		 */
+-		pid = FORK_OR_VFORK();
+-		if (pid < 0)
+-			tst_brkm(TBROK, NULL, "Fork failed");
+-
+-		if (pid == 0) {
+-			int tst_fd2;
+-
+-			/* Test to open the file in son process */
+-			TEST(tst_fd2 = open(testfile, O_RDWR));
+-
+-			if (TEST_RETURN != -1) {
+-				printf("call succeeded unexpectedly\n");
+-				close(tst_fd2);
+-				exit(TFAIL);
+-			}
+-
+-			if (TEST_ERRNO == EACCES) {
+-				printf("open failed with EACCES as expected\n");
+-				exit(TPASS);
+-			} else {
+-				printf("open failed unexpectedly\n");
+-				exit(TFAIL);
+-			}
+-		} else {
+-			/* Wait for son completion */
+-			if (waitpid(pid, &status, 0) == -1) {
+-				perror("waitpid failed");
+-				exit(TFAIL);
+-			}
+-
+-			if (!WIFEXITED(status))
+-				exit(TFAIL);
+-
+-			if (WEXITSTATUS(status) != TPASS)
+-				exit(WEXITSTATUS(status));
++		if(pthread_create(&tid, NULL, do_sub_child, NULL) != 0)
++		{
++			tst_brkm(TBROK, NULL, "TEST_FAILED: thread creation failed");
++			pthread_exit(NULL);
+ 		}
++		/* wait for the thread to complete the test */
++		pthread_join(tid, NULL);
+ 
+ 		/* Test 3: Fallback to initial uid and check we can again open
+ 		 *         the file with RDWR permissions.
+ 		 */
+ 		tst_count++;
+ 		if (SETRESUID(NULL, 0, 0, 0) == -1) {
+-			perror("setresuid failed");
+-			exit(TFAIL);
++			tst_brkm(TBROK, NULL, "TEST_FAILED: setresuid() failed");
++			pthread_exit(NULL);
+ 		}
+ 
+ 		TEST(tst_fd = open(testfile, O_RDWR));
+ 
+ 		if (TEST_RETURN == -1) {
+-			perror("open failed unexpectedly");
+-			exit(TFAIL);
++			tst_brkm(TBROK, NULL, "TEST_FAILED: test file open failed unexpectedly after setresuid()");
++			pthread_exit(NULL);
+ 		} else {
+-			printf("open call succeeded\n");
++			tst_resm(TPASS, "PASSED: test file open succeeded after setresuid()\n");
+ 			close(tst_fd);
+ 		}
+ 	}
+-	exit(TPASS);
++	pthread_exit(NULL);
+ }
+ 
+ /*


### PR DESCRIPTION
Test case (testcases/kernel/syscalls/setresuid/setresuid04)
is failed/skipped because it exit improperly in middle of test.
this is due to single process environment. Test case is modified
and updated to test setresuid syscall in multithreaded environment