### PR TITLE
Disable java hello world app temporarily due to a bug

### DIFF
--- a/.azure-pipelines/scripts/disabled_tests.txt
+++ b/.azure-pipelines/scripts/disabled_tests.txt
@@ -8,3 +8,4 @@ tests/containers/unencrypted/env/Makefile
 tests/virtio/ping_test/Makefile
 tests/virtio/python_read/Makefile
 tests/languages/java/network/Makefile
+tests/languages/java/hello_world/Makefile


### PR DESCRIPTION
Per @letmaik 's request I am disabling Java hello world test due to issue https://github.com/lsds/sgx-lkl/issues/258 to unblock pipeline failures.  

Eventually this issue must be fixed and this test must be enabled.