### PR TITLE
LTP test case timeout should be logged in stderr file

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -1015,7 +1015,7 @@
 /ltp/testcases/kernel/syscalls/ustat/ustat02
 #/ltp/testcases/kernel/syscalls/utime/utime01
 /ltp/testcases/kernel/syscalls/utime/utime02
-#/ltp/testcases/kernel/syscalls/utime/utime03
+/ltp/testcases/kernel/syscalls/utime/utime03
 #/ltp/testcases/kernel/syscalls/utime/utime04
 /ltp/testcases/kernel/syscalls/utime/utime05
 /ltp/testcases/kernel/syscalls/utime/utime06

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -986,7 +986,7 @@
 /ltp/testcases/kernel/syscalls/timerfd/timerfd_gettime01
 /ltp/testcases/kernel/syscalls/timerfd/timerfd_settime01
 #/ltp/testcases/kernel/syscalls/times/times01
-#/ltp/testcases/kernel/syscalls/times/times03
+/ltp/testcases/kernel/syscalls/times/times03
 #/ltp/testcases/kernel/syscalls/tkill/tkill01
 #/ltp/testcases/kernel/syscalls/tkill/tkill02
 #/ltp/testcases/kernel/syscalls/truncate/truncate01
@@ -1015,7 +1015,7 @@
 /ltp/testcases/kernel/syscalls/ustat/ustat02
 /ltp/testcases/kernel/syscalls/utime/utime01
 /ltp/testcases/kernel/syscalls/utime/utime02
-/ltp/testcases/kernel/syscalls/utime/utime03
+#/ltp/testcases/kernel/syscalls/utime/utime03
 #/ltp/testcases/kernel/syscalls/utime/utime04
 /ltp/testcases/kernel/syscalls/utime/utime05
 /ltp/testcases/kernel/syscalls/utime/utime06

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -78,7 +78,7 @@ for file in ${ltp_tests[@]}; do
     exit_code=$?
     if [[ $exit_code -eq  124 ]]; then
         echo "$SGX_LKL_RUN_CMD $file : TIMED OUT after $timeout secs"
-        echo "$SGX_LKL_RUN_CMD $file : TIMED OUT after $timeout secs. TEST_FAILED" >> "$stderr_file"
+        echo "TIMED OUT after $timeout secs. TEST_FAILED" >> "$stderr_file"
     else
         echo "$SGX_LKL_RUN_CMD $file: RETURNED EXIT CODE: $exit_code"
     fi

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -75,6 +75,14 @@ for file in ${ltp_tests[@]}; do
 
     echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > \"$stdout_file\" 2> \"$stderr_file\""
     SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > "$stdout_file" 2> "$stderr_file"
+    exit_code=$?
+    if [[ $exit_code -eq  124 ]]; then
+        echo "$SGX_LKL_RUN_CMD $file : TIMED OUT after $timeout secs"
+        echo "$SGX_LKL_RUN_CMD $file : TIMED OUT after $timeout secs. TEST_FAILED" >> "$stderr_file"
+    else
+        echo "$SGX_LKL_RUN_CMD $file: RETURNED EXIT CODE: $exit_code"
+    fi
+
     total_failures=0
     total_pass=0
     for ((i = 0; i < ${#current_failure_identifiers[@]}; i++))
@@ -116,6 +124,7 @@ for file in ${ltp_tests[@]}; do
         else
             echo "Stack trace not available for $test_name." > "$stack_trace_file_path"
         fi
+
         JunitTestFinished "$test_name" "failed" "$test_class" "$test_suite"
     fi
     echo "-------------------------------------------------------------------"


### PR DESCRIPTION
This PR is addressing issue https://github.com/lsds/sgx-lkl/issues/217
We are checking exit code of sgx-lkl-run-oe and if it is 124, outputing to stderr log file.

@letmaik you can review and merge if looks good. 