### PR TITLE
Fixed ltp/kernel/syscalls/fsync01 and fsync04

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -261,10 +261,10 @@
 #/ltp/testcases/kernel/syscalls/fstatat/fstatat01
 #/ltp/testcases/kernel/syscalls/fstatfs/fstatfs01
 /ltp/testcases/kernel/syscalls/fstatfs/fstatfs02
-/ltp/testcases/kernel/syscalls/fsync/fsync01
+#/ltp/testcases/kernel/syscalls/fsync/fsync01
 #/ltp/testcases/kernel/syscalls/fsync/fsync02
 #/ltp/testcases/kernel/syscalls/fsync/fsync03
-/ltp/testcases/kernel/syscalls/fsync/fsync04
+#/ltp/testcases/kernel/syscalls/fsync/fsync04
 #/ltp/testcases/kernel/syscalls/ftruncate/ftruncate01
 #/ltp/testcases/kernel/syscalls/ftruncate/ftruncate03
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate04

--- a/tests/ltp/patches/ltp_fsync_fsync01.patch
+++ b/tests/ltp/patches/ltp_fsync_fsync01.patch
@@ -1,7 +1,7 @@
-+ // Patch Description: Tests were failing with kernel panic in loop filesystem.
++ // Patch Description: Tests are failing with kernel panic while using loop device filesystem
 + // So modified the tests to use root file system.
 diff --git a/testcases/kernel/syscalls/fsync/fsync01.c b/testcases/kernel/syscalls/fsync/fsync01.c
-index 9af38dce0..40dd86330 100644
+index 9af38dce0..3e0e7d5f5 100644
 --- a/testcases/kernel/syscalls/fsync/fsync01.c
 +++ b/testcases/kernel/syscalls/fsync/fsync01.c
 @@ -33,6 +33,9 @@ static void verify_fsync(void)
@@ -14,18 +14,19 @@ index 9af38dce0..40dd86330 100644
         sprintf(fname, "mntpoint/tfile_%d", getpid());
         fd = SAFE_OPEN(fname, O_RDWR | O_CREAT, 0700);
  }
