### PR TITLE
Compile OE with COMPILE_SYSTEM_EDL

### DIFF
--- a/.azure-pipelines/scripts/install_openenclave.sh
+++ b/.azure-pipelines/scripts/install_openenclave.sh
@@ -36,7 +36,7 @@ sudo ansible-playbook scripts/ansible/oe-contributors-acc-setup-no-driver.yml
 
 mkdir -p build
 cd build
-cmake -G "Ninja" ..
+cmake -G "Ninja" -DCOMPILE_SYSTEM_EDL=ON ..
 sudo ninja
 sudo ninja install
 if [[ "$?" == "0" ]]; then

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ sudo ansible-playbook scripts/ansible/oe-contributors-setup.yml
 ```
 mkdir build
 cd build
-cmake -G "Unix Makefiles" ..
+cmake -G "Unix Makefiles" -DCOMPILE_SYSTEM_EDL=ON ..
 make
 sudo make install
 ```


### PR DESCRIPTION
Recently there has been work done in OE to convert ecalls and ocalls that were previously builtin to core libraries and make them opt-in instead. This change will mean that SGX-LKL will need to specifically import the EDL that it uses from oecore.

I am turning off this new feature to prevent upcoming changes from breaking SGX-LKL. Once the feature is fully merged in OE I will revert this change and make the necessary changes in SGX-LKL to make use of the feature.