### PR TITLE
LTP: Fix test case mkdir02, mkdir04 issue

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -512,7 +512,7 @@
 /ltp/testcases/kernel/syscalls/migrate_pages/migrate_pages03
 /ltp/testcases/kernel/syscalls/mincore/mincore01
 /ltp/testcases/kernel/syscalls/mincore/mincore02
-/ltp/testcases/kernel/syscalls/mkdir/mkdir02
+#/ltp/testcases/kernel/syscalls/mkdir/mkdir02
 /ltp/testcases/kernel/syscalls/mkdir/mkdir03
 /ltp/testcases/kernel/syscalls/mkdir/mkdir04
 #/ltp/testcases/kernel/syscalls/mkdir/mkdir05

--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -514,7 +514,7 @@
 /ltp/testcases/kernel/syscalls/mincore/mincore02
 #/ltp/testcases/kernel/syscalls/mkdir/mkdir02
 /ltp/testcases/kernel/syscalls/mkdir/mkdir03
-/ltp/testcases/kernel/syscalls/mkdir/mkdir04
+#/ltp/testcases/kernel/syscalls/mkdir/mkdir04
 #/ltp/testcases/kernel/syscalls/mkdir/mkdir05
 /ltp/testcases/kernel/syscalls/mkdir/mkdir09
 #/ltp/testcases/kernel/syscalls/mkdirat/mkdirat01