-@@ -41,6 +44,10 @@ static void cleanup(void)
+@@ -41,6 +44,11 @@ static void cleanup(void)
  {
         if (fd > 0)
                 SAFE_CLOSE(fd);
-+       if(tst_umount("mntpoint") < 0){
-+       tst_res(TWARN | TERRNO, "unmount device:mntpoint failed");
++       remove(fname);
++       if (tst_umount("mntpoint") < 0) {
++               tst_res(TWARN | TERRNO, "umount device :mntpoint failed");
 +       }
 +       rmdir("mntpoint");
  }
 
  static struct tst_test test = {
-@@ -49,7 +56,4 @@ static struct tst_test test = {
+@@ -49,7 +57,4 @@ static struct tst_test test = {
         .test_all = verify_fsync,
         .needs_tmpdir = 1,
         .needs_root = 1,

--- a/tests/ltp/patches/ltp_fsync_fsync01.patch
+++ b/tests/ltp/patches/ltp_fsync_fsync01.patch
@@ -1,32 +1,29 @@
 + // Patch Description: Tests are failing with kernel panic while using loop device filesystem
 + // So modified the tests to use root file system.
 diff --git a/testcases/kernel/syscalls/fsync/fsync01.c b/testcases/kernel/syscalls/fsync/fsync01.c
-index 9af38dce0..3e0e7d5f5 100644
+index 9af38dce0..5bea2773a 100644
 --- a/testcases/kernel/syscalls/fsync/fsync01.c
 +++ b/testcases/kernel/syscalls/fsync/fsync01.c
-@@ -33,6 +33,9 @@ static void verify_fsync(void)
+@@ -33,6 +33,8 @@ static void verify_fsync(void)
 
  static void setup(void)
  {
-+       rmdir("mntpoint");
 +       SAFE_MKDIR("mntpoint", 0644);
 +       SAFE_MOUNT("/dev/vda", "mntpoint", "ext4", 0, NULL);
         sprintf(fname, "mntpoint/tfile_%d", getpid());
         fd = SAFE_OPEN(fname, O_RDWR | O_CREAT, 0700);
  }
-@@ -41,6 +44,11 @@ static void cleanup(void)
+@@ -41,6 +43,9 @@ static void cleanup(void)
  {
         if (fd > 0)
                 SAFE_CLOSE(fd);
 +       remove(fname);
-+       if (tst_umount("mntpoint") < 0) {
-+               tst_res(TWARN | TERRNO, "umount device :mntpoint failed");
-+       }
-+       rmdir("mntpoint");
++       SAFE_UMOUNT("mntpoint");
++       SAFE_RMDIR("mntpoint");
  }
 
  static struct tst_test test = {
-@@ -49,7 +57,4 @@ static struct tst_test test = {
+@@ -49,7 +54,4 @@ static struct tst_test test = {
         .test_all = verify_fsync,
         .needs_tmpdir = 1,
         .needs_root = 1,

--- a/tests/ltp/patches/ltp_fsync_fsync01.patch
+++ b/tests/ltp/patches/ltp_fsync_fsync01.patch
@@ -1,0 +1,36 @@
++ // Patch Description: Tests were failing with kernel panic in loop filesystem.
++ // So modified the tests to use root file system.
+diff --git a/testcases/kernel/syscalls/fsync/fsync01.c b/testcases/kernel/syscalls/fsync/fsync01.c
+index 9af38dce0..40dd86330 100644
+--- a/testcases/kernel/syscalls/fsync/fsync01.c
++++ b/testcases/kernel/syscalls/fsync/fsync01.c
+@@ -33,6 +33,9 @@ static void verify_fsync(void)
+
+ static void setup(void)
+ {
++       rmdir("mntpoint");
++       SAFE_MKDIR("mntpoint", 0644);
++       SAFE_MOUNT("/dev/vda", "mntpoint", "ext4", 0, NULL);
+        sprintf(fname, "mntpoint/tfile_%d", getpid());
+        fd = SAFE_OPEN(fname, O_RDWR | O_CREAT, 0700);
+ }
+@@ -41,6 +44,10 @@ static void cleanup(void)
+ {
+        if (fd > 0)
+                SAFE_CLOSE(fd);
++       if(tst_umount("mntpoint") < 0){
++       tst_res(TWARN | TERRNO, "unmount device:mntpoint failed");
++       }
++       rmdir("mntpoint");
+ }
+
+ static struct tst_test test = {
+@@ -49,7 +56,4 @@ static struct tst_test test = {
+        .test_all = verify_fsync,
+        .needs_tmpdir = 1,
+        .needs_root = 1,
+-       .mount_device = 1,
+-       .mntpoint = "mntpoint",
+-       .all_filesystems = 1,
+ };
+

--- a/tests/ltp/patches/ltp_fsync_fsync04.patch
+++ b/tests/ltp/patches/ltp_fsync_fsync04.patch
@@ -1,15 +1,14 @@
 + // Patch Description: Tests are failing with kernel panic while using loop device filesystem
 + // So modified the tests to use root file system.
 diff --git a/testcases/kernel/syscalls/fsync/fsync04.c b/testcases/kernel/syscalls/fsync/fsync04.c
-index c67fc5692..f8682e950 100644
+index c67fc5692..b9711350a 100644
 --- a/testcases/kernel/syscalls/fsync/fsync04.c
 +++ b/testcases/kernel/syscalls/fsync/fsync04.c
-@@ -29,10 +29,12 @@ static void verify_fsync(void)
+@@ -29,10 +29,11 @@ static void verify_fsync(void)
  {
         int fd;
         unsigned long written;
 -
-+       rmdir(MNTPOINT);
 +       SAFE_MKDIR(MNTPOINT, MODE);
 +       SAFE_MOUNT("/dev/vda", MNTPOINT, "ext4", 0, NULL);
         fd = SAFE_OPEN(FNAME, O_RDWR|O_CREAT, MODE);
@@ -19,7 +18,7 @@ index c67fc5692..f8682e950 100644
 
         tst_fill_fd(fd, 0, TST_MB, FILE_SIZE_MB);
 
-@@ -41,9 +43,14 @@ static void verify_fsync(void)
+@@ -41,9 +42,12 @@ static void verify_fsync(void)
         if (TST_RET)
                 tst_brk(TFAIL | TTERRNO, "fsync(fd) failed");
 
@@ -28,14 +27,12 @@ index c67fc5692..f8682e950 100644
 
         SAFE_CLOSE(fd);
 +       remove(FNAME);
-+       if (tst_umount(MNTPOINT) < 0) {
-+               tst_res(TWARN | TERRNO, "umount device :mntpoint failed");
-+       }
-+       rmdir(MNTPOINT);
++       SAFE_UMOUNT(MNTPOINT);
++       SAFE_RMDIR(MNTPOINT);
 
         if (written >= FILE_SIZE)
                 tst_res(TPASS, "Test file synced to device");
-@@ -53,8 +60,5 @@ static void verify_fsync(void)
+@@ -53,8 +57,5 @@ static void verify_fsync(void)
 
  static struct tst_test test = {
         .needs_root = 1,

--- a/tests/ltp/patches/ltp_fsync_fsync04.patch
+++ b/tests/ltp/patches/ltp_fsync_fsync04.patch
@@ -1,0 +1,46 @@
++ // Patch Description: Tests were failing with kernel panic in loop filesystem.
++ // So modified the tests to use root file system.
+diff --git a/testcases/kernel/syscalls/fsync/fsync04.c b/testcases/kernel/syscalls/fsync/fsync04.c
+index c67fc5692..708b0962e 100644
+--- a/testcases/kernel/syscalls/fsync/fsync04.c
++++ b/testcases/kernel/syscalls/fsync/fsync04.c
+@@ -29,10 +29,12 @@ static void verify_fsync(void)
+ {
+        int fd;
+        unsigned long written;
+-
++       rmdir(MNTPOINT);
++        SAFE_MKDIR(MNTPOINT, MODE);
++        SAFE_MOUNT("/dev/vda", MNTPOINT, "ext4", 0, NULL);
+        fd = SAFE_OPEN(FNAME, O_RDWR|O_CREAT, MODE);
+
+-       tst_dev_bytes_written(tst_device->dev);
++       tst_dev_bytes_written("/dev/vda");
+
+        tst_fill_fd(fd, 0, TST_MB, FILE_SIZE_MB);
+
+@@ -41,9 +43,13 @@ static void verify_fsync(void)
+        if (TST_RET)
+                tst_brk(TFAIL | TTERRNO, "fsync(fd) failed");
+
+-       written = tst_dev_bytes_written(tst_device->dev);
++       written = tst_dev_bytes_written("/dev/vda");
+
+        SAFE_CLOSE(fd);
++       if(tst_umount(MNTPOINT) < 0){
++        tst_res(TWARN | TERRNO, "unmount device:mnt_point failed");
++        }
++       rmdir(MNTPOINT);
+
+        if (written >= FILE_SIZE)
+                tst_res(TPASS, "Test file synced to device");
+@@ -53,8 +59,5 @@ static void verify_fsync(void)
+
+ static struct tst_test test = {
+        .needs_root = 1,
+-       .mount_device = 1,
+-       .all_filesystems = 1,
+-       .mntpoint = MNTPOINT,
+        .test_all = verify_fsync,
+ };
+

--- a/tests/ltp/patches/ltp_fsync_fsync04.patch
+++ b/tests/ltp/patches/ltp_fsync_fsync04.patch
@@ -1,7 +1,7 @@
-+ // Patch Description: Tests were failing with kernel panic in loop filesystem.
++ // Patch Description: Tests are failing with kernel panic while using loop device filesystem
 + // So modified the tests to use root file system.
 diff --git a/testcases/kernel/syscalls/fsync/fsync04.c b/testcases/kernel/syscalls/fsync/fsync04.c
-index c67fc5692..708b0962e 100644
+index c67fc5692..f8682e950 100644
 --- a/testcases/kernel/syscalls/fsync/fsync04.c
 +++ b/testcases/kernel/syscalls/fsync/fsync04.c
 @@ -29,10 +29,12 @@ static void verify_fsync(void)
@@ -10,8 +10,8 @@ index c67fc5692..708b0962e 100644
         unsigned long written;
 -
 +       rmdir(MNTPOINT);
-+        SAFE_MKDIR(MNTPOINT, MODE);
-+        SAFE_MOUNT("/dev/vda", MNTPOINT, "ext4", 0, NULL);
++       SAFE_MKDIR(MNTPOINT, MODE);
++       SAFE_MOUNT("/dev/vda", MNTPOINT, "ext4", 0, NULL);
         fd = SAFE_OPEN(FNAME, O_RDWR|O_CREAT, MODE);
 
 -       tst_dev_bytes_written(tst_device->dev);
@@ -19,7 +19,7 @@ index c67fc5692..708b0962e 100644
 
         tst_fill_fd(fd, 0, TST_MB, FILE_SIZE_MB);
 
-@@ -41,9 +43,13 @@ static void verify_fsync(void)
+@@ -41,9 +43,14 @@ static void verify_fsync(void)
         if (TST_RET)
                 tst_brk(TFAIL | TTERRNO, "fsync(fd) failed");
 
@@ -27,14 +27,15 @@ index c67fc5692..708b0962e 100644
 +       written = tst_dev_bytes_written("/dev/vda");
 
         SAFE_CLOSE(fd);
-+       if(tst_umount(MNTPOINT) < 0){
-+        tst_res(TWARN | TERRNO, "unmount device:mnt_point failed");
-+        }
++       remove(FNAME);
++       if (tst_umount(MNTPOINT) < 0) {
++               tst_res(TWARN | TERRNO, "umount device :mntpoint failed");
++       }
 +       rmdir(MNTPOINT);
 
         if (written >= FILE_SIZE)
                 tst_res(TPASS, "Test file synced to device");
-@@ -53,8 +59,5 @@ static void verify_fsync(void)
+@@ -53,8 +60,5 @@ static void verify_fsync(void)
 
  static struct tst_test test = {
         .needs_root = 1,


### PR DESCRIPTION
Tests were failing with kernel panic while using loop device
So modified the tests to use root file system.