### PR TITLE
Confidential Container docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ A Confidential Container is a Docker image that only contains the disk images
 and the host and app config files.
 It is used for deploying an SGX-LKL application to a target system that has
 Docker as well as SGX-LKL installed on the host.
-This allows to update SGX-LKL without rebuilding all Docker images.
+This allows to update SGX-LKL without rebuilding all Confidential Containers.
 Like Docker, SGX-LKL can be considered part of the host runtime environment.
 
 To create a Confidential Container, run:

--- a/README.md
+++ b/README.md
@@ -465,8 +465,8 @@ To create initial host and app config files in the current directory, run:
 ```
 sgx-lkl-cfg create --disk sgxlkl-disk.img
 ```
-Note that you may have to adapt the generated files to your needs.
-See the `tests/containers/cc` folder for example host and app config files.
+Note that you may have to adapt the generated files to your needs
+(see the `tests/containers/cc` folder for sample host and app config files).
 You can then run SGX-LKL using the host and app config files alone:
 ```
 sgx-lkl-run-oe --hw-debug --host-config=host-config.json --app-config=app-config.json

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ and the host and app config files.
 It is used for deploying an SGX-LKL application to a target system that has
 Docker as well as SGX-LKL installed on the host.
 This allows to update SGX-LKL without rebuilding all Docker images.
-Like Docker, SGX-LKL can be considered part of the host runtime environment.
+Like the Docker daemon, SGX-LKL can be considered part of the host runtime environment.
 
 To create a Confidential Container, run:
 ```


### PR DESCRIPTION
This extends the main README to include steps on creating a confidential container.