### PR TITLE
Modified fstat/fstat03 and fstatfs/fstatfs02

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -257,10 +257,10 @@
 /ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr01
 /ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr02
 #/ltp/testcases/kernel/syscalls/fstat/fstat02
-/ltp/testcases/kernel/syscalls/fstat/fstat03
+#/ltp/testcases/kernel/syscalls/fstat/fstat03
 #/ltp/testcases/kernel/syscalls/fstatat/fstatat01
 #/ltp/testcases/kernel/syscalls/fstatfs/fstatfs01
-/ltp/testcases/kernel/syscalls/fstatfs/fstatfs02
+#/ltp/testcases/kernel/syscalls/fstatfs/fstatfs02
 #/ltp/testcases/kernel/syscalls/fsync/fsync01
 #/ltp/testcases/kernel/syscalls/fsync/fsync02
 #/ltp/testcases/kernel/syscalls/fsync/fsync03

--- a/tests/ltp/patches/ltp_fstat_fstat03.patch
+++ b/tests/ltp/patches/ltp_fstat_fstat03.patch
@@ -1,0 +1,31 @@
+diff --git a/testcases/kernel/syscalls/fstat/fstat03.c b/testcases/kernel/syscalls/fstat/fstat03.c
+index 68fae43df..134c5185a 100644
+--- a/testcases/kernel/syscalls/fstat/fstat03.c
++++ b/testcases/kernel/syscalls/fstat/fstat03.c
+@@ -12,6 +12,14 @@
+  * 2) Calls fstat() with an invalid address for stat structure
+  *    -> EFAULT (or receive signal SIGSEGV)
+  */
++/*
++ * Patch Description: Here one test is trying to access invalid address,
++ * Process should get efault if it access invalid address
++ * But in sg,x enclave exits when process access invalid address, so application will not get control.
++ * Please refer git issue 169
++ * This cannot be tested now, so commented the 2nd test and will enable the test once issue 169 is fixed.
++ */
++
+
+ #include <errno.h>
+ #include <stdlib.h>
+@@ -33,8 +41,8 @@ static struct tcase {
+        struct stat *stat_buf;
+        int exp_err;
+ } tcases[] = {
+-       {&fd_ebadf, &stat_buf, EBADF},
+-       {&fd_ok, NULL, EFAULT},
++       {&fd_ebadf, &stat_buf, EBADF}
++       //{&fd_ok, NULL, EFAULT}, TODO: Analyze and enable once issue 169 is fixed
+ };
+
+ static void check_fstat(unsigned int tc_num)
+

--- a/tests/ltp/patches/ltp_fstat_fstat03.patch
+++ b/tests/ltp/patches/ltp_fstat_fstat03.patch
@@ -1,8 +1,8 @@
 +// Patch Description: Here one test is trying to access invalid address,
 +// Process should get efault if it access invalid address
 +// But in sgx, enclave exits when process access invalid address, so application will not get control.
-+// Please refer git issue 169
-+// This cannot be tested now, so commented the 2nd test and will enable the test once issue 169 is fixed.
++// Please refer git issue 297
++// This cannot be tested now, so commented the 2nd test and will enable the test once issue 297 is fixed.
 diff --git a/testcases/kernel/syscalls/fstat/fstat03.c b/testcases/kernel/syscalls/fstat/fstat03.c
 index 68fae43df..8284b0f61 100644
 --- a/testcases/kernel/syscalls/fstat/fstat03.c

--- a/tests/ltp/patches/ltp_fstat_fstat03.patch
+++ b/tests/ltp/patches/ltp_fstat_fstat03.patch
@@ -14,7 +14,7 @@ index 68fae43df..8284b0f61 100644
 -       {&fd_ebadf, &stat_buf, EBADF},
 -       {&fd_ok, NULL, EFAULT},
 +       {&fd_ebadf, &stat_buf, EBADF}
-+//     {&fd_ok, NULL, EFAULT}, TODO: Analyze and enable once issue 169 is fixed
++//     {&fd_ok, NULL, EFAULT}, TODO: Analyze and enable once issue 297 is fixed
  };
 
  static void check_fstat(unsigned int tc_num)

--- a/tests/ltp/patches/ltp_fstat_fstat03.patch
+++ b/tests/ltp/patches/ltp_fstat_fstat03.patch
@@ -1,31 +1,20 @@
++// Patch Description: Here one test is trying to access invalid address,
++// Process should get efault if it access invalid address
++// But in sgx, enclave exits when process access invalid address, so application will not get control.
++// Please refer git issue 169
++// This cannot be tested now, so commented the 2nd test and will enable the test once issue 169 is fixed.
 diff --git a/testcases/kernel/syscalls/fstat/fstat03.c b/testcases/kernel/syscalls/fstat/fstat03.c
-index 68fae43df..134c5185a 100644
+index 68fae43df..8284b0f61 100644
 --- a/testcases/kernel/syscalls/fstat/fstat03.c
 +++ b/testcases/kernel/syscalls/fstat/fstat03.c
