### PR TITLE
Test oe_get_report & fix CC test

### DIFF
--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -128,6 +128,24 @@ static int startmain(void* args)
     /* Get the application configuration & disk param from remote server */
     enclave_get_app_config(&app_config);
 
+    /* Retrieve remote attestation report to exercise Azure DCAP Client (for testing only) */
+    // TODO replace this later on
+    uint8_t* remote_report;
+    size_t remote_report_size;
+    oe_result_t result = OE_UNEXPECTED;
+    result = oe_get_report_v2(
+        OE_REPORT_FLAGS_REMOTE_ATTESTATION,
+        NULL,
+        0,
+        NULL,
+        0,
+        &remote_report,
+        &remote_report_size
+    );
+    if (OE_OK != result)
+        sgxlkl_fail("Failed to retrieve report via oe_get_report_v2: %d.\n", result);
+    oe_free_report(&remote_report);
+
     /* Disk config has been set through app config
      * Merge host-provided disk info (fd, capacity, mmap) */
     if (app_config.disks)

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -130,21 +130,24 @@ static int startmain(void* args)
 
     /* Retrieve remote attestation report to exercise Azure DCAP Client (for testing only) */
     // TODO replace this later on
-    uint8_t* remote_report;
-    size_t remote_report_size;
-    oe_result_t result = OE_UNEXPECTED;
-    result = oe_get_report_v2(
-        OE_REPORT_FLAGS_REMOTE_ATTESTATION,
-        NULL,
-        0,
-        NULL,
-        0,
-        &remote_report,
-        &remote_report_size
-    );
-    if (OE_OK != result)
-        sgxlkl_fail("Failed to retrieve report via oe_get_report_v2: %d.\n", result);
-    oe_free_report(&remote_report);
+    if (sgxlkl_enclave->mode == HW_DEBUG_MODE)
+    {
+        uint8_t* remote_report;
+        size_t remote_report_size;
+        oe_result_t result = OE_UNEXPECTED;
+        result = oe_get_report_v2(
+            OE_REPORT_FLAGS_REMOTE_ATTESTATION,
+            NULL,
+            0,
+            NULL,
+            0,
+            &remote_report,
+            &remote_report_size
+        );
+        if (OE_OK != result)
+            sgxlkl_fail("Failed to retrieve report via oe_get_report_v2: %d.\n", result);
+        oe_free_report(&remote_report);
+    }
 
     /* Disk config has been set through app config
      * Merge host-provided disk info (fd, capacity, mmap) */

--- a/tests/containers/cc/Makefile
+++ b/tests/containers/cc/Makefile
@@ -11,10 +11,12 @@ CC=python-helloworld-cc
 CC_stamp=$(CC).stamp
 
 # This test verifies in-enclave networking.
-# TODO verify host-side networking for DCAP Client
+# TODO verify host-side networking for DCAP Client once oe_get_report is used in SGX-LKL
+# Note: /etc/ssl/certs is read by libcurl which is used by the Azure DCAP Client.
 CC_DOCKER_ARGS=\
 	--rm --privileged --network=host \
 	-v $(SGXLKL_PREFIX):$(SGXLKL_PREFIX) \
+	-v /etc/ssl/certs:/etc/ssl/certs:ro \
 	-e SGXLKL_VERBOSE=1 -e SGXLKL_KERNEL_VERBOSE=1 -e SGXLKL_TAP=sgxlkl_tap0
 
 .DELETE_ON_ERROR:

--- a/tests/containers/cc/Makefile
+++ b/tests/containers/cc/Makefile
@@ -11,13 +11,14 @@ CC=python-helloworld-cc
 CC_stamp=$(CC).stamp
 
 # This test verifies in-enclave networking.
-# TODO verify host-side networking for DCAP Client once oe_get_report is used in SGX-LKL
 # Note: /etc/ssl/certs is read by libcurl which is used by the Azure DCAP Client.
+# Note: OE_LOG_LEVEL=INFO also enables Azure DCAP Client logging.
 CC_DOCKER_ARGS=\
 	--rm --privileged --network=host \
 	-v $(SGXLKL_PREFIX):$(SGXLKL_PREFIX) \
 	-v /etc/ssl/certs:/etc/ssl/certs:ro \
-	-e SGXLKL_VERBOSE=1 -e SGXLKL_KERNEL_VERBOSE=1 -e SGXLKL_TAP=sgxlkl_tap0
+	-e SGXLKL_VERBOSE=1 -e SGXLKL_KERNEL_VERBOSE=1 -e SGXLKL_TAP=sgxlkl_tap0 \
+	-e OE_LOG_LEVEL=INFO
 
 .DELETE_ON_ERROR:
 .PHONY: run run-hw run-sw clean

--- a/tests/containers/cc/Makefile
+++ b/tests/containers/cc/Makefile
@@ -11,12 +11,10 @@ CC=python-helloworld-cc
 CC_stamp=$(CC).stamp
 
 # This test verifies in-enclave networking.
-# Note: /etc/ssl/certs is read by libcurl which is used by the Azure DCAP Client.
 # Note: OE_LOG_LEVEL=INFO also enables Azure DCAP Client logging.
 CC_DOCKER_ARGS=\
 	--rm --privileged --network=host \
 	-v $(SGXLKL_PREFIX):$(SGXLKL_PREFIX) \
-	-v /etc/ssl/certs:/etc/ssl/certs:ro \
 	-e SGXLKL_VERBOSE=1 -e SGXLKL_KERNEL_VERBOSE=1 -e SGXLKL_TAP=sgxlkl_tap0 \
 	-e OE_LOG_LEVEL=INFO
 

--- a/tools/sgx-lkl-docker
+++ b/tools/sgx-lkl-docker
@@ -52,7 +52,11 @@ function build-cc() {
     install_prefix="/opt/sgx-lkl$suffix"
 
     cat >>${context_dir}/Dockerfile << EOF
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y ca-certificates
+
 FROM scratch
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY . /
 
 # Note: WORKDIR also creates the directory.

--- a/tools/sgx-lkl-docker
+++ b/tools/sgx-lkl-docker
@@ -56,6 +56,7 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y ca-certificates
 
 FROM scratch
+# ca-certificates.crt is read by libcurl which is used by the Azure DCAP Client.
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY . /
 


### PR DESCRIPTION
This PR adds a dummy `oe_get_report_v2` call at enclave start-up as a placeholder for future use. Doing that exercises the Azure DCAP Client library and associated host-side networking and will provide insight into issues appearing in CI over time. The confidential container test was fixed to mount the missing SSL certificates loaded by libcurl (via the Azure DCAP Client library) from the host via `-v /etc/ssl/certs:/etc/ssl/certs:ro`.