### PR TITLE
Resolve relative Docker entrypoints

### DIFF
--- a/tools/sgx-lkl-cfg
+++ b/tools/sgx-lkl-cfg
@@ -64,6 +64,7 @@ def create(args):
         img_folder = img_path.parent
         img_filename = img_path.name
         docker_meta_path = img_folder / (img_filename + '.docker')
+        docker_entrypoint_path = img_folder / (img_filename + '.docker_entrypoint')
         img_roothash_path = img_folder / (img_filename + '.roothash')
         img_roothash_offset_path = img_folder / (img_filename + '.hashoffset')
         
@@ -93,6 +94,11 @@ def create(args):
         if i == 0 and docker_meta_path.exists():
             with open(docker_meta_path) as f:
                 docker_meta = json.load(f)
+            if docker_entrypoint_path.exists():
+                with open(docker_entrypoint_path) as f:
+                    docker_entrypoint_abs = f.read().strip()
+            else:
+                docker_entrypoint_abs = None
             docker_cfg = docker_meta[0]['Config']
             docker_entrypoint = docker_cfg['Entrypoint'] or [] # type: List[str]
             docker_cmd = docker_cfg['Cmd'] or [] # type: List[str]
@@ -103,6 +109,9 @@ def create(args):
                 app_cfg['run'] = docker_entrypoint.pop(0)
             elif docker_cmd:
                 app_cfg['run'] = docker_cmd.pop(0)
+
+            if docker_entrypoint_abs:
+                app_cfg['run'] = docker_entrypoint_abs
 
             app_cfg['args'] = docker_entrypoint + docker_cmd
 
@@ -129,6 +138,7 @@ def create(args):
     if app_cfg['run'] in ['/bin/sh', '/bin/bash']:
         print(f'  Note: {app_cfg["run"]} was detected as Docker image entrypoint.')
         print( '        This entrypoint is the default of many Docker images.')
+        print( '        It is also implicitly used in the \'shell\' form of CMD or ENTRYPOINT.')
         print( '        Please modify "run" in the app configuration if needed.')
     print('- Change any additional fields if needed (see documentation).')
 

--- a/tools/sgx-lkl-disk
+++ b/tools/sgx-lkl-disk
@@ -455,6 +455,23 @@ function create_from_docker() {
 
     docker export ${docker_container_id} | sudo tar -C ${tmp_mnt_point} -xf - 
 
+    # `docker image inspect` includes the entrypoint which may be relative.
+    # Resolve it to an absolute path while we have access to the unencrypted filesystem.
+    path_env=$(docker inspect --format='{{range $i, $env := .Config.Env}}{{println $env}}{{end}}' ${docker_image} | grep PATH= || true)
+    path_env=${path_env/PATH=/}
+    wd=$(docker inspect --format='{{.Config.WorkingDir}}' ${docker_image} || true)
+    entrypoint=$(docker inspect --format='{{index .Config.Entrypoint 0}}' ${docker_image} 2>/dev/null || true)
+    cmd=$(docker inspect --format='{{index .Config.Cmd 0}}' ${docker_image} 2>/dev/null || true)
+    entrypoint=${entrypoint:-$cmd}
+    rm -f ${disk_image}.docker_entrypoint
+    if [[ "$path_env" != "" && "$entrypoint" != "" && "$entrypoint" != /* ]]; then
+        path_env_mnt=${tmp_mnt_point}${path_env//:/:${tmp_mnt_point}}
+        entrypoint_abs=$(cd ${tmp_mnt_point}$wd && PATH=${path_env_mnt} /usr/bin/which ${entrypoint} | xargs realpath -s --relative-to=${tmp_mnt_point} || true)
+        if [[ "$entrypoint_abs" != "" ]]; then
+            echo "/$entrypoint_abs" > ${disk_image}.docker_entrypoint
+        fi
+    fi
+
     echo "${IMG_BUILDENV_RESOLV}" | sudo tee -a ${tmp_mnt_point}/etc/resolv.conf > /dev/null
     if [[ ! -z "${copy_src}" ]]; then sudo cp -r ${copy_src} ${tmp_mnt_point}; fi
     for sysdir in "${SYSDIRS[@]}"; do


### PR DESCRIPTION
Fixes #212.

This handles the following cases:
```
ENTRYPOINT ["python3"]
```
```
CMD ["python3"]
```
```
WORKDIR /app
ENTRYPOINT ["./myapp"]
```
```
WORKDIR /app
CMD ["./myapp"]
```

If the entrypoint/cmd is given in shell form like
```
ENTRYPOINT python3
```
then Docker translates this into `/bin/sh -c python3` which results in `/bin/sh` being extracted as entrypoint. This is annoying but OK. The `sgx-lkl-cfg` tool prints a helpful advice message in that case.