### PR TITLE
chown04 Tests are modified to use the root file system.

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -45,7 +45,7 @@
 #/ltp/testcases/kernel/syscalls/chown/chown01
 #/ltp/testcases/kernel/syscalls/chown/chown02
 #/ltp/testcases/kernel/syscalls/chown/chown03
-/ltp/testcases/kernel/syscalls/chown/chown04
+#/ltp/testcases/kernel/syscalls/chown/chown04
 #/ltp/testcases/kernel/syscalls/chown/chown05
 /ltp/testcases/kernel/syscalls/chroot/chroot01
 /ltp/testcases/kernel/syscalls/chroot/chroot02

--- a/tests/ltp/patches/chown04.patch
+++ b/tests/ltp/patches/chown04.patch
@@ -1,18 +1,23 @@
 diff --git a/testcases/kernel/syscalls/chown/chown04.c b/testcases/kernel/syscalls/chown/chown04.c
-index 1f3ed412b..487aec16e 100644
+index 1f3ed412b..d87463524 100644
 --- a/testcases/kernel/syscalls/chown/chown04.c
 +++ b/testcases/kernel/syscalls/chown/chown04.c
-@@ -37,7 +37,8 @@
+@@ -37,7 +37,13 @@
   *   6) chown(2) returns -1 and sets errno to ENOENT if the specified file
   *              does not exists.
   */
 -
-+/* Patch Description: Test cases were failing as there was not sufficient memory to use for test image creation for a loop device for test purpose.
-+Solution: Test cases are modified to use /dev/vda the root file system device. In test accessing fault address is commented. This is a known issue in sgx that it causes enclave abort and is being tracked in Issue 169. Also commented testcase which checks mounted filesystem is readonly or not , it has a bug will be tracked under issue 189*/
++/*
++ * Patch Description: Test cases were failing as there was not sufficient memory
++ * to use for test image creation for a loop device for test purpose.
++ * Test cases are modified to use /dev/vda the root file system device.
++ * In test accessing fault address is commented, will be enabled after Issue 169 is fixed.
++ * Also commented testcase which checks mounted filesystem is readonly or not ,will enabled after issue 189 is fixed
++ */
  #include <stdio.h>
  #include <stdlib.h>
  #include <unistd.h>
-@@ -68,7 +69,7 @@
+@@ -68,7 +74,7 @@
  #define TEST_FILE5              "mntpoint"
 
  static char long_path[PATH_MAX + 2];
