### PR TITLE
Remove some libc dependencies from src/enclave

### DIFF
--- a/src/enclave/enclave_event_channel.c
+++ b/src/enclave/enclave_event_channel.c
@@ -12,6 +12,8 @@
 #include "enclave/ticketlock.h"
 #include "enclave/vio_enclave_event_channel.h"
 
+#include "openenclave/corelibc/oemalloc.h"
+
 static struct ticketlock** evt_chn_lock;
 
 /* Tasks monitoring event channels */
@@ -88,7 +90,7 @@ static void vio_enclave_process_host_event(uint8_t* param)
     uint8_t dev_id = *param;
 
     /* release memory after extracting dev_id */
-    free(param);
+    oe_free(param);
 
     enc_evt_channel_t* evt_channel = _enc_dev_config[dev_id].enc_evt_chn;
     evt_t* evt_processed = &_enc_dev_config[dev_id].evt_processed;
@@ -142,27 +144,27 @@ void initialize_enclave_event_channel(
     uint8_t* dev_id = NULL;
     _evt_channel_num = evt_channel_num;
 
-    evt_chn_lock = (struct ticketlock**)calloc(
+    evt_chn_lock = (struct ticketlock**)oe_calloc(
         evt_channel_num, sizeof(struct ticketlock*));
 
     vio_tasks =
-        (struct lthread**)calloc(evt_channel_num, sizeof(struct lthread*));
+        (struct lthread**)oe_calloc(evt_channel_num, sizeof(struct lthread*));
 
     _enc_dev_config = enc_dev_config;
     for (int i = 0; i < evt_channel_num; i++)
     {
         evt_chn_lock[i] =
-            (struct ticketlock*)calloc(1, sizeof(struct ticketlock));
+            (struct ticketlock*)oe_calloc(1, sizeof(struct ticketlock));
         memset(evt_chn_lock[i], 0, sizeof(struct ticketlock));
 
-        dev_id = (uint8_t*)calloc(1, sizeof(uint8_t));
+        dev_id = (uint8_t*)oe_calloc(1, sizeof(uint8_t));
         *dev_id = enc_dev_config[i].dev_id;
 
         struct lthread* lt = NULL;
         if (lthread_create(
                 &lt, NULL, vio_enclave_process_host_event, (void*)dev_id) != 0)
         {
-            free(vio_tasks);
+            oe_free(vio_tasks);
             sgxlkl_fail("Failed to create lthread for event channel\n");
         }
         vio_tasks[i] = lt;

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -9,6 +9,8 @@
 #include "lkl/setup.h"
 
 #include <openenclave/internal/globals.h>
+#include "openenclave/corelibc/oemalloc.h"
+#include "openenclave/corelibc/oestring.h"
 
 #include "enclave/enclave_mem.h"
 #include "enclave/enclave_util.h"
@@ -43,22 +45,22 @@ static void __sgxlkl_enclave_copy_app_config(
     char** envp = NULL;
 
     app_config->argc = sgxlkl_config->argc;
-    app_config->argv = malloc((app_config->argc + 1) * sizeof(char*));
+    app_config->argv = oe_malloc((app_config->argc + 1) * sizeof(char*));
 
     for (i = 0; i < app_config->argc; i++)
-        app_config->argv[i] = strdup(sgxlkl_config->argv[i]);
+        app_config->argv[i] = oe_strdup(sgxlkl_config->argv[i]);
     app_config->argv[i] = NULL;
 
     envp = sgxlkl_config->argv + sgxlkl_config->argc + 1;
     for (; envp[j++] != NULL;)
         ;
 
-    app_config->envp = malloc((j + 1) * sizeof(char*));
+    app_config->envp = oe_malloc((j + 1) * sizeof(char*));
     for (j = 0; envp[j] != NULL; j++)
-        app_config->envp[j] = strdup(envp[j]);
+        app_config->envp[j] = oe_strdup(envp[j]);
     app_config->envp[j] = NULL;
 
-    app_config->cwd = strdup(sgxlkl_config->cwd);
+    app_config->cwd = oe_strdup(sgxlkl_config->cwd);
 
     return;
 }

--- a/src/enclave/sgxlkl_config.c
+++ b/src/enclave/sgxlkl_config.c
@@ -3,10 +3,7 @@
 #include <enclave/enclave_util.h>
 #include <shared/sgxlkl_config.h>
 
-// We can't use normal malloc at this point in time,
-// so we use the OE-internal malloc here.
-extern void* oe_malloc(size_t size);
-extern void oe_free(void*);
+#include "openenclave/corelibc/oemalloc.h"
 
 // Duplicate a string
 static int strdupz(char** to, const char* from)
@@ -55,7 +52,8 @@ int sgxlkl_copy_config(const sgxlkl_config_t* from, sgxlkl_config_t** to)
     sgxlkl_config_t* cfg = *to;
 
     // Catch modifications to sgxlkl_config_t early.
-    _Static_assert(sizeof(sgxlkl_config_t) == 472, "sgxlkl_config_t size has changed");
+    _Static_assert(
+        sizeof(sgxlkl_config_t) == 472, "sgxlkl_config_t size has changed");
 
     cfg->max_user_threads = from->max_user_threads;
     cfg->stacksize = from->stacksize;

--- a/src/include/openenclave/corelibc/oestring.h
+++ b/src/include/openenclave/corelibc/oestring.h
@@ -1,0 +1,6 @@
+#ifndef __OE_STRING_INCLUDED__
+#define __OE_STRING_INCLUDED__
+
+char *oe_strdup(const char *s);
+
+#endif


### PR DESCRIPTION
As part of relayering work, we want to ensure that nothing in src/enclave
depends on libc init. This is a first step in that direction.

Partially addresses #151 