### PR TITLE
Fix for getxattr01,getxattr02,getxattr03

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -188,7 +188,7 @@
 #/ltp/testcases/kernel/syscalls/fchownat/fchownat01
 #/ltp/testcases/kernel/syscalls/fchownat/fchownat02
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl01
-#/ltp/testcases/kernel/syscalls/fcntl/fcntl02
+/ltp/testcases/kernel/syscalls/fcntl/fcntl02
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl03
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl04
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl05
@@ -220,7 +220,7 @@
 /ltp/testcases/kernel/syscalls/fcntl/fcntl31
 /ltp/testcases/kernel/syscalls/fcntl/fcntl32
 /ltp/testcases/kernel/syscalls/fcntl/fcntl33
-#/ltp/testcases/kernel/syscalls/fcntl/fcntl34
+/ltp/testcases/kernel/syscalls/fcntl/fcntl34
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl35
 /ltp/testcases/kernel/syscalls/fcntl/fcntl36
 #/ltp/testcases/kernel/syscalls/fdatasync/fdatasync01

--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -188,7 +188,7 @@
 #/ltp/testcases/kernel/syscalls/fchownat/fchownat01
 #/ltp/testcases/kernel/syscalls/fchownat/fchownat02
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl01
-/ltp/testcases/kernel/syscalls/fcntl/fcntl02
+#/ltp/testcases/kernel/syscalls/fcntl/fcntl02
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl03
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl04
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl05

--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -346,9 +346,9 @@
 #/ltp/testcases/kernel/syscalls/gettimeofday/gettimeofday02
 #/ltp/testcases/kernel/syscalls/getuid/getuid01
 #/ltp/testcases/kernel/syscalls/getuid/getuid03
-/ltp/testcases/kernel/syscalls/getxattr/getxattr01
-/ltp/testcases/kernel/syscalls/getxattr/getxattr02
-/ltp/testcases/kernel/syscalls/getxattr/getxattr03
+#/ltp/testcases/kernel/syscalls/getxattr/getxattr01
+#/ltp/testcases/kernel/syscalls/getxattr/getxattr02
+#/ltp/testcases/kernel/syscalls/getxattr/getxattr03
 /ltp/testcases/kernel/syscalls/getxattr/getxattr04
 /ltp/testcases/kernel/syscalls/getxattr/getxattr05
 /ltp/testcases/kernel/syscalls/inotify/inotify01

--- a/tests/ltp/patches/getxattr01.patch
+++ b/tests/ltp/patches/getxattr01.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/getxattr/getxattr01.c b/testcases/kernel/syscalls/getxattr/getxattr01.c
-index 54ca65390..bb1f6ad03 100644
+index 54ca65390..3af8d1fb3 100644
 --- a/testcases/kernel/syscalls/getxattr/getxattr01.c
 +++ b/testcases/kernel/syscalls/getxattr/getxattr01.c
 @@ -35,6 +35,10 @@
@@ -13,15 +13,6 @@ index 54ca65390..bb1f6ad03 100644
  #include "config.h"
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -45,7 +49,7 @@
- #include <stdlib.h>
- #include <string.h>
- #ifdef HAVE_SYS_XATTR_H
--# include <sys/xattr.h>
-+#include <sys/xattr.h>
- #endif
- #include "test.h"
- #include "safe_macros.h"
 @@ -57,7 +61,13 @@ char *TCID = "getxattr01";
  #define XATTR_TEST_VALUE "this is a test value"
  #define XATTR_TEST_VALUE_SIZE 20

