### PR TITLE
LTP: Fix failure in chroot syscall test chroot02

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -48,7 +48,7 @@
 /ltp/testcases/kernel/syscalls/chown/chown04
 #/ltp/testcases/kernel/syscalls/chown/chown05
 /ltp/testcases/kernel/syscalls/chroot/chroot01
-/ltp/testcases/kernel/syscalls/chroot/chroot02
+#/ltp/testcases/kernel/syscalls/chroot/chroot02
 /ltp/testcases/kernel/syscalls/chroot/chroot03
 #/ltp/testcases/kernel/syscalls/chroot/chroot04
 #/ltp/testcases/kernel/syscalls/clock_adjtime/clock_adjtime01

--- a/tests/ltp/patches/fix_chroot_chroot02.patch
+++ b/tests/ltp/patches/fix_chroot_chroot02.patch
@@ -1,0 +1,35 @@
+commit 9dacbeffecd080404ddcc71e33dd4698c5656818
+Author: shaik shavali <shaik.shavali1@wipro.com>
+Date:   Tue May 5 12:03:37 2020 +0000
+
+    LTP: Fix chroot02 test case issue
+    
+    Removed exit code from child and wait code from parent.
+    FORK_OR_VFORK return always 0 in sgxlkl environment.
+
+diff --git a/testcases/kernel/syscalls/chroot/chroot02.c b/testcases/kernel/syscalls/chroot/chroot02.c
+index e483ca4b5..e30fcc421 100644
+--- a/testcases/kernel/syscalls/chroot/chroot02.c
++++ b/testcases/kernel/syscalls/chroot/chroot02.c
+@@ -94,17 +94,13 @@ int main(int ac, char **av)
+ 				}
+ 			}
+ 
+-			exit(retval);
+ 		}
+ 
+-		/* parent */
+-		wait(&status);
+-		/* make sure the child returned a good exit status */
+-		if (WIFSIGNALED(status) ||
+-		    (WIFEXITED(status) && WEXITSTATUS(status) != 0))
+-			tst_resm(TFAIL, "chroot functionality incorrect");
++		/* make sure the chroot is sucessfull */
++		if (retval)
++			tst_brkm(TBROK, cleanup, "TEST_FAILED: chroot() functionality incorrect");
+ 		else
+-			tst_resm(TPASS, "chroot functionality correct");
++			tst_resm(TPASS, "PASSED: chroot() functionality correct");
+ 	}
+ 
+ 	cleanup();


### PR DESCRIPTION
Test case (testcases/kernel/syscalls/chroot/chroot02)
is failed/skipped because it exit improperly in middle of test.
this is due to single process environment. Test case is modified
to work in single process environment.