### PR TITLE
Adding --debug option to sgx-lkl-java to support debugging

### DIFF
--- a/tools/sgx-lkl-java
+++ b/tools/sgx-lkl-java
@@ -9,6 +9,7 @@ if [ -f ${THIS_DIR}/../build/sgx-lkl-run-oe ]; then
 else
     SGX_LKL_RUN_EXEC=$THIS_DIR/sgx-lkl-run-oe
 fi
+
 SGX_LKL_OPTIONS="\
   SGXLKL_MMAP_FILES=${SGXLKL_MMAP_FILES:-Shared}"
 
@@ -25,6 +26,23 @@ DEFAULT_JRE_ARGS="\
   -cp /app"
 
 DISK_IMAGE=$2
-ARGS="${@:3}"
 
-env LD_LIBRARY_PATH=${JRE_LIB_PATH} ${SGX_LKL_OPTIONS} ${SGX_LKL_RUN_EXEC} ${EXECUTION_MODE} ${DISK_IMAGE} /usr/bin/java ${DEFAULT_JRE_ARGS} ${ARGS}
+# if --debug option provided after execution_mode and disk_image as third option
+# run sgx-lkl-java with sgx-lkl-gdb for debugging
+#
+# sample usage:
+# sgx-lkl-java --hw-debug sgxlkl-java.img --debug
+
+if [[ ! -z "$3" && "$3" == "--debug" ]]; then
+    if [ -f ${THIS_DIR}/../tools/gdb/sgx-lkl-gdb ]; then
+        SGX_LKL_GDB=${THIS_DIR}/../tools/gdb/sgx-lkl-gdb
+    else
+        SGX_LKL_GDB=$THIS_DIR/sgx-lkl-gdb
+    fi
+
+    ARGS="${@:4}"
+    env LD_LIBRARY_PATH=${JRE_LIB_PATH} ${SGX_LKL_OPTIONS} ${SGX_LKL_GDB} --args ${SGX_LKL_RUN_EXEC} ${EXECUTION_MODE} ${DISK_IMAGE} /usr/bin/java ${DEFAULT_JRE_ARGS} ${ARGS}
+else
+    ARGS="${@:3}"
+    env LD_LIBRARY_PATH=${JRE_LIB_PATH} ${SGX_LKL_OPTIONS} ${SGX_LKL_RUN_EXEC} ${EXECUTION_MODE} ${DISK_IMAGE} /usr/bin/java ${DEFAULT_JRE_ARGS} ${ARGS}
+fi

--- a/tools/sgx-lkl-java
+++ b/tools/sgx-lkl-java
@@ -33,7 +33,7 @@ DISK_IMAGE=$2
 # sample usage:
 # sgx-lkl-java --hw-debug sgxlkl-java.img --debug
 
-if [[ ! -z "$3" && "$3" == "--debug" ]]; then
+if [ "$3" == "--debug" ]; then
     if [ -f ${THIS_DIR}/../tools/gdb/sgx-lkl-gdb ]; then
         SGX_LKL_GDB=${THIS_DIR}/../tools/gdb/sgx-lkl-gdb
     else


### PR DESCRIPTION
Adding --debug option to sgx-lkl-java to support debugging.
Provide --debug as third option after execution_mode and disk_image if you want to debug

Sample usages:
sgx-lkl-java --hw-debug sgxlkl-java.img --debug
sgx-lkl-java --sw-debug sgxlkl-java.img --debug
sgx-lkl-java --hw-debug sgxlkl-java.img

Note: Below command doesn't work that's why we need to add support to sgx-lkl-java
``` sgx-lkl-gdb --args sgx-lkl-java  --hw-debug sgxlkl-java.img ```

cc @prp @davidchisnall @letmaik  @jxyang 