### PR TITLE
Fixes for umount2_01,umount2_02,umount2_03

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -997,9 +997,9 @@
 /ltp/testcases/kernel/syscalls/umount/umount01
 /ltp/testcases/kernel/syscalls/umount/umount02
 /ltp/testcases/kernel/syscalls/umount/umount03
-/ltp/testcases/kernel/syscalls/umount2/umount2_01
-/ltp/testcases/kernel/syscalls/umount2/umount2_02
-/ltp/testcases/kernel/syscalls/umount2/umount2_03
+#/ltp/testcases/kernel/syscalls/umount2/umount2_01
+#/ltp/testcases/kernel/syscalls/umount2/umount2_02
+#/ltp/testcases/kernel/syscalls/umount2/umount2_03
 /ltp/testcases/kernel/syscalls/uname/uname01
 /ltp/testcases/kernel/syscalls/uname/uname02
 /ltp/testcases/kernel/syscalls/uname/uname03

--- a/tests/ltp/patches/umount2_01.patch
+++ b/tests/ltp/patches/umount2_01.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/umount2/umount2_01.c b/testcases/kernel/syscalls/umount2/umount2_01.c
-index 46a6d59c3..e1057c2f9 100644
+index 46a6d59c3..4ca381738 100644
 --- a/testcases/kernel/syscalls/umount2/umount2_01.c
 +++ b/testcases/kernel/syscalls/umount2/umount2_01.c
 @@ -22,6 +22,10 @@
@@ -24,34 +24,30 @@ index 46a6d59c3..e1057c2f9 100644
  
  int main(int ac, char **av)
  {
-@@ -71,7 +75,7 @@ static void setup(void)
+@@ -71,15 +75,7 @@ static void setup(void)
  	tst_sig(NOFORK, DEF_HANDLER, NULL);
  
  	tst_tmpdir();
 -
-+/*
- 	fs_type = tst_dev_fs_type();
- 	device = tst_acquire_device(cleanup);
- 
-@@ -79,7 +83,8 @@ static void setup(void)
- 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
- 
- 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-	fs_type = tst_dev_fs_type();
+-	device = tst_acquire_device(cleanup);
 -
-+*/
+-	if (!device)
+-		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+-
+-	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-
 +	rmdir(MNTPOINT);
  	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
  
  	TEST_PAUSE;
-@@ -157,9 +162,9 @@ static void cleanup(void)
+@@ -157,9 +153,5 @@ static void cleanup(void)
  
  	if (mount_flag && tst_umount(MNTPOINT))
  		tst_resm(TWARN | TERRNO, "Failed to unmount");
 -
-+/*
- 	if (device)
- 		tst_release_device(device);
+-	if (device)
+-		tst_release_device(device);
 -
-+*/
  	tst_rmdir();
  }

--- a/tests/ltp/patches/umount2_01.patch
+++ b/tests/ltp/patches/umount2_01.patch
@@ -1,0 +1,57 @@
+diff --git a/testcases/kernel/syscalls/umount2/umount2_01.c b/testcases/kernel/syscalls/umount2/umount2_01.c
+index 46a6d59c3..e1057c2f9 100644
+--- a/testcases/kernel/syscalls/umount2/umount2_01.c
++++ b/testcases/kernel/syscalls/umount2/umount2_01.c
+@@ -22,6 +22,10 @@
+  *   point ceases to be busy."
+  */
+ 
++/* Patch to use root file system for the test as loop device file 
++ * system cannot be used as lkl Kernel Memory is set to 32M.
++ */
++
+ #include <errno.h>
+ #include <sys/mount.h>
+ 
+@@ -43,8 +47,8 @@ int TST_TOTAL = 1;
+ static int fd;
+ static int mount_flag;
+ 
+-static const char *device;
+-static const char *fs_type;
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ int main(int ac, char **av)
+ {
+@@ -71,7 +75,7 @@ static void setup(void)
+ 	tst_sig(NOFORK, DEF_HANDLER, NULL);
+ 
+ 	tst_tmpdir();
+-
++/*
+ 	fs_type = tst_dev_fs_type();
+ 	device = tst_acquire_device(cleanup);
+ 
+@@ -79,7 +83,8 @@ static void setup(void)
+ 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+ 
+ 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-
++*/
++	rmdir(MNTPOINT);
+ 	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
+ 
+ 	TEST_PAUSE;
+@@ -157,9 +162,9 @@ static void cleanup(void)
+ 
+ 	if (mount_flag && tst_umount(MNTPOINT))
+ 		tst_resm(TWARN | TERRNO, "Failed to unmount");
+-
++/*
+ 	if (device)
+ 		tst_release_device(device);
+-
++*/
+ 	tst_rmdir();
+ }