--- a/tests/ltp/patches/fix_mkdir_mkdir02.patch
+++ b/tests/ltp/patches/fix_mkdir_mkdir02.patch
@@ -1,0 +1,74 @@
+	This change is necessary to run this test case in sgx-lkl
+	environment. Test case is modified to work in single
+	process environment by Removing exit code from child and 
+	wait code from parent. FORK_OR_VFORK return always 0 in
+	sgxlkl environment. Application in sgx-lkl environment
+	start with root user if this is the case Effective
+	capabilities of an user cleared when changing user
+	from root to non-root.Hence, test case is updated
+	to handle this scenario as well.
+
+diff --git a/testcases/kernel/syscalls/mkdir/mkdir02.c b/testcases/kernel/syscalls/mkdir/mkdir02.c
+index f09e3c33d..99f4324d5 100644
+--- a/testcases/kernel/syscalls/mkdir/mkdir02.c
++++ b/testcases/kernel/syscalls/mkdir/mkdir02.c
+@@ -17,6 +17,8 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include "tst_test.h"
++#include <sys/prctl.h>
++#include <linux/securebits.h>
+ 
+ #define TESTDIR1	"testdir1"
+ #define TESTDIR2	"testdir1/testdir2"
+@@ -54,10 +56,8 @@ static void verify_mkdir(void)
+ 		if (!fail)
+ 			tst_res(TPASS, "New dir inherited GID and S_ISGID");
+ 
+-		exit(0);
+ 	}
+ 
+-	tst_reap_children();
+ 	SAFE_RMDIR(TESTDIR2);
+ }
+ 
+@@ -67,6 +67,19 @@ static void setup(void)
+ 	struct passwd *pw;
+ 	struct stat buf;
+ 	pid_t pid;
++	int usr_secbits;
++
++	/*
++	 * if program started as a root user, avoid clearing of
++	 * effective capabilities when changing from user root
++         * non-root user.
++	 */
++	if(!getuid())
++	{
++		usr_secbits = prctl(PR_GET_SECUREBITS, 0, 0, 0, 0);
++		usr_secbits |= SECBIT_NO_SETUID_FIXUP;
++		prctl(PR_SET_SECUREBITS, usr_secbits, 0, 0, 0);
++	}
+ 
+ 	pw = SAFE_GETPWNAM("nobody");
+ 	nobody_uid = pw->pw_uid;
+@@ -74,7 +87,7 @@ static void setup(void)
+ 	pw = SAFE_GETPWNAM("bin");
+ 	bin_uid = pw->pw_uid;
+ 	bin_gid = pw->pw_gid;
+-
++	
+ 	umask(0);
+ 
+ 	pid = SAFE_FORK();
+@@ -84,10 +97,7 @@ static void setup(void)
+ 		SAFE_MKDIR(TESTDIR1, 0777);
+ 		SAFE_STAT(TESTDIR1, &buf);
+ 		SAFE_CHMOD(TESTDIR1, buf.st_mode | S_ISGID);
+-		exit(0);
+ 	}
+-
+-	tst_reap_children();
+ }
+ 
+ static struct tst_test test = {

--- a/tests/ltp/patches/fix_mkdir_mkdir02.patch
+++ b/tests/ltp/patches/fix_mkdir_mkdir02.patch
@@ -1,14 +1,15 @@
 In the original test a child process is used,
-and parent process waits for child process to finish,
-and child process calls exit to return to parent process.
-The test case is modified to work in sgx-lkl single
-process environment by removing codes related to exit
-from child and wait on parent. FORK_OR_VFORK always
-returns 0 in sgxlkl environment. In addition, application
-in sgx-lkl environment starts with root user and
-admin permissions lost when user changed from root
-to non-root user. Test case is updated to handle
-this scenario as well.
+and parent process waits for child process to
+finish, and child process calls exit to return
+to parent process. The test case is modified to
+work in sgx-lkl single process environment by
+removing codes related to exit from child and
+wait on parent. FORK_OR_VFORK always returns 0
+in sgxlkl environment. In addition, application
+in sgx-lkl environment starts with root user
+and admin permissions lost when user changed
+from root to non-root user. Test case is updated
+to handle this scenario as well.
 
 diff --git a/testcases/kernel/syscalls/mkdir/mkdir02.c b/testcases/kernel/syscalls/mkdir/mkdir02.c
 index f09e3c33d..64ca4ad10 100644

--- a/tests/ltp/patches/fix_mkdir_mkdir02.patch
+++ b/tests/ltp/patches/fix_mkdir_mkdir02.patch
@@ -1,15 +1,5 @@
-	This change is necessary to run this test case in sgx-lkl
-	environment. Test case is modified to work in single
-	process environment by Removing exit code from child and 
-	wait code from parent. FORK_OR_VFORK return always 0 in
-	sgxlkl environment. Application in sgx-lkl environment
-	start with root user if this is the case Effective
-	capabilities of an user cleared when changing user
-	from root to non-root.Hence, test case is updated
-	to handle this scenario as well.
-
 diff --git a/testcases/kernel/syscalls/mkdir/mkdir02.c b/testcases/kernel/syscalls/mkdir/mkdir02.c
-index f09e3c33d..99f4324d5 100644
+index f09e3c33d..50dbcd2e5 100644
 --- a/testcases/kernel/syscalls/mkdir/mkdir02.c
 +++ b/testcases/kernel/syscalls/mkdir/mkdir02.c
 @@ -17,6 +17,8 @@
@@ -32,17 +22,14 @@ index f09e3c33d..99f4324d5 100644
  	SAFE_RMDIR(TESTDIR2);
  }
  
-@@ -67,6 +67,19 @@ static void setup(void)
+@@ -67,6 +67,16 @@ static void setup(void)
  	struct passwd *pw;
  	struct stat buf;
  	pid_t pid;
 +	int usr_secbits;
 +