-@@ -12,6 +12,14 @@
-  * 2) Calls fstat() with an invalid address for stat structure
-  *    -> EFAULT (or receive signal SIGSEGV)
-  */
-+/*
-+ * Patch Description: Here one test is trying to access invalid address,
-+ * Process should get efault if it access invalid address
-+ * But in sg,x enclave exits when process access invalid address, so application will not get control.
-+ * Please refer git issue 169
-+ * This cannot be tested now, so commented the 2nd test and will enable the test once issue 169 is fixed.
-+ */
-+
-
- #include <errno.h>
- #include <stdlib.h>
-@@ -33,8 +41,8 @@ static struct tcase {
+@@ -33,8 +33,8 @@ static struct tcase {
         struct stat *stat_buf;
         int exp_err;
  } tcases[] = {
 -       {&fd_ebadf, &stat_buf, EBADF},
 -       {&fd_ok, NULL, EFAULT},
 +       {&fd_ebadf, &stat_buf, EBADF}
-+       //{&fd_ok, NULL, EFAULT}, TODO: Analyze and enable once issue 169 is fixed
++//     {&fd_ok, NULL, EFAULT}, TODO: Analyze and enable once issue 169 is fixed
  };
 
  static void check_fstat(unsigned int tc_num)
-

--- a/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
+++ b/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
@@ -1,8 +1,8 @@
 +// Patch Description: Here one test is trying to access invalid address,
 +// Process should get efault if it access invalid address
 +// But in sgx, enclave exits when process access invalid address, so application will not get control.
-+// Please refer git issue 169
-+// This cannot be tested now so commented the 2nd test and will enable the test once 169 is fixed.
++// Please refer git issue 297
++// This cannot be tested now so commented the 2nd test and will enable the test once 297 is fixed.
 diff --git a/testcases/kernel/syscalls/fstatfs/fstatfs02.c b/testcases/kernel/syscalls/fstatfs/fstatfs02.c
 index db2230f82..5b2666686 100644
 --- a/testcases/kernel/syscalls/fstatfs/fstatfs02.c
@@ -33,7 +33,7 @@ index db2230f82..5b2666686 100644
 -#ifndef UCLINUX
 -       TC[1].fd = SAFE_OPEN(cleanup, "tempfile", O_RDWR | O_CREAT, 0700);
 -#endif
-+//#ifndef UCLINUX //TODO: Analyze and enable once issue 169 is fixed.
++//#ifndef UCLINUX //TODO: Analyze and enable once issue 297 is fixed.
 +//     TC[1].fd = SAFE_OPEN(cleanup, "tempfile", O_RDWR | O_CREAT, 0700);
 +//#endif
  }
@@ -44,7 +44,7 @@ index db2230f82..5b2666686 100644
 -       if (TC[1].fd > 0 && close(TC[1].fd))
 -               tst_resm(TWARN | TERRNO, "Failed to close fd");
 -#endif
-+//#ifndef UCLINUX //TODO: Analyze and enable once issue 169 is fixed.
++//#ifndef UCLINUX //TODO: Analyze and enable once issue 297 is fixed.
 +//     if (TC[1].fd > 0 && close(TC[1].fd))
 +//             tst_resm(TWARN | TERRNO, "Failed to close fd");
 +//#endif

--- a/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
+++ b/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
@@ -14,7 +14,7 @@ index db2230f82..5b2666686 100644
 -       -1, &buf, EBADF},
 -#ifndef UCLINUX
 +       -1, &buf, EBADF}
-+//#ifndef UCLINUX // TODO: Analyze and enable once issue 169 is fixed.
++//#ifndef UCLINUX // TODO: Analyze and enable once issue 297 is fixed.
             /* Skip since uClinux does not implement memory protection */
             /* EFAULT - address for buf is invalid */
 -       {

--- a/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
+++ b/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
@@ -1,48 +1,39 @@
++// Patch Description: Here one test is trying to access invalid address,
++// Process should get efault if it access invalid address
++// But in sgx, enclave exits when process access invalid address, so application will not get control.
++// Please refer git issue 169
++// This cannot be tested now so commented the 2nd test and will enable the test once 169 is fixed.
 diff --git a/testcases/kernel/syscalls/fstatfs/fstatfs02.c b/testcases/kernel/syscalls/fstatfs/fstatfs02.c
-index db2230f82..385d846d0 100644
+index db2230f82..5b2666686 100644
 --- a/testcases/kernel/syscalls/fstatfs/fstatfs02.c
 +++ b/testcases/kernel/syscalls/fstatfs/fstatfs02.c
-@@ -20,6 +20,13 @@
-  * DESCRIPTION
-  *     Testcase to check fstatfs() sets errno correctly.
-  */
-+/*
-+ * Patch Description: Here one test is trying to access invalid address,
-+ * Process should get efault if it access invalid address
-+ * But in sgx, enclave exits when process access invalid address, so application will not get control.
-+ * Please refer git issue 169
-+ * This cannot be tested now so commented the 2nd test and will enable the test once 169 is fixed.
-+ */
-
- #include <sys/vfs.h>
- #include <sys/types.h>
-@@ -42,13 +49,13 @@ static struct test_case_t {
+@@ -42,13 +42,13 @@ static struct test_case_t {
  } TC[] = {
         /* EBADF - fd is invalid */
         {
 -       -1, &buf, EBADF},
 -#ifndef UCLINUX
 +       -1, &buf, EBADF}
-+//#ifndef UCLINUX
++//#ifndef UCLINUX // TODO: Analyze and enable once issue 169 is fixed.
             /* Skip since uClinux does not implement memory protection */
             /* EFAULT - address for buf is invalid */
 -       {
 -       -1, (void *)-1, EFAULT}
 -#endif
 +//     {
-+//     -1, (void *)-1, EFAULT} TODO: Analyze and enable once issue 169 is fixed.
++//     -1, (void *)-1, EFAULT}
 +//#endif
  };
 
  int TST_TOTAL = ARRAY_SIZE(TC);
-@@ -98,17 +105,17 @@ static void setup(void)
+@@ -98,17 +98,17 @@ static void setup(void)
         TEST_PAUSE;
 
         tst_tmpdir();
 -#ifndef UCLINUX
 -       TC[1].fd = SAFE_OPEN(cleanup, "tempfile", O_RDWR | O_CREAT, 0700);
 -#endif
-+//#ifndef UCLINUX
++//#ifndef UCLINUX //TODO: Analyze and enable once issue 169 is fixed.
 +//     TC[1].fd = SAFE_OPEN(cleanup, "tempfile", O_RDWR | O_CREAT, 0700);
 +//#endif
  }