--- a/tests/ltp/patches/umount2_02.patch
+++ b/tests/ltp/patches/umount2_02.patch
@@ -1,0 +1,45 @@
+diff --git a/testcases/kernel/syscalls/umount2/umount2_02.c b/testcases/kernel/syscalls/umount2/umount2_02.c
+index 7d558fa11..256bc3f4d 100644
+--- a/testcases/kernel/syscalls/umount2/umount2_02.c
++++ b/testcases/kernel/syscalls/umount2/umount2_02.c
+@@ -26,6 +26,10 @@
+  *   MNT_DETACH. (fails with the error EINVAL)"
+  */
+ 
++/* Patch to use root file system for the test as loop device file
++ * system cannot be used as lkl Kernel Memory is set to 32M.
++ */
++
+ #include <errno.h>
+ #include <sys/mount.h>
+ 
+@@ -44,8 +48,8 @@ static void verify_failure(int i);
+ static void verify_success(int i);
+ static void cleanup(void);
+ 
+-static const char *device;
+-static const char *fs_type;
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ static int mount_flag;
+ 
+@@ -111,7 +115,7 @@ static void setup(void)
+ 	tst_sig(NOFORK, DEF_HANDLER, NULL);
+ 
+ 	tst_tmpdir();
+-
++/*
+ 	fs_type = tst_dev_fs_type();
+ 	device = tst_acquire_device(cleanup);
+ 
+@@ -119,7 +123,8 @@ static void setup(void)
+ 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+ 
+ 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-
++*/
++	rmdir(MNTPOINT);
+ 	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
+ 
+ 	TEST_PAUSE;

--- a/tests/ltp/patches/umount2_02.patch
+++ b/tests/ltp/patches/umount2_02.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/umount2/umount2_02.c b/testcases/kernel/syscalls/umount2/umount2_02.c
-index 7d558fa11..256bc3f4d 100644
+index 7d558fa11..0a8119fb4 100644
 --- a/testcases/kernel/syscalls/umount2/umount2_02.c
 +++ b/testcases/kernel/syscalls/umount2/umount2_02.c
 @@ -26,6 +26,10 @@
@@ -24,21 +24,19 @@ index 7d558fa11..256bc3f4d 100644
  
  static int mount_flag;
  
-@@ -111,7 +115,7 @@ static void setup(void)
+@@ -111,15 +115,7 @@ static void setup(void)
  	tst_sig(NOFORK, DEF_HANDLER, NULL);
  
  	tst_tmpdir();
 -
-+/*
- 	fs_type = tst_dev_fs_type();
- 	device = tst_acquire_device(cleanup);
- 
-@@ -119,7 +123,8 @@ static void setup(void)
- 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
- 
- 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-	fs_type = tst_dev_fs_type();
+-	device = tst_acquire_device(cleanup);
 -
-+*/
+-	if (!device)
+-		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+-
+-	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-
 +	rmdir(MNTPOINT);
  	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
  

--- a/tests/ltp/patches/umount2_03.patch
+++ b/tests/ltp/patches/umount2_03.patch
@@ -1,0 +1,45 @@
+diff --git a/testcases/kernel/syscalls/umount2/umount2_03.c b/testcases/kernel/syscalls/umount2/umount2_03.c
+index a8fddf694..895dbd57a 100644
+--- a/testcases/kernel/syscalls/umount2/umount2_03.c
++++ b/testcases/kernel/syscalls/umount2/umount2_03.c
+@@ -21,6 +21,10 @@
+  *   and fails with the error EINVAL."
+  */
+ 
++/* Patch to use root file system for the test as loop device file
++ * system cannot be used as lkl Kernel Memory is set to 32M.
++ */
++
+ #include <errno.h>
+ #include <sys/mount.h>
+ 
+@@ -40,8 +44,8 @@ static void verify_failure(int i);
+ static void verify_success(int i);
+ static void cleanup(void);
+ 
+-static const char *device;
+-static const char *fs_type;
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ static int mount_flag;
+ 
+@@ -91,7 +95,7 @@ static void setup(void)
+ 	tst_sig(NOFORK, DEF_HANDLER, NULL);
+ 
+ 	tst_tmpdir();
+-
++/*
+ 	fs_type = tst_dev_fs_type();
+ 	device = tst_acquire_device(cleanup);
+ 
+@@ -99,7 +103,8 @@ static void setup(void)
+ 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+ 
+ 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-
++*/
++	rmdir(MNTPOINT);
+ 	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
+ 
+ 	SAFE_SYMLINK(cleanup, MNTPOINT, SYMLINK);

--- a/tests/ltp/patches/umount2_03.patch
+++ b/tests/ltp/patches/umount2_03.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/umount2/umount2_03.c b/testcases/kernel/syscalls/umount2/umount2_03.c
-index a8fddf694..895dbd57a 100644
+index a8fddf694..5405381bd 100644
 --- a/testcases/kernel/syscalls/umount2/umount2_03.c
 +++ b/testcases/kernel/syscalls/umount2/umount2_03.c
 @@ -21,6 +21,10 @@
@@ -24,21 +24,19 @@ index a8fddf694..895dbd57a 100644
  
  static int mount_flag;
  
-@@ -91,7 +95,7 @@ static void setup(void)
+@@ -91,15 +95,7 @@ static void setup(void)
  	tst_sig(NOFORK, DEF_HANDLER, NULL);
  
  	tst_tmpdir();
 -
-+/*
- 	fs_type = tst_dev_fs_type();
- 	device = tst_acquire_device(cleanup);
- 
-@@ -99,7 +103,8 @@ static void setup(void)
- 		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
- 
- 	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-	fs_type = tst_dev_fs_type();
+-	device = tst_acquire_device(cleanup);
 -
-+*/
+-	if (!device)
+-		tst_brkm(TCONF, cleanup, "Failed to obtain block device");
+-
+-	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-
 +	rmdir(MNTPOINT);
  	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
  


### PR DESCRIPTION
Issue: umount2_01,umount2_02 and umount2_03 tests were failing as they were using loop filesystem for the tests. The lkl sgx has kernel memory set to 32M. So this was causing an out of memory panic. 
Solution:Fix is to use root file system for these tests