### PR TITLE
LTP:Fixed issue setfsuid syscall test setfsuid04

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -822,7 +822,7 @@
 #/ltp/testcases/kernel/syscalls/setfsuid/setfsuid01
 #/ltp/testcases/kernel/syscalls/setfsuid/setfsuid02
 /ltp/testcases/kernel/syscalls/setfsuid/setfsuid03
-/ltp/testcases/kernel/syscalls/setfsuid/setfsuid04
+#/ltp/testcases/kernel/syscalls/setfsuid/setfsuid04
 #/ltp/testcases/kernel/syscalls/setgid/setgid01
 /ltp/testcases/kernel/syscalls/setgid/setgid02
 #/ltp/testcases/kernel/syscalls/setgid/setgid03

--- a/tests/ltp/patches/setfsuid04.patch
+++ b/tests/ltp/patches/setfsuid04.patch
@@ -1,0 +1,74 @@
+diff --git a/testcases/kernel/syscalls/setfsuid/setfsuid04.c b/testcases/kernel/syscalls/setfsuid/setfsuid04.c
+index 8585d6207..75621d652 100644
+--- a/testcases/kernel/syscalls/setfsuid/setfsuid04.c
++++ b/testcases/kernel/syscalls/setfsuid/setfsuid04.c
+@@ -25,7 +25,7 @@
+  * The same test is done in a fork to check if new UIDs are correctly
+  * passed to the son.
+  */
+-
++// Patch Description : Modified to report PASS/FAIL status by replacing exit, as child process is not supported.
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>
+@@ -69,7 +69,7 @@ int main(int ac, char **av)
+        if (pid == 0)
+                do_master_child();
+
+-       tst_record_childstatus(cleanup, pid);
++       //tst_record_childstatus(cleanup, pid);
+
+        cleanup();
+        tst_exit();
+@@ -92,15 +92,13 @@ static void do_master_child(void)
+
+        if (TEST_RETURN != -1) {
+                close(TEST_RETURN);
+-               printf("open succeeded unexpectedly\n");
+-               exit(TFAIL);
++               tst_resm(TFAIL, "open succeeded unexpectedly TEST_FAILED\n");
+        }
+
+        if (TEST_ERRNO == EACCES) {
+-               printf("open failed with EACCESS as expected\n");
++               tst_resm(TPASS, "open failed with EACCESS as expected PASSED\n");
+        } else {
+-               printf("open returned unexpected errno - %d\n", TEST_ERRNO);
+-               exit(TFAIL);
++               tst_resm(TFAIL, "open returned unexpected errno - %d TEST_FAILED\n", TEST_ERRNO);
+        }
+
+        /* Test 2: Check a son process cannot open the file
+@@ -118,16 +116,14 @@ static void do_master_child(void)
+
+                if (TEST_RETURN != -1) {
+                        close(TEST_RETURN);
+-                       printf("open succeeded unexpectedly\n");
+-                       exit(TFAIL);
++                       tst_resm(TFAIL, "open succeeded unexpectedly TEST_FAILED\n");
+                }
+
+                if (TEST_ERRNO == EACCES) {
+-                       printf("open failed with EACCESS as expected\n");
++                       tst_resm(TPASS, "open failed with EACCESS as expected PASSED\n");
+                } else {
+-                       printf("open returned unexpected errno - %d\n",
++                       tst_resm(TFAIL, "open returned unexpected errno - %d TEST_FAILED\n",
+                               TEST_ERRNO);
+-                       exit(TFAIL);
+                }
+        } else {
+                /* Wait for son completion */
+@@ -155,10 +151,10 @@ static void do_master_child(void)
+                perror("open failed unexpectedly");
+                exit(TFAIL);
+        } else {
+-               printf("open call succeeded\n");
++               tst_resm(TPASS, "open call succeeded PASSED\n");
+                close(TEST_RETURN);
+        }
+-       exit(TPASS);
++       //exit(TPASS);
+ }
+
+ static void setup(void)

--- a/tests/ltp/patches/setfsuid04.patch
+++ b/tests/ltp/patches/setfsuid04.patch
@@ -26,16 +26,16 @@ index 8585d6207..75621d652 100644
                 close(TEST_RETURN);
 -               printf("open succeeded unexpectedly\n");
 -               exit(TFAIL);
-+               tst_resm(TFAIL, "open succeeded unexpectedly TEST_FAILED\n");
++               tst_resm(TFAIL, "open succeeded unexpectedly\n");
         }
 
         if (TEST_ERRNO == EACCES) {
 -               printf("open failed with EACCESS as expected\n");
-+               tst_resm(TPASS, "open failed with EACCESS as expected PASSED\n");
++               tst_resm(TPASS, "open failed with EACCESS as expected\n");
         } else {
 -               printf("open returned unexpected errno - %d\n", TEST_ERRNO);
 -               exit(TFAIL);
-+               tst_resm(TFAIL, "open returned unexpected errno - %d TEST_FAILED\n", TEST_ERRNO);
++               tst_resm(TFAIL, "open returned unexpected errno - %d\n", TEST_ERRNO);
         }
 
         /* Test 2: Check a son process cannot open the file
@@ -45,15 +45,15 @@ index 8585d6207..75621d652 100644
                         close(TEST_RETURN);
 -                       printf("open succeeded unexpectedly\n");
 -                       exit(TFAIL);
-+                       tst_resm(TFAIL, "open succeeded unexpectedly TEST_FAILED\n");
++                       tst_resm(TFAIL, "open succeeded unexpectedly\n");
                 }
 
                 if (TEST_ERRNO == EACCES) {
 -                       printf("open failed with EACCESS as expected\n");
-+                       tst_resm(TPASS, "open failed with EACCESS as expected PASSED\n");
++                       tst_resm(TPASS, "open failed with EACCESS as expected\n");
                 } else {
 -                       printf("open returned unexpected errno - %d\n",
-+                       tst_resm(TFAIL, "open returned unexpected errno - %d TEST_FAILED\n",
++                       tst_resm(TFAIL, "open returned unexpected errno - %d\n",
                                TEST_ERRNO);
 -                       exit(TFAIL);
                 }
@@ -64,7 +64,7 @@ index 8585d6207..75621d652 100644
                 exit(TFAIL);
         } else {
 -               printf("open call succeeded\n");
-+               tst_resm(TPASS, "open call succeeded PASSED\n");
++               tst_resm(TPASS, "open call succeeded\n");
                 close(TEST_RETURN);
         }
 -       exit(TPASS);


### PR DESCRIPTION
Testcase met success criteria but due to lack of child process, it is
not reporting test status, so replaced exit with tst_resm to report
the status and removed wait for child in parent.