@@ -53,11 +44,10 @@ index db2230f82..385d846d0 100644
 -       if (TC[1].fd > 0 && close(TC[1].fd))
 -               tst_resm(TWARN | TERRNO, "Failed to close fd");
 -#endif
-+//#ifndef UCLINUX
++//#ifndef UCLINUX //TODO: Analyze and enable once issue 169 is fixed.
 +//     if (TC[1].fd > 0 && close(TC[1].fd))
 +//             tst_resm(TWARN | TERRNO, "Failed to close fd");
 +//#endif
 
         tst_rmdir();
  }
-

--- a/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
+++ b/tests/ltp/patches/ltp_fstatfs_fstatfs02.patch
@@ -1,0 +1,63 @@
+diff --git a/testcases/kernel/syscalls/fstatfs/fstatfs02.c b/testcases/kernel/syscalls/fstatfs/fstatfs02.c
+index db2230f82..385d846d0 100644
+--- a/testcases/kernel/syscalls/fstatfs/fstatfs02.c
++++ b/testcases/kernel/syscalls/fstatfs/fstatfs02.c
+@@ -20,6 +20,13 @@
+  * DESCRIPTION
+  *     Testcase to check fstatfs() sets errno correctly.
+  */
++/*
++ * Patch Description: Here one test is trying to access invalid address,
++ * Process should get efault if it access invalid address
++ * But in sgx, enclave exits when process access invalid address, so application will not get control.
++ * Please refer git issue 169
++ * This cannot be tested now so commented the 2nd test and will enable the test once 169 is fixed.
++ */
+
+ #include <sys/vfs.h>
+ #include <sys/types.h>
+@@ -42,13 +49,13 @@ static struct test_case_t {
+ } TC[] = {
+        /* EBADF - fd is invalid */
+        {
+-       -1, &buf, EBADF},
+-#ifndef UCLINUX
++       -1, &buf, EBADF}
++//#ifndef UCLINUX
+            /* Skip since uClinux does not implement memory protection */
+            /* EFAULT - address for buf is invalid */
+-       {
+-       -1, (void *)-1, EFAULT}
+-#endif
++//     {
++//     -1, (void *)-1, EFAULT} TODO: Analyze and enable once issue 169 is fixed.
++//#endif
+ };
+
+ int TST_TOTAL = ARRAY_SIZE(TC);
+@@ -98,17 +105,17 @@ static void setup(void)
+        TEST_PAUSE;
+
+        tst_tmpdir();
+-#ifndef UCLINUX
+-       TC[1].fd = SAFE_OPEN(cleanup, "tempfile", O_RDWR | O_CREAT, 0700);
+-#endif
++//#ifndef UCLINUX
++//     TC[1].fd = SAFE_OPEN(cleanup, "tempfile", O_RDWR | O_CREAT, 0700);
++//#endif
+ }
+
+ static void cleanup(void)
+ {
+-#ifndef UCLINUX
+-       if (TC[1].fd > 0 && close(TC[1].fd))
+-               tst_resm(TWARN | TERRNO, "Failed to close fd");
+-#endif
++//#ifndef UCLINUX
++//     if (TC[1].fd > 0 && close(TC[1].fd))
++//             tst_resm(TWARN | TERRNO, "Failed to close fd");
++//#endif
+
+        tst_rmdir();
+ }
+


### PR DESCRIPTION
 * Patch Description: Here one test is trying to access invalid address,
 * Process should get efault if it access invalid address
 * But in sgx, enclave exits when process access invalid address, so application will not get control.
 * Please refer git issue 169
 * This cannot be tested now, so commented the 2nd test and will enable the test once issue 169 is fixed.