-+	/*
-+	 * if program started as a root user, avoid clearing of
-+	 * effective capabilities when changing from user root
-+         * non-root user.
-+	 */
++	// set the flag "SECBIT_NO_SETUID_FIXUP" to retain the
++	// effective capabilities, when user id changed from root to non-root.
 +	if(!getuid())
 +	{
 +		usr_secbits = prctl(PR_GET_SECUREBITS, 0, 0, 0, 0);
@@ -52,7 +39,7 @@ index f09e3c33d..99f4324d5 100644
  
  	pw = SAFE_GETPWNAM("nobody");
  	nobody_uid = pw->pw_uid;
-@@ -74,7 +87,7 @@ static void setup(void)
+@@ -74,7 +84,7 @@ static void setup(void)
  	pw = SAFE_GETPWNAM("bin");
  	bin_uid = pw->pw_uid;
  	bin_gid = pw->pw_gid;
@@ -61,7 +48,7 @@ index f09e3c33d..99f4324d5 100644
  	umask(0);
  
  	pid = SAFE_FORK();
-@@ -84,10 +97,7 @@ static void setup(void)
+@@ -84,10 +94,7 @@ static void setup(void)
  		SAFE_MKDIR(TESTDIR1, 0777);
  		SAFE_STAT(TESTDIR1, &buf);
  		SAFE_CHMOD(TESTDIR1, buf.st_mode | S_ISGID);

--- a/tests/ltp/patches/fix_mkdir_mkdir02.patch
+++ b/tests/ltp/patches/fix_mkdir_mkdir02.patch
@@ -1,11 +1,14 @@
-This change is necessary to run this test case in sgx-lkl
-environment. Test case is modified to work in single
-process environment by removing exit code from child and
-wait code from parent. FORK_OR_VFORK always returns 0 in
-sgxlkl environment. Application in sgx-lkl environment
-starts with root user and effective capabilities are cleared
-when user changed from root to non-root. Hence, test case
-is updated to handle this scenario as well.
+In the original test a child process is used,
+and parent process waits for child process to finish,
+and child process calls exit to return to parent process.
+The test case is modified to work in sgx-lkl single
+process environment by removing codes related to exit
+from child and wait on parent. FORK_OR_VFORK always
+returns 0 in sgxlkl environment. In addition, application
+in sgx-lkl environment starts with root user and
+admin permissions lost when user changed from root
+to non-root user. Test case is updated to handle
+this scenario as well.
 
 diff --git a/testcases/kernel/syscalls/mkdir/mkdir02.c b/testcases/kernel/syscalls/mkdir/mkdir02.c
 index f09e3c33d..64ca4ad10 100644

--- a/tests/ltp/patches/fix_mkdir_mkdir02.patch
+++ b/tests/ltp/patches/fix_mkdir_mkdir02.patch
@@ -1,5 +1,14 @@
+This change is necessary to run this test case in sgx-lkl
+environment. Test case is modified to work in single
+process environment by removing exit code from child and
+wait code from parent. FORK_OR_VFORK always returns 0 in
+sgxlkl environment. Application in sgx-lkl environment
+starts with root user and effective capabilities are cleared
+when user changed from root to non-root. Hence, test case
+is updated to handle this scenario as well.
+
 diff --git a/testcases/kernel/syscalls/mkdir/mkdir02.c b/testcases/kernel/syscalls/mkdir/mkdir02.c
-index f09e3c33d..50dbcd2e5 100644
+index f09e3c33d..64ca4ad10 100644
 --- a/testcases/kernel/syscalls/mkdir/mkdir02.c
 +++ b/testcases/kernel/syscalls/mkdir/mkdir02.c
 @@ -17,6 +17,8 @@
@@ -30,7 +39,7 @@ index f09e3c33d..50dbcd2e5 100644
 +
 +	// set the flag "SECBIT_NO_SETUID_FIXUP" to retain the
 +	// effective capabilities, when user id changed from root to non-root.
-+	if(!getuid())
++	if(getuid() == 0)
 +	{
 +		usr_secbits = prctl(PR_GET_SECUREBITS, 0, 0, 0, 0);
 +		usr_secbits |= SECBIT_NO_SETUID_FIXUP;
@@ -39,15 +48,6 @@ index f09e3c33d..50dbcd2e5 100644
  
  	pw = SAFE_GETPWNAM("nobody");
  	nobody_uid = pw->pw_uid;
-@@ -74,7 +84,7 @@ static void setup(void)
- 	pw = SAFE_GETPWNAM("bin");
- 	bin_uid = pw->pw_uid;
- 	bin_gid = pw->pw_gid;
--
-+	
- 	umask(0);
- 
- 	pid = SAFE_FORK();
 @@ -84,10 +94,7 @@ static void setup(void)
  		SAFE_MKDIR(TESTDIR1, 0777);
  		SAFE_STAT(TESTDIR1, &buf);

--- a/tests/ltp/patches/fix_mkdir_mkdir04.patch
+++ b/tests/ltp/patches/fix_mkdir_mkdir04.patch
@@ -1,7 +1,8 @@
-This patch is necessary to fix failure of the test case 
-(testcases/kernel/syscalls/mkdir/mkdir04) in sgx-lkl
-Environment. Test case is updated to use multi-threaded
-Environment instead of multi-process.
+This patch is necessary to fix the test case
+(testcases/kernel/syscalls/mkdir/mkdir04) failure
+in sgx-lkl environment. Test case is updated to
+use multi-threaded environment instead of
+multi-process.
 
 diff --git a/testcases/kernel/syscalls/mkdir/mkdir04.c b/testcases/kernel/syscalls/mkdir/mkdir04.c
 index 87512a4be..730d116d1 100644

--- a/tests/ltp/patches/fix_mkdir_mkdir04.patch
+++ b/tests/ltp/patches/fix_mkdir_mkdir04.patch
@@ -1,0 +1,66 @@
+This patch is necessary to fix failure of the test case 
+(testcases/kernel/syscalls/mkdir/mkdir04) in sgx-lkl
+Environment. Test case is updated to use multi-threaded
+Environment instead of multi-process.
+
+diff --git a/testcases/kernel/syscalls/mkdir/mkdir04.c b/testcases/kernel/syscalls/mkdir/mkdir04.c
+index 87512a4be..730d116d1 100644
+--- a/testcases/kernel/syscalls/mkdir/mkdir04.c
++++ b/testcases/kernel/syscalls/mkdir/mkdir04.c
+@@ -15,6 +15,7 @@
+ #include <unistd.h>
+ #include <stdlib.h>
+ #include "tst_test.h"
++#include <pthread.h>
+ 
+ #define TESTDIR	 "testdir"
+ #define TESTSUBDIR "testdir/testdir"
+@@ -37,24 +38,31 @@ static void verify_mkdir(void)
+ 	tst_res(TPASS | TERRNO, "mkdir() failed expectedly");
+ }
+ 
+-static void setup(void)
++void* child_thread(void* arg)
+ {
+ 	struct passwd *pw;
+-	pid_t pid;
+-
+ 	pw = SAFE_GETPWNAM("nobody");
+ 	nobody_uid = pw->pw_uid;
++
++	SAFE_SETREUID(nobody_uid, nobody_uid);
++	SAFE_MKDIR(TESTDIR, 0700);
++	pthread_exit(NULL);
++}
++
++static void setup(void)
++{
++	struct passwd *pw;
++	pthread_t tid;
++
+ 	pw = SAFE_GETPWNAM("bin");
+ 	bin_uid = pw->pw_uid;
+-
+-	pid = SAFE_FORK();
+-	if (pid == 0) {
+-		SAFE_SETREUID(nobody_uid, nobody_uid);
+-		SAFE_MKDIR(TESTDIR, 0700);
+-		exit(0);
++	
++	//start a child thread to create a directory	
++	if(pthread_create(&tid, NULL, child_thread, NULL)== -1)
++	{
++		tst_brk(TBROK, "Thread create failed");
+ 	}
+-
+-	tst_reap_children();
++	pthread_join(tid, NULL);
+ 
+ 	SAFE_SETREUID(bin_uid, bin_uid);
+ }
+@@ -64,5 +72,4 @@ static struct tst_test test = {
+ 	.needs_tmpdir = 1,
+ 	.needs_root = 1,
+ 	.setup = setup,
+-	.forks_child = 1,
+ };


### PR DESCRIPTION
Test cases(mkdir02, mkdir04) is failed/skipped
because it exit improperly in middle of test. This is due
to single process environment. Test case is modified
to work in single process environment.