@@ -21,23 +26,23 @@ index 1f3ed412b..487aec16e 100644
  static int mount_flag;
 
  static struct test_case_t {
-@@ -77,12 +78,12 @@ static struct test_case_t {
+@@ -77,12 +83,12 @@ static struct test_case_t {
  } tc[] = {
         {TEST_FILE1, EPERM},
         {TEST_FILE2, EACCES},
 -       {(char *)-1, EFAULT},
-+       //{(char *)-1, EFAULT}, will be enabled after github issue 169 is fixed
++       //{(char *)-1, EFAULT}, TODO: Enable after github issue 169 is fixed
         {long_path, ENAMETOOLONG},
         {"", ENOENT},
         {TEST_FILE3, ENOTDIR},
 -       {TEST_FILE4, ELOOP},
 -       {TEST_FILE5, EROFS}
 +       {TEST_FILE4, ELOOP}
-+       //{TEST_FILE5, EROFS} will be enabled after github issue 189 is fixed
++       //{TEST_FILE5, EROFS} TODO: Enable after github issue 189 is fixed
  };
 
  TCID_DEFINE(chown04);
-@@ -136,7 +137,7 @@ int main(int ac, char **av)
+@@ -136,7 +142,7 @@ int main(int ac, char **av)
  static void setup(void)
  {
         struct passwd *ltpuser;
@@ -46,7 +51,7 @@ index 1f3ed412b..487aec16e 100644
 
         tst_require_root();
         tst_sig(FORK, DEF_HANDLER, cleanup);
-@@ -144,23 +145,12 @@ static void setup(void)
+@@ -144,23 +150,12 @@ static void setup(void)
 
         tst_tmpdir();
 
@@ -67,12 +72,12 @@ index 1f3ed412b..487aec16e 100644
 -               tst_brkm(TBROK | TERRNO, cleanup, "mmap failed");
 -
 -       tc[2].pathname = bad_addr;
-+       /*bad_addr = 0;
-+       tc[2].pathname = bad_addr; Commented because mmap not supported and lkl_access_ok is failing Github issue 169*/
++       //bad_addr = 0;
++       //tc[2].pathname = bad_addr; Commented because mmap not supported and lkl_access_ok is failing Github issue 169
 
         SAFE_SYMLINK(cleanup, "test_eloop1", "test_eloop2");
         SAFE_SYMLINK(cleanup, "test_eloop2", "test_eloop1");
-@@ -170,9 +160,11 @@ static void setup(void)
+@@ -170,9 +165,11 @@ static void setup(void)
         SAFE_TOUCH(cleanup, TEST_FILE1, 0666, NULL);
         SAFE_MKDIR(cleanup, DIR_TEMP, S_IRWXU);
         SAFE_TOUCH(cleanup, TEST_FILE2, 0666, NULL);
@@ -81,12 +86,12 @@ index 1f3ed412b..487aec16e 100644
 +       rmdir("mntpoint");
         SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
 -       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, MS_RDONLY, NULL);
-+       //SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, MS_RDONLY, NULL);// Replace with below line after issue 189 fixed
++       //SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, MS_RDONLY, NULL); Should be replaced with below line after issue 189 fixed
 +       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL);
         mount_flag = 1;
 
         SAFE_SETEUID(cleanup, ltpuser->pw_uid);
-@@ -188,8 +180,5 @@ void cleanup(void)
+@@ -188,8 +185,5 @@ void cleanup(void)
                          "umount device:%s failed", device);
         }
 