--- a/tests/ltp/patches/getxattr01.patch
+++ b/tests/ltp/patches/getxattr01.patch
@@ -1,0 +1,64 @@
+diff --git a/testcases/kernel/syscalls/getxattr/getxattr01.c b/testcases/kernel/syscalls/getxattr/getxattr01.c
+index 54ca65390..63dd06b40 100644
+--- a/testcases/kernel/syscalls/getxattr/getxattr01.c
++++ b/testcases/kernel/syscalls/getxattr/getxattr01.c
+@@ -35,6 +35,10 @@
+  * 4. Verify the attribute got by getxattr(2) is same as the value we set
+  */
+ 
++/* Currently xattr is not enabled while mounting root file system. Patch is
++ * mount root file system with xattr enabled and then use  it for the test.
++ */
++
+ #include "config.h"
+ #include <sys/types.h>
+ #include <sys/stat.h>
+@@ -45,8 +49,9 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #ifdef HAVE_SYS_XATTR_H
+-# include <sys/xattr.h>
++#include <sys/xattr.h>
+ #endif
++#include <sys/mount.h>
+ #include "test.h"
+ #include "safe_macros.h"
+ 
+@@ -57,7 +62,13 @@ char *TCID = "getxattr01";
+ #define XATTR_TEST_VALUE "this is a test value"
+ #define XATTR_TEST_VALUE_SIZE 20
+ #define BUFFSIZE 64
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++#define MNTPOINT        "mntpoint"
++
+ 
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ static void setup(void);
+ static void cleanup(void);
+ 
+@@ -147,9 +158,12 @@ static void setup(void)
+ 	tst_require_root();
+ 
+ 	tst_tmpdir();
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, "user_xattr");
+ 
+ 	/* Create test file and setup initial xattr */
+-	snprintf(filename, BUFSIZ, "getxattr01testfile");
++	snprintf(filename, BUFSIZ, "mntpoint/getxattr01testfile");
+ 	fd = SAFE_CREAT(cleanup, filename, 0644);
+ 	close(fd);
+ 	if (setxattr(filename, XATTR_TEST_KEY, XATTR_TEST_VALUE,
+@@ -174,6 +188,9 @@ static void setup(void)
+ 
+ static void cleanup(void)
+ {
++	remove("mntpoint/getxattr01testfile");
++	umount(MNTPOINT);
++	rmdir(MNTPOINT);
+ 	tst_rmdir();
+ }
+ #else /* HAVE_SYS_XATTR_H */

--- a/tests/ltp/patches/getxattr01.patch
+++ b/tests/ltp/patches/getxattr01.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/getxattr/getxattr01.c b/testcases/kernel/syscalls/getxattr/getxattr01.c
-index 54ca65390..63dd06b40 100644
+index 54ca65390..bb1f6ad03 100644
 --- a/testcases/kernel/syscalls/getxattr/getxattr01.c
 +++ b/testcases/kernel/syscalls/getxattr/getxattr01.c
 @@ -35,6 +35,10 @@
@@ -13,18 +13,16 @@ index 54ca65390..63dd06b40 100644
  #include "config.h"
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -45,8 +49,9 @@
+@@ -45,7 +49,7 @@
  #include <stdlib.h>
  #include <string.h>
  #ifdef HAVE_SYS_XATTR_H
 -# include <sys/xattr.h>
 +#include <sys/xattr.h>
  #endif
-+#include <sys/mount.h>
  #include "test.h"
  #include "safe_macros.h"
- 
-@@ -57,7 +62,13 @@ char *TCID = "getxattr01";
+@@ -57,7 +61,13 @@ char *TCID = "getxattr01";
  #define XATTR_TEST_VALUE "this is a test value"
  #define XATTR_TEST_VALUE_SIZE 20
  #define BUFFSIZE 64
@@ -38,7 +36,7 @@ index 54ca65390..63dd06b40 100644
  static void setup(void);
  static void cleanup(void);
  
-@@ -147,9 +158,12 @@ static void setup(void)
+@@ -147,11 +157,14 @@ static void setup(void)
  	tst_require_root();
  
  	tst_tmpdir();
@@ -50,15 +48,18 @@ index 54ca65390..63dd06b40 100644
 -	snprintf(filename, BUFSIZ, "getxattr01testfile");
 +	snprintf(filename, BUFSIZ, "mntpoint/getxattr01testfile");
  	fd = SAFE_CREAT(cleanup, filename, 0644);
- 	close(fd);
+-	close(fd);
++	SAFE_CLOSE(cleanup,fd);
  	if (setxattr(filename, XATTR_TEST_KEY, XATTR_TEST_VALUE,
-@@ -174,6 +188,9 @@ static void setup(void)
+ 		     strlen(XATTR_TEST_VALUE), XATTR_CREATE) == -1) {
+ 		if (errno == ENOTSUP) {
+@@ -174,6 +187,9 @@ static void setup(void)
  
  static void cleanup(void)
  {
 +	remove("mntpoint/getxattr01testfile");
-+	umount(MNTPOINT);
-+	rmdir(MNTPOINT);
++	SAFE_UMOUNT(NULL,MNTPOINT);
++	SAFE_RMDIR(NULL,MNTPOINT);
  	tst_rmdir();
  }
  #else /* HAVE_SYS_XATTR_H */

--- a/tests/ltp/patches/getxattr02.patch
+++ b/tests/ltp/patches/getxattr02.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/getxattr/getxattr02.c b/testcases/kernel/syscalls/getxattr/getxattr02.c
-index dca6b13be..7867b0bec 100644
+index dca6b13be..891308dd4 100644
 --- a/testcases/kernel/syscalls/getxattr/getxattr02.c
 +++ b/testcases/kernel/syscalls/getxattr/getxattr02.c
 @@ -38,6 +38,10 @@
@@ -13,18 +13,16 @@ index dca6b13be..7867b0bec 100644
  #include "config.h"
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -51,8 +55,9 @@
+@@ -51,7 +55,7 @@
  #include <stdlib.h>
  #include <string.h>
  #ifdef HAVE_SYS_XATTR_H
 -# include <sys/xattr.h>
 +#include <sys/xattr.h>
  #endif
-+#include <sys/mount.h>
  #include "test.h"
  #include "safe_macros.h"
- 
-@@ -66,6 +71,13 @@ char *TCID = "getxattr02";
+@@ -66,6 +70,13 @@ char *TCID = "getxattr02";
  #define BLK  "getxattr02blk"
  #define SOCK "getxattr02sock"
  
@@ -38,7 +36,7 @@ index dca6b13be..7867b0bec 100644
  static void setup(void);
  static void cleanup(void);
  
-@@ -125,9 +137,12 @@ static void setup(void)
+@@ -125,10 +136,13 @@ static void setup(void)
  	tst_require_root();
  
  	tst_tmpdir();
@@ -48,17 +46,19 @@ index dca6b13be..7867b0bec 100644
  
  	/* Test for xattr support */
 -	fd = SAFE_CREAT(cleanup, "testfile", 0644);
+-	close(fd);
 +	fd = SAFE_CREAT(cleanup, "mntpoint/getxattr02testfile", 0644);
- 	close(fd);
++	SAFE_CLOSE(cleanup,fd);
  	if (setxattr("testfile", "user.test", "test", 4, XATTR_CREATE) == -1)
  		if (errno == ENOTSUP)
-@@ -158,6 +173,10 @@ static void setup(void)
+ 			tst_brkm(TCONF, cleanup, "No xattr support in fs or "
+@@ -158,6 +172,10 @@ static void setup(void)
  
  static void cleanup(void)
  {
 +	remove("mntpoint/getxattr02testfile");
-+	umount(MNTPOINT);
-+	rmdir(MNTPOINT);
++	SAFE_UMOUNT(NULL,MNTPOINT);
++	SAFE_RMDIR(NULL,MNTPOINT);
 +
  	tst_rmdir();
  }

--- a/tests/ltp/patches/getxattr02.patch
+++ b/tests/ltp/patches/getxattr02.patch
@@ -1,0 +1,65 @@
+diff --git a/testcases/kernel/syscalls/getxattr/getxattr02.c b/testcases/kernel/syscalls/getxattr/getxattr02.c
+index dca6b13be..7867b0bec 100644
+--- a/testcases/kernel/syscalls/getxattr/getxattr02.c
++++ b/testcases/kernel/syscalls/getxattr/getxattr02.c
+@@ -38,6 +38,10 @@
+  *    return -1 and set errno to ENODATA
+  */
+ 
++/* Currently xattr is not enabled while mounting root file system. Patch is
++ * mount root file system with xattr enabled and then use  it for the test.
++ */
++
+ #include "config.h"
+ #include <sys/types.h>
+ #include <sys/stat.h>
+@@ -51,8 +55,9 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #ifdef HAVE_SYS_XATTR_H
+-# include <sys/xattr.h>
++#include <sys/xattr.h>
+ #endif
++#include <sys/mount.h>
+ #include "test.h"
+ #include "safe_macros.h"
+ 
+@@ -66,6 +71,13 @@ char *TCID = "getxattr02";
+ #define BLK  "getxattr02blk"
+ #define SOCK "getxattr02sock"
+ 
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++#define MNTPOINT        "mntpoint"
++
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
++
+ static void setup(void);
+ static void cleanup(void);
+ 
+@@ -125,9 +137,12 @@ static void setup(void)
+ 	tst_require_root();
+ 
+ 	tst_tmpdir();
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, "user_xattr");
+ 
+ 	/* Test for xattr support */
+-	fd = SAFE_CREAT(cleanup, "testfile", 0644);
++	fd = SAFE_CREAT(cleanup, "mntpoint/getxattr02testfile", 0644);
+ 	close(fd);
+ 	if (setxattr("testfile", "user.test", "test", 4, XATTR_CREATE) == -1)
+ 		if (errno == ENOTSUP)
+@@ -158,6 +173,10 @@ static void setup(void)
+ 
+ static void cleanup(void)
+ {
++	remove("mntpoint/getxattr02testfile");
++	umount(MNTPOINT);
++	rmdir(MNTPOINT);
++
+ 	tst_rmdir();
+ }
+ #else /* HAVE_SYS_XATTR_H */

--- a/tests/ltp/patches/getxattr02.patch
+++ b/tests/ltp/patches/getxattr02.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/getxattr/getxattr02.c b/testcases/kernel/syscalls/getxattr/getxattr02.c
-index dca6b13be..891308dd4 100644
+index dca6b13be..7d95ac988 100644
 --- a/testcases/kernel/syscalls/getxattr/getxattr02.c
 +++ b/testcases/kernel/syscalls/getxattr/getxattr02.c
 @@ -38,6 +38,10 @@
@@ -13,15 +13,6 @@ index dca6b13be..891308dd4 100644
  #include "config.h"
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -51,7 +55,7 @@
- #include <stdlib.h>
- #include <string.h>
- #ifdef HAVE_SYS_XATTR_H
--# include <sys/xattr.h>
-+#include <sys/xattr.h>
- #endif
- #include "test.h"
- #include "safe_macros.h"
 @@ -66,6 +70,13 @@ char *TCID = "getxattr02";
  #define BLK  "getxattr02blk"
  #define SOCK "getxattr02sock"

--- a/tests/ltp/patches/getxattr03.patch
+++ b/tests/ltp/patches/getxattr03.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/getxattr/getxattr03.c b/testcases/kernel/syscalls/getxattr/getxattr03.c
-index b6ea14287..f8b651c34 100644
+index b6ea14287..d6a99fbee 100644
 --- a/testcases/kernel/syscalls/getxattr/getxattr03.c
 +++ b/testcases/kernel/syscalls/getxattr/getxattr03.c
 @@ -27,6 +27,10 @@
@@ -13,15 +13,6 @@ index b6ea14287..f8b651c34 100644
  #include "config.h"
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -39,7 +43,7 @@
- #include <stdlib.h>
- #include <string.h>
- #ifdef HAVE_SYS_XATTR_H
--# include <sys/xattr.h>
-+#include <sys/xattr.h>
- #endif
- #include "test.h"
- #include "safe_macros.h"
 @@ -50,8 +54,13 @@ char *TCID = "getxattr03";
  #define XATTR_TEST_KEY "user.testkey"
  #define XATTR_TEST_VALUE "test value"

--- a/tests/ltp/patches/getxattr03.patch
+++ b/tests/ltp/patches/getxattr03.patch
@@ -1,0 +1,61 @@
+diff --git a/testcases/kernel/syscalls/getxattr/getxattr03.c b/testcases/kernel/syscalls/getxattr/getxattr03.c
+index b6ea14287..a7819c2b1 100644
+--- a/testcases/kernel/syscalls/getxattr/getxattr03.c
++++ b/testcases/kernel/syscalls/getxattr/getxattr03.c
+@@ -27,6 +27,10 @@
+  * the current size of the named extended attribute.
+  */
+ 
++/* Currently xattr is not enabled while mounting root file system. Patch is
++ * to mount root file system with xattr enabled and then use it for the test.
++*/
++
+ #include "config.h"
+ #include <sys/types.h>
+ #include <sys/stat.h>
+@@ -39,8 +43,9 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #ifdef HAVE_SYS_XATTR_H
+-# include <sys/xattr.h>
++#include <sys/xattr.h>
+ #endif
++#include <sys/mount.h>
+ #include "test.h"
+ #include "safe_macros.h"
+ 
+@@ -50,8 +55,13 @@ char *TCID = "getxattr03";
+ #define XATTR_TEST_KEY "user.testkey"
+ #define XATTR_TEST_VALUE "test value"
+ #define XATTR_TEST_VALUE_SIZE (sizeof(XATTR_TEST_VALUE) - 1)
+-#define TESTFILE "getxattr03testfile"
++#define TESTFILE "mntpoint/getxattr03testfile"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++#define MNTPOINT        "mntpoint"
+ 
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ static void setup(void);
+ static void cleanup(void);
+ 
+@@ -87,6 +97,9 @@ static void setup(void)
+ 	tst_require_root();
+ 
+ 	tst_tmpdir();
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, "user_xattr");
+ 
+ 	/* Test for xattr support and set attr value */
+ 	fd = SAFE_CREAT(cleanup, TESTFILE, 0644);
+@@ -107,6 +120,9 @@ static void setup(void)
+ 
+ static void cleanup(void)
+ {
++	remove(TESTFILE);
++	umount(MNTPOINT);
++	rmdir(MNTPOINT);
+ 	tst_rmdir();
+ }
+ #else /* HAVE_SYS_XATTR_H */

--- a/tests/ltp/patches/getxattr03.patch
+++ b/tests/ltp/patches/getxattr03.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/getxattr/getxattr03.c b/testcases/kernel/syscalls/getxattr/getxattr03.c
-index b6ea14287..a7819c2b1 100644
+index b6ea14287..f8b651c34 100644
 --- a/testcases/kernel/syscalls/getxattr/getxattr03.c
 +++ b/testcases/kernel/syscalls/getxattr/getxattr03.c
 @@ -27,6 +27,10 @@
@@ -13,18 +13,16 @@ index b6ea14287..a7819c2b1 100644
  #include "config.h"
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -39,8 +43,9 @@
+@@ -39,7 +43,7 @@
  #include <stdlib.h>
  #include <string.h>
  #ifdef HAVE_SYS_XATTR_H
 -# include <sys/xattr.h>
 +#include <sys/xattr.h>
  #endif
-+#include <sys/mount.h>
  #include "test.h"
  #include "safe_macros.h"
- 
-@@ -50,8 +55,13 @@ char *TCID = "getxattr03";
+@@ -50,8 +54,13 @@ char *TCID = "getxattr03";
  #define XATTR_TEST_KEY "user.testkey"
  #define XATTR_TEST_VALUE "test value"
  #define XATTR_TEST_VALUE_SIZE (sizeof(XATTR_TEST_VALUE) - 1)
@@ -39,7 +37,7 @@ index b6ea14287..a7819c2b1 100644
  static void setup(void);
  static void cleanup(void);
  
-@@ -87,6 +97,9 @@ static void setup(void)
+@@ -87,10 +96,13 @@ static void setup(void)
  	tst_require_root();
  
  	tst_tmpdir();
@@ -49,13 +47,18 @@ index b6ea14287..a7819c2b1 100644
  
  	/* Test for xattr support and set attr value */
  	fd = SAFE_CREAT(cleanup, TESTFILE, 0644);
-@@ -107,6 +120,9 @@ static void setup(void)
+-	close(fd);
++	SAFE_CLOSE(cleanup,fd);
+ 
+ 	if (setxattr(TESTFILE, XATTR_TEST_KEY, XATTR_TEST_VALUE,
+ 		     XATTR_TEST_VALUE_SIZE, XATTR_CREATE) == -1) {
+@@ -107,6 +119,9 @@ static void setup(void)
  
  static void cleanup(void)
  {
 +	remove(TESTFILE);
-+	umount(MNTPOINT);
-+	rmdir(MNTPOINT);
++	SAFE_UMOUNT(NULL,MNTPOINT);
++	SAFE_RMDIR(NULL,MNTPOINT);
  	tst_rmdir();
  }
  #else /* HAVE_SYS_XATTR_H */


### PR DESCRIPTION
Issue: These tests needed filesystem to be mounted with xattr support. Hence they were failing with no xattr support. 
Solution: Mount root filesystem with xattr option and then run the test on that.