### PR TITLE
LTP:Fix failure setreuid syscall test setreuid07

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -32,6 +32,7 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
 	$(ESCALATE_CMD) cp ltp_fork_disable.patch $(MOUNTPOINT)/
+	$(ESCALATE_CMD) cp patches/fix_setreuid_setreuid07.patch $(MOUNTPOINT)/
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -30,6 +30,7 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
 	$(ESCALATE_CMD) cp ../ltp_fork_disable.patch $(MOUNTPOINT)/
+	$(ESCALATE_CMD) cp ../patches/fix_setreuid_setreuid07.patch $(MOUNTPOINT)/
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/buildenv.sh
+++ b/tests/ltp/buildenv.sh
@@ -5,6 +5,7 @@ test_directory=$2
 
 LTP_GIT_TAG="20190930"
 FORK_DISABLE_PATCH="/ltp_fork_disable.patch"
+FIX_SETREUID_PATCH="/fix_setreuid_setreuid07.patch"
 
 if [ -z $test_directory ]; then
     echo "Please provide ltp tests directory. Example: ltp.sh 'testcases/kernel/syscalls'"
@@ -43,6 +44,11 @@ if [[ "$mode" == "build" ]]; then
     if [ -f $FORK_DISABLE_PATCH ];then
         echo applying patch "$FORK_DISABLE_PATCH"
         git apply $FORK_DISABLE_PATCH
+    fi
+
+    if [ -f $FIX_SETREUID_PATCH ];then
+        echo applying patch "$FIX_SETREUID_PATCH"
+        git apply $FIX_SETREUID_PATCH
     fi
 
     echo "Running make clean..."

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -862,7 +862,7 @@
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid04
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid05
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid06
-/ltp/testcases/kernel/syscalls/setreuid/setreuid07
+#/ltp/testcases/kernel/syscalls/setreuid/setreuid07
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit01
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit02
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit03