--- a/tests/ltp/patches/chown04.patch
+++ b/tests/ltp/patches/chown04.patch
@@ -1,0 +1,98 @@
+diff --git a/testcases/kernel/syscalls/chown/chown04.c b/testcases/kernel/syscalls/chown/chown04.c
+index 1f3ed412b..95fee2087 100644
+--- a/testcases/kernel/syscalls/chown/chown04.c
++++ b/testcases/kernel/syscalls/chown/chown04.c
+@@ -37,7 +37,8 @@
+  *   6) chown(2) returns -1 and sets errno to ENOENT if the specified file
+  *              does not exists.
+  */
+-
++/* Patch Description: Test cases were failing as there was not sufficient memory to use for test image creation for a loop device for test purpose.
++Solution: Test cases are modified to use /dev/vda the root file system device. In test accessing fault address is commented. This is a known issue in sgx that it causes enclave abort and is being tracked in Issue 169. Also commented testcase which checks mounted filesystem is readonly or not , it has a bug will be tracked under issue 189*/
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <unistd.h>
+@@ -68,7 +69,7 @@
+ #define TEST_FILE5              "mntpoint"
+
+ static char long_path[PATH_MAX + 2];
+-static const char *device;
++static const char *device = "/dev/vda";
+ static int mount_flag;
+
+ static struct test_case_t {
+@@ -77,12 +78,12 @@ static struct test_case_t {
+ } tc[] = {
+        {TEST_FILE1, EPERM},
+        {TEST_FILE2, EACCES},
+-       {(char *)-1, EFAULT},
++       //{(char *)-1, EFAULT}, will be enabled after github issue 169 is fixed
+        {long_path, ENAMETOOLONG},
+        {"", ENOENT},
+        {TEST_FILE3, ENOTDIR},
+-       {TEST_FILE4, ELOOP},
+-       {TEST_FILE5, EROFS}
++       {TEST_FILE4, ELOOP}
++       //{TEST_FILE5, EROFS} will be enabled after github issue 189 is fixed
+ };
+
+ TCID_DEFINE(chown04);
+@@ -136,7 +137,7 @@ int main(int ac, char **av)
+ static void setup(void)
+ {
+        struct passwd *ltpuser;
+-       const char *fs_type;
++       const char *fs_type = "ext4";
+
+        tst_require_root();
+        tst_sig(FORK, DEF_HANDLER, cleanup);
+@@ -144,24 +145,24 @@ static void setup(void)
+
+        tst_tmpdir();
+
+-       fs_type = tst_dev_fs_type();
+-       device = tst_acquire_device(cleanup);
++       //fs_type = tst_dev_fs_type;
++       //device = tst_acquire_device(cleanup);
+        if (!device)
+                tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+
+-       tst_mkfs(cleanup, device, fs_type, NULL, NULL);
++       //tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+
+        TEST_PAUSE;
+
+        memset(long_path, 'a', PATH_MAX - 1);
+
+-       bad_addr = mmap(0, 1, PROT_NONE,
++/*     bad_addr = mmap(0, 1, PROT_NONE,
+                        MAP_PRIVATE_EXCEPT_UCLINUX | MAP_ANONYMOUS, 0, 0);
+        if (bad_addr == MAP_FAILED)
+                tst_brkm(TBROK | TERRNO, cleanup, "mmap failed");
+
+        tc[2].pathname = bad_addr;
+-
++Commented because mmap not supported and lkl_access_ok is failing Github issue 169: */
+        SAFE_SYMLINK(cleanup, "test_eloop1", "test_eloop2");
+        SAFE_SYMLINK(cleanup, "test_eloop2", "test_eloop1");
+
+@@ -172,7 +173,7 @@ static void setup(void)
+        SAFE_TOUCH(cleanup, TEST_FILE2, 0666, NULL);
+
+        SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
+-       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, MS_RDONLY, NULL);
++       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL); // Will be reverted once github issue 189 is fixed
+        mount_flag = 1;
+
+        SAFE_SETEUID(cleanup, ltpuser->pw_uid);
+@@ -188,8 +189,8 @@ void cleanup(void)
+                         "umount device:%s failed", device);
+        }
+
+-       if (device)
+-               tst_release_device(device);
++       /*if (device)
++               tst_release_device(device);*/
+
+        tst_rmdir();
+ }

--- a/tests/ltp/patches/chown04.patch
+++ b/tests/ltp/patches/chown04.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/chown/chown04.c b/testcases/kernel/syscalls/chown/chown04.c
-index 1f3ed412b..95fee2087 100644
+index 1f3ed412b..d509ee92b 100644
 --- a/testcases/kernel/syscalls/chown/chown04.c
 +++ b/testcases/kernel/syscalls/chown/chown04.c
 @@ -37,7 +37,8 @@
@@ -46,53 +46,52 @@ index 1f3ed412b..95fee2087 100644
 
         tst_require_root();
         tst_sig(FORK, DEF_HANDLER, cleanup);
-@@ -144,24 +145,24 @@ static void setup(void)
+@@ -144,23 +145,12 @@ static void setup(void)
 
         tst_tmpdir();
 
 -       fs_type = tst_dev_fs_type();
 -       device = tst_acquire_device(cleanup);
-+       //fs_type = tst_dev_fs_type;
-+       //device = tst_acquire_device(cleanup);
-        if (!device)
-                tst_brkm(TCONF, cleanup, "Failed to obtain block device");
-
+-       if (!device)
+-               tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+-
 -       tst_mkfs(cleanup, device, fs_type, NULL, NULL);
