### PR TITLE
Remove unused clock ocalls

### DIFF
--- a/src/host_interface/host_interface_calls.c
+++ b/src/host_interface/host_interface_calls.c
@@ -143,19 +143,3 @@ void sgxlkl_host_shutdown_notification(void)
     /* Notify host device for the shutdown evt */
     vio_host_notify_guest_shutdown_evt();
 }
-
-/*
- * Function to get clock resolution
- */
-int sgxlkl_host_syscall_clock_getres(clockid_t clk_id, struct timespec* res)
-{
-    return clock_getres(clk_id, res);
-}
-
-/*
- * Function to get the time from host
- */
-int sgxlkl_host_syscall_clock_gettime(clockid_t clk_id, struct timespec* tp)
-{
-    return clock_gettime(clk_id, tp);
-}

--- a/src/sgxlkl.edl
+++ b/src/sgxlkl.edl
@@ -27,16 +27,6 @@ enclave {
             size_t len,
             int prot);
 
-        // Host call to get clock resolution
-        int sgxlkl_host_syscall_clock_getres(
-            clockid_t clk_id,
-            [out] struct timespec *res);
-
-        // Host call to get clock gettime
-        int sgxlkl_host_syscall_clock_gettime(
-            clockid_t clk_id,
-            [out] struct timespec *tp);
-
 	    // Host call for signal handler registration to support signal handling in software mode
 	    void sgxlkl_host_sw_register_signal_handler(
             [user_check] void *sgxlkl_enclave_sw_signal_handler);


### PR DESCRIPTION
With the addition of an in-enclave source of time,

- sgxlkl_host_syscall_clock_getres
- sgxlkl_host_syscall_clock_gettime

are no longer used or needed.