--- a/tests/ltp/patches/fix_setreuid_setreuid07.patch
+++ b/tests/ltp/patches/fix_setreuid_setreuid07.patch
@@ -1,0 +1,193 @@
+diff --git a/testcases/kernel/syscalls/setreuid/setreuid07.c b/testcases/kernel/syscalls/setreuid/setreuid07.c
+index ff222cd00..16f4ac2d9 100644
+--- a/testcases/kernel/syscalls/setreuid/setreuid07.c
++++ b/testcases/kernel/syscalls/setreuid/setreuid07.c
+@@ -34,6 +34,7 @@
+ #include <fcntl.h>
+ #include <unistd.h>
+ #include <pwd.h>
++#include <pthread.h>
+ 
+ #include "test.h"
+ #include "safe_macros.h"
+@@ -49,34 +50,50 @@ static int fd = -1;
+ 
+ static void setup(void);
+ static void cleanup(void);
+-static void do_master_child(void);
++static void* do_master_child(void* arg);
+ 
+ int main(int ac, char **av)
+ {
+-	pid_t pid;
+-
++	pthread_t threadid;
+ 	tst_parse_opts(ac, av, NULL, NULL);
+ 
+ 	setup();
+ 
+-	pid = FORK_OR_VFORK();
+-	if (pid < 0)
+-		tst_brkm(TBROK, cleanup, "Fork failed");
+-
+-	if (pid == 0)
+-		do_master_child();
+-
+-	tst_record_childstatus(cleanup, pid);
++        if(pthread_create(&threadid, NULL, do_master_child, NULL))
++        {
++                tst_brkm(TBROK, NULL, "TEST_FAILED: Thread creation failed");
++                tst_exit();
++        }
++        /* wait for the thread to join */
++        pthread_join(threadid, NULL);
+ 
++	tst_resm(TPASS, "Test case passed TPASS");
+ 	cleanup();
+ 	tst_exit();
+ }
+ 
+-static void do_master_child(void)
++static void *do_sub_child(void* arg)
++{
++        int tst_fd2;
++
++        /* Test to open the file in thread2 created by thread1 */
++        TEST(tst_fd2 = open(testfile, O_RDWR));
++
++        if (TEST_RETURN != -1) {
++                tst_resm(TPASS,
++                        "PASSED: setresuid() file  opened succeeded in thread2");
++                close(tst_fd2);
++        } else {
++                tst_brkm(TBROK, NULL,
++                        "TEST_FAILED open failed unexpectedly in thread2\n");
++        }
++        pthread_exit(NULL);
++}
++
++static void* do_master_child(void* arg)
+ {
+ 	int lc;
+-	int pid;
+-	int status;
++	pthread_t tid;
+ 
+ 	for (lc = 0; TEST_LOOPING(lc); lc++) {
+ 		int tst_fd;
+@@ -84,8 +101,8 @@ static void do_master_child(void)
+ 		tst_count = 0;
+ 
+ 		if (SETREUID(NULL, 0, ltpuser->pw_uid) == -1) {
+-			perror("setreuid failed");
+-			exit(TFAIL);
++                        tst_brkm(TBROK, NULL, "TEST_FAILED: setreuid() failed");
++                        pthread_exit(NULL);
+ 		}
+ 
+ 		/* Test 1: Check the process with new uid cannot open the file
+@@ -94,74 +111,50 @@ static void do_master_child(void)
+ 		TEST(tst_fd = open(testfile, O_RDWR));
+ 
+ 		if (TEST_RETURN != -1) {
+-			printf("open succeeded unexpectedly\n");
+-			close(tst_fd);
+-			exit(TFAIL);
++		        tst_brkm(TBROK, NULL, "TEST_FAILED: test file open succeeded unexpectedly\n");
++                        close(tst_fd);
++                        pthread_exit(NULL);
+ 		}
+ 
+ 		if (TEST_ERRNO == EACCES) {
+-			printf("open failed with EACCES as expected\n");
++			tst_resm(TPASS, "PASSED:test file open failed with EACCES as expected after setreuid()\n");
+ 		} else {
+-			perror("open failed unexpectedly");
+-			exit(TFAIL);
++			tst_brkm(TBROK, NULL, "TEST_FAILED: test file open failed unexpectedly after setreuid()");
++                        pthread_exit(NULL);
+ 		}
+ 
+ 		/* Test 2: Check a son process cannot open the file
+ 		 *         with RDWR permissions.
+ 		 */
+-		pid = FORK_OR_VFORK();
+-		if (pid < 0)
+-			tst_brkm(TBROK, cleanup, "Fork failed");
+-
+-		if (pid == 0) {
+-			int tst_fd2;
+-
+-			/* Test to open the file in son process */
+-			TEST(tst_fd2 = open(testfile, O_RDWR));
+-
+-			if (TEST_RETURN != -1) {
+-				printf("call succeeded unexpectedly\n");
+-				close(tst_fd2);
+-				exit(TFAIL);
+-			}
+-
+-			if (TEST_ERRNO == EACCES) {
+-				printf("open failed with EACCES as expected\n");
+-				exit(TPASS);
+-			} else {
+-				printf("open failed unexpectedly\n");
+-				exit(TFAIL);
+-			}
+-		} else {
+-			/* Wait for son completion */
+-			if (waitpid(pid, &status, 0) == -1) {
+-				perror("waitpid failed");
+-				exit(TFAIL);
+-			}
+-			if (!WIFEXITED(status) || (WEXITSTATUS(status) != 0))
+-				exit(WEXITSTATUS(status));
+-		}
++
++		if(pthread_create(&tid, NULL, do_sub_child, NULL) != 0)
++                {
++                        tst_brkm(TBROK, NULL, "TEST_FAILED: thread creation failed");
++                        pthread_exit(NULL);
++                }
++                /* wait for the thread to complete the test */
++                pthread_join(tid, NULL);
+ 
+ 		/* Test 3: Fallback to initial uid and check we can again open
+ 		 *         the file with RDWR permissions.
+ 		 */
+ 		tst_count++;
+ 		if (SETREUID(NULL, 0, 0) == -1) {
+-			perror("setreuid failed");
+-			exit(TFAIL);
++			tst_brkm(TBROK, NULL, "TEST_FAILED: setreuid() failed");
++                        pthread_exit(NULL);
+ 		}
+ 
+ 		TEST(tst_fd = open(testfile, O_RDWR));
+ 
+ 		if (TEST_RETURN == -1) {
+-			perror("open failed unexpectedly");
+-			exit(TFAIL);
++		        tst_brkm(TBROK, NULL, "TEST_FAILED: test file open failed unexpectedly after setreuid()");
++                        pthread_exit(NULL);
+ 		} else {
+-			printf("open call succeeded\n");
+-			close(tst_fd);
++		        tst_resm(TPASS, "PASSED: test file open succeeded after setreuid()\n");
++                        close(tst_fd);
+ 		}
+ 	}
+-	exit(TPASS);
++	pthread_exit(NULL);
+ }
+ 
+ static void setup(void)
+@@ -170,7 +163,7 @@ static void setup(void)
+ 
+ 	ltpuser = getpwnam("nobody");
+ 	if (ltpuser == NULL)
+-		tst_brkm(TBROK, NULL, "nobody must be a valid user.");
++		tst_brkm(TBROK, NULL, "TEST_FAILED: nobody must be a valid user.");
+ 
+ 	tst_tmpdir();
+ 


### PR DESCRIPTION
Test case (testcases/kernel/syscalls/setreuid/setreuid07)
is failed/skipped because it exit improperly in middle of test
because of single process environment. Test case issue is fixed
and updated the test case to test setreuid syscall in multithreaded
environment