-+       //tst_mkfs(cleanup, device, fs_type, NULL, NULL);
-
+-
         TEST_PAUSE;
 
         memset(long_path, 'a', PATH_MAX - 1);
 
 -       bad_addr = mmap(0, 1, PROT_NONE,
-+/*     bad_addr = mmap(0, 1, PROT_NONE,
-                        MAP_PRIVATE_EXCEPT_UCLINUX | MAP_ANONYMOUS, 0, 0);
-        if (bad_addr == MAP_FAILED)
-                tst_brkm(TBROK | TERRNO, cleanup, "mmap failed");
-
-        tc[2].pathname = bad_addr;
+-                       MAP_PRIVATE_EXCEPT_UCLINUX | MAP_ANONYMOUS, 0, 0);
+-       if (bad_addr == MAP_FAILED)
+-               tst_brkm(TBROK | TERRNO, cleanup, "mmap failed");
 -
-+Commented because mmap not supported and lkl_access_ok is failing Github issue 169: */
+-       tc[2].pathname = bad_addr;
++       /*bad_addr = 0;
++       tc[2].pathname = bad_addr; Commented because mmap not supported and lkl_access_ok is failing Github issue 169*/
+
         SAFE_SYMLINK(cleanup, "test_eloop1", "test_eloop2");
         SAFE_SYMLINK(cleanup, "test_eloop2", "test_eloop1");
-
-@@ -172,7 +173,7 @@ static void setup(void)
+@@ -170,9 +160,10 @@ static void setup(void)
+        SAFE_TOUCH(cleanup, TEST_FILE1, 0666, NULL);
+        SAFE_MKDIR(cleanup, DIR_TEMP, S_IRWXU);
         SAFE_TOUCH(cleanup, TEST_FILE2, 0666, NULL);
-
+-
++
++       rmdir("mntpoint");
         SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
 -       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, MS_RDONLY, NULL);
 +       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL); // Will be reverted once github issue 189 is fixed
         mount_flag = 1;
 
         SAFE_SETEUID(cleanup, ltpuser->pw_uid);
-@@ -188,8 +189,8 @@ void cleanup(void)
+@@ -188,8 +179,5 @@ void cleanup(void)
                          "umount device:%s failed", device);
         }
 
 -       if (device)
 -               tst_release_device(device);
-+       /*if (device)
-+               tst_release_device(device);*/
-
+-
         tst_rmdir();
  }
+

--- a/tests/ltp/patches/chown04.patch
+++ b/tests/ltp/patches/chown04.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/chown/chown04.c b/testcases/kernel/syscalls/chown/chown04.c
-index 1f3ed412b..d509ee92b 100644
+index 1f3ed412b..487aec16e 100644
 --- a/testcases/kernel/syscalls/chown/chown04.c
 +++ b/testcases/kernel/syscalls/chown/chown04.c
 @@ -37,7 +37,8 @@
@@ -72,7 +72,7 @@ index 1f3ed412b..d509ee92b 100644
 
         SAFE_SYMLINK(cleanup, "test_eloop1", "test_eloop2");
         SAFE_SYMLINK(cleanup, "test_eloop2", "test_eloop1");
-@@ -170,9 +160,10 @@ static void setup(void)
+@@ -170,9 +160,11 @@ static void setup(void)
         SAFE_TOUCH(cleanup, TEST_FILE1, 0666, NULL);
         SAFE_MKDIR(cleanup, DIR_TEMP, S_IRWXU);
         SAFE_TOUCH(cleanup, TEST_FILE2, 0666, NULL);
@@ -81,11 +81,12 @@ index 1f3ed412b..d509ee92b 100644
 +       rmdir("mntpoint");
         SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
 -       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, MS_RDONLY, NULL);
-+       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL); // Will be reverted once github issue 189 is fixed
++       //SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, MS_RDONLY, NULL);// Replace with below line after issue 189 fixed
++       SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL);
         mount_flag = 1;
 
         SAFE_SETEUID(cleanup, ltpuser->pw_uid);
-@@ -188,8 +179,5 @@ void cleanup(void)
+@@ -188,8 +180,5 @@ void cleanup(void)
                          "umount device:%s failed", device);
         }
 


### PR DESCRIPTION
In test accessing fault address is commented. This is a known issue in sgx that it causes enclave abort and is being tracked in Issue 169. Also commented testcase which checks mounted filesystem is readonly or not , it has a bug will be tracked under issue 189