### PR TITLE
CI: adapt to Azure Pipelines job user changes

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -19,9 +19,6 @@ pr:
 variables:
   - name: SGXLKL_ROOT
     value: $(Build.SourcesDirectory)
-  # For some reason $USER is undefined in the scale set agents (Ubuntu stock image)
-  - name: USER
-    value: root
 
 parameters:
 - name: 'build_modes'

--- a/.azure-pipelines/scripts/dump_system_info.sh
+++ b/.azure-pipelines/scripts/dump_system_info.sh
@@ -22,3 +22,6 @@ ps -aux | grep sgx-lkl-run-oe | grep -v grep || echo "none"
 echo
 echo "Environment variables:"
 printenv | sort
+echo
+echo "User:"
+id -un

--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -10,3 +10,6 @@ sudo apt-get install -y \
     ninja-build ansible linux-headers-$(uname -r) \
     docker.io python3-venv unzip dkms debhelper apt-utils openjdk-8-jdk-headless \
     expect
+
+# Allow to run Docker without sudo
+sudo chmod u+s $(which docker)


### PR DESCRIPTION
With scale set agents, jobs would run as root in the past. Azure Pipelines rolled out an update to change that and run jobs as non-root user with password-less sudo, like the regular hosted agents do it. This PR adapt to that change.