### PR TITLE
Test CI with libc.tls_enabled = 0

### DIFF
--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -206,9 +206,11 @@ int __libc_init_enclave(int argc, char** argv)
         sgxlkl_enclave->mmap_files);
 
     libc.vvar_base = sgxlkl_enclave->shared_memory.vvar;
-    libc.user_tls_enabled =
-        sgxlkl_enclave->mode == SW_DEBUG_MODE ? 1 : sgxlkl_enclave->fsgsbase;
+    //libc.user_tls_enabled =
+    //    sgxlkl_enclave->mode == SW_DEBUG_MODE ? 1 : sgxlkl_enclave->fsgsbase;
 
+    libc.user_tls_enabled = 0;
+    
     init_sysconf(
         sgxlkl_enclave->sysconf_nproc_conf, sgxlkl_enclave->sysconf_nproc_onln);
     init_clock_res(sgxlkl_enclave->clock_res);


### PR DESCRIPTION
Having it on, seems to cause a lot of problems in HW mode. I keep bumping into it when testing things and turning it off
has been the fix on 2 different occasions. I want to see what happens with CI if I turn off with no other changes.