### PR TITLE
Fix for flistxattr02,flistxattr03,listxattr03

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -230,8 +230,8 @@
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr02
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr03
 /ltp/testcases/kernel/syscalls/flistxattr/flistxattr01
-/ltp/testcases/kernel/syscalls/flistxattr/flistxattr02
-/ltp/testcases/kernel/syscalls/flistxattr/flistxattr03
+#/ltp/testcases/kernel/syscalls/flistxattr/flistxattr02
+#/ltp/testcases/kernel/syscalls/flistxattr/flistxattr03
 #/ltp/testcases/kernel/syscalls/flock/flock01
 #/ltp/testcases/kernel/syscalls/flock/flock02
 #/ltp/testcases/kernel/syscalls/flock/flock03
@@ -471,7 +471,7 @@
 #/ltp/testcases/kernel/syscalls/listen/listen01
 /ltp/testcases/kernel/syscalls/listxattr/listxattr01
 /ltp/testcases/kernel/syscalls/listxattr/listxattr02
-/ltp/testcases/kernel/syscalls/listxattr/listxattr03
+#/ltp/testcases/kernel/syscalls/listxattr/listxattr03
 /ltp/testcases/kernel/syscalls/llistxattr/llistxattr01
 /ltp/testcases/kernel/syscalls/llistxattr/llistxattr02
 /ltp/testcases/kernel/syscalls/llistxattr/llistxattr03

--- a/tests/ltp/patches/flistxattr02.patch
+++ b/tests/ltp/patches/flistxattr02.patch
@@ -1,8 +1,8 @@
 diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr02.c b/testcases/kernel/syscalls/flistxattr/flistxattr02.c
-index 13aa0b7e7..25defe2c8 100644
+index 13aa0b7e7..f1cc48f95 100644
 --- a/testcases/kernel/syscalls/flistxattr/flistxattr02.c
 +++ b/testcases/kernel/syscalls/flistxattr/flistxattr02.c
-@@ -17,14 +17,20 @@
+@@ -17,12 +17,17 @@
  * 2) flistxattr(2) should return -1 and set errno to EBADF.
  */
  
@@ -20,11 +20,8 @@ index 13aa0b7e7..25defe2c8 100644
 +#include <sys/xattr.h>
  #endif
  
-+#include <sys/mount.h>
  #include "tst_test.h"
- 
- #ifdef HAVE_SYS_XATTR_H
-@@ -33,6 +39,13 @@
+@@ -33,6 +38,13 @@
  #define VALUE	"test"
  #define VALUE_SIZE	(sizeof(VALUE) - 1)
  
@@ -38,7 +35,7 @@ index 13aa0b7e7..25defe2c8 100644
  static int fd1;
  static int fd2 = -1;
  
-@@ -70,7 +83,11 @@ static void verify_flistxattr(unsigned int n)
+@@ -70,7 +82,11 @@ static void verify_flistxattr(unsigned int n)
  
  static void setup(void)
  {
@@ -51,14 +48,13 @@ index 13aa0b7e7..25defe2c8 100644
  
  	SAFE_FSETXATTR(fd1, SECURITY_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
  }
-@@ -79,6 +96,10 @@ static void cleanup(void)
+@@ -79,6 +95,9 @@ static void cleanup(void)
  {
  	if (fd1 > 0)
  		SAFE_CLOSE(fd1);
 +	remove(TESTFILE);
-+	umount(MNTPOINT);
-+	rmdir(MNTPOINT);
-+
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
  }
  
  static struct tst_test test = {

--- a/tests/ltp/patches/flistxattr02.patch
+++ b/tests/ltp/patches/flistxattr02.patch
@@ -1,0 +1,64 @@
+diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr02.c b/testcases/kernel/syscalls/flistxattr/flistxattr02.c
+index 13aa0b7e7..25defe2c8 100644
+--- a/testcases/kernel/syscalls/flistxattr/flistxattr02.c
++++ b/testcases/kernel/syscalls/flistxattr/flistxattr02.c
+@@ -17,14 +17,20 @@
+ * 2) flistxattr(2) should return -1 and set errno to EBADF.
+ */
+ 
++/* Currently xattr is not enabled while mounting root file system. Patch is
++ * to mount root file system with xattr enabled and then use it for the test.
++*/
++
++#include <stdio.h>
+ #include "config.h"
+ #include <errno.h>
+ #include <sys/types.h>
+ 
+ #ifdef HAVE_SYS_XATTR_H
+-# include <sys/xattr.h>
++#include <sys/xattr.h>
+ #endif
+ 
++#include <sys/mount.h>
+ #include "tst_test.h"
+ 
+ #ifdef HAVE_SYS_XATTR_H
+@@ -33,6 +39,13 @@
+ #define VALUE	"test"
+ #define VALUE_SIZE	(sizeof(VALUE) - 1)
+ 
++#define MNTPOINT        "mntpoint"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++#define TESTFILE "mntpoint/flistxattr02testfile"
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
++
+ static int fd1;
+ static int fd2 = -1;
+ 
+@@ -70,7 +83,11 @@ static void verify_flistxattr(unsigned int n)
+ 
+ static void setup(void)
+ {
+-	fd1 = SAFE_OPEN("testfile", O_RDWR | O_CREAT, 0644);
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++
++	fd1 = SAFE_OPEN(TESTFILE, O_RDWR | O_CREAT, 0644);
+ 
+ 	SAFE_FSETXATTR(fd1, SECURITY_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
+ }
+@@ -79,6 +96,10 @@ static void cleanup(void)
+ {
+ 	if (fd1 > 0)
+ 		SAFE_CLOSE(fd1);
++	remove(TESTFILE);
++	umount(MNTPOINT);
++	rmdir(MNTPOINT);
++
+ }
+ 
+ static struct tst_test test = {

--- a/tests/ltp/patches/flistxattr02.patch
+++ b/tests/ltp/patches/flistxattr02.patch
@@ -1,8 +1,8 @@
 diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr02.c b/testcases/kernel/syscalls/flistxattr/flistxattr02.c
-index 13aa0b7e7..f1cc48f95 100644
+index 13aa0b7e7..67cc27877 100644
 --- a/testcases/kernel/syscalls/flistxattr/flistxattr02.c
 +++ b/testcases/kernel/syscalls/flistxattr/flistxattr02.c
-@@ -17,12 +17,17 @@
+@@ -17,6 +17,11 @@
  * 2) flistxattr(2) should return -1 and set errno to EBADF.
  */
  
@@ -14,13 +14,6 @@ index 13aa0b7e7..f1cc48f95 100644
  #include "config.h"
  #include <errno.h>
  #include <sys/types.h>
- 
- #ifdef HAVE_SYS_XATTR_H
--# include <sys/xattr.h>
-+#include <sys/xattr.h>
- #endif
- 
- #include "tst_test.h"
 @@ -33,6 +38,13 @@
  #define VALUE	"test"
  #define VALUE_SIZE	(sizeof(VALUE) - 1)

--- a/tests/ltp/patches/flistxattr03.patch
+++ b/tests/ltp/patches/flistxattr03.patch
@@ -1,8 +1,8 @@
 diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr03.c b/testcases/kernel/syscalls/flistxattr/flistxattr03.c
-index 49b463425..2b7130211 100644
+index 49b463425..ab17f8703 100644
 --- a/testcases/kernel/syscalls/flistxattr/flistxattr03.c
 +++ b/testcases/kernel/syscalls/flistxattr/flistxattr03.c
-@@ -13,14 +13,19 @@
+@@ -13,12 +13,17 @@
  * which can be used to estimate a suitable buffer.
  */
  
@@ -19,11 +19,8 @@ index 49b463425..2b7130211 100644
 -# include <sys/xattr.h>
 +#include <sys/xattr.h>
  #endif
--
-+#include <sys/mount.h>
- #include "tst_test.h"
  
- #ifdef HAVE_SYS_XATTR_H
+ #include "tst_test.h"
 @@ -28,6 +33,14 @@
  #define SECURITY_KEY	"security.ltptest"
  #define VALUE	"test"
@@ -54,15 +51,14 @@ index 49b463425..2b7130211 100644
  
  	SAFE_FSETXATTR(fd[1], SECURITY_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
  }
-@@ -68,6 +84,11 @@ static void cleanup(void)
+@@ -68,6 +84,10 @@ static void cleanup(void)
  {
  	SAFE_CLOSE(fd[1]);
  	SAFE_CLOSE(fd[0]);
 +	remove(TESTFILE1);
 +	remove(TESTFILE2);
-+	umount(MNTPOINT);
-+	rmdir(MNTPOINT);
-+
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
  }
  
  static struct tst_test test = {

--- a/tests/ltp/patches/flistxattr03.patch
+++ b/tests/ltp/patches/flistxattr03.patch
@@ -1,8 +1,8 @@
 diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr03.c b/testcases/kernel/syscalls/flistxattr/flistxattr03.c
-index 49b463425..ab17f8703 100644
+index 49b463425..82fe02f64 100644
 --- a/testcases/kernel/syscalls/flistxattr/flistxattr03.c
 +++ b/testcases/kernel/syscalls/flistxattr/flistxattr03.c
-@@ -13,12 +13,17 @@
+@@ -13,6 +13,11 @@
  * which can be used to estimate a suitable buffer.
  */
  
@@ -14,13 +14,6 @@ index 49b463425..ab17f8703 100644
  #include "config.h"
  #include <errno.h>
  #include <sys/types.h>
- 
- #ifdef HAVE_SYS_XATTR_H
--# include <sys/xattr.h>
-+#include <sys/xattr.h>
- #endif
- 
- #include "tst_test.h"
 @@ -28,6 +33,14 @@
  #define SECURITY_KEY	"security.ltptest"
  #define VALUE	"test"

--- a/tests/ltp/patches/flistxattr03.patch
+++ b/tests/ltp/patches/flistxattr03.patch
@@ -1,0 +1,68 @@
+diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr03.c b/testcases/kernel/syscalls/flistxattr/flistxattr03.c
+index 49b463425..2b7130211 100644
+--- a/testcases/kernel/syscalls/flistxattr/flistxattr03.c
++++ b/testcases/kernel/syscalls/flistxattr/flistxattr03.c
+@@ -13,14 +13,19 @@
+ * which can be used to estimate a suitable buffer.
+ */
+ 
++/* Currently xattr is not enabled while mounting root file system. Patch is
++ * to mount root file system with xattr enabled and then use it for the test.
++*/
++
++#include <stdio.h>
+ #include "config.h"
+ #include <errno.h>
+ #include <sys/types.h>
+ 
+ #ifdef HAVE_SYS_XATTR_H
+-# include <sys/xattr.h>
++#include <sys/xattr.h>
+ #endif
+-
++#include <sys/mount.h>
+ #include "tst_test.h"
+ 
+ #ifdef HAVE_SYS_XATTR_H
+@@ -28,6 +33,14 @@
+ #define SECURITY_KEY	"security.ltptest"
+ #define VALUE	"test"
+ #define VALUE_SIZE	(sizeof(VALUE) - 1)
++#define MNTPOINT        "mntpoint"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++#define TESTFILE1 "mntpoint/flistxattr03testfile1"
++#define TESTFILE2 "mntpoint/flistxattr03testfile2"
++
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ static int fd[] = {0, 0};
+ 
+@@ -57,9 +70,12 @@ static void verify_flistxattr(unsigned int n)
+ 
+ static void setup(void)
+ {
+-	fd[0] = SAFE_OPEN("testfile1", O_RDWR | O_CREAT, 0644);
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++	fd[0] = SAFE_OPEN(TESTFILE1, O_RDWR | O_CREAT, 0644);
+ 
+-	fd[1] = SAFE_OPEN("testfile2", O_RDWR | O_CREAT, 0644);
++	fd[1] = SAFE_OPEN(TESTFILE2, O_RDWR | O_CREAT, 0644);
+ 
+ 	SAFE_FSETXATTR(fd[1], SECURITY_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
+ }
+@@ -68,6 +84,11 @@ static void cleanup(void)
+ {
+ 	SAFE_CLOSE(fd[1]);
+ 	SAFE_CLOSE(fd[0]);
++	remove(TESTFILE1);
++	remove(TESTFILE2);
++	umount(MNTPOINT);
++	rmdir(MNTPOINT);
++
+ }
+ 
+ static struct tst_test test = {

--- a/tests/ltp/patches/listxattr03.patch
+++ b/tests/ltp/patches/listxattr03.patch
@@ -1,0 +1,76 @@
+diff --git a/testcases/kernel/syscalls/listxattr/listxattr03.c b/testcases/kernel/syscalls/listxattr/listxattr03.c
+index 4c1e7f16c..7f5a901d9 100644
+--- a/testcases/kernel/syscalls/listxattr/listxattr03.c
++++ b/testcases/kernel/syscalls/listxattr/listxattr03.c
+@@ -12,23 +12,35 @@
+ * of extended attribute names, which can be used to estimate a suitable buffer.
+ */
+ 
++/* Currently xattr is not enabled while mounting root file system. Patch is
++ * to mount root file system with xattr enabled and then use it for the test.
++*/
++
++#include <stdio.h>
+ #include "config.h"
+ #include <errno.h>
+ #include <sys/types.h>
+ 
+ #ifdef HAVE_SYS_XATTR_H
+-# include <sys/xattr.h>
++#include <sys/xattr.h>
+ #endif
+-
++#include <sys/mount.h>
+ #include "tst_test.h"
+-
+ #ifdef HAVE_SYS_XATTR_H
+ 
+ #define SECURITY_KEY	"security.ltptest"
+ #define VALUE	"test"
+ #define VALUE_SIZE	(sizeof(VALUE) - 1)
+ 
+-static const char * const filename[] = {"testfile1", "testfile2"};
++#define MNTPOINT        "mntpoint"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++#define TESTFILE1 "mntpoint/listxattr03testfile1"
++#define TESTFILE2 "mntpoint/listxattr03testfile2"
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
++
++static const char * const filename[] = {TESTFILE1,TESTFILE2};
+ 
+ static int check_suitable_buf(const char *name, long size)
+ {
+@@ -58,6 +70,10 @@ static void verify_listxattr(unsigned int n)
+ 
+ static void setup(void)
+ {
++        rmdir(MNTPOINT);
++        SAFE_MKDIR(MNTPOINT, DIR_MODE);
++        SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++
+ 	SAFE_TOUCH(filename[0], 0644, NULL);
+ 
+ 	SAFE_TOUCH(filename[1], 0644, NULL);
+@@ -65,12 +81,20 @@ static void setup(void)
+ 	SAFE_SETXATTR(filename[1], SECURITY_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
+ }
+ 
++static void cleanup(void)
++{
++        remove(TESTFILE1);
++        remove(TESTFILE2);
++        umount(MNTPOINT);
++        rmdir(MNTPOINT);
++}
+ static struct tst_test test = {
+ 	.needs_tmpdir = 1,
+ 	.needs_root = 1,
+ 	.test = verify_listxattr,
+ 	.tcnt = ARRAY_SIZE(filename),
+ 	.setup = setup,
++	.cleanup = cleanup,
+ };
+ 
+ #else /* HAVE_SYS_XATTR_H */

--- a/tests/ltp/patches/listxattr03.patch
+++ b/tests/ltp/patches/listxattr03.patch
@@ -1,8 +1,8 @@
 diff --git a/testcases/kernel/syscalls/listxattr/listxattr03.c b/testcases/kernel/syscalls/listxattr/listxattr03.c
-index 4c1e7f16c..e20a19b5d 100644
+index 4c1e7f16c..f86fd4a6f 100644
 --- a/testcases/kernel/syscalls/listxattr/listxattr03.c
 +++ b/testcases/kernel/syscalls/listxattr/listxattr03.c
-@@ -12,12 +12,17 @@
+@@ -12,6 +12,11 @@
  * of extended attribute names, which can be used to estimate a suitable buffer.
  */
  
@@ -14,13 +14,6 @@ index 4c1e7f16c..e20a19b5d 100644
  #include "config.h"
  #include <errno.h>
  #include <sys/types.h>
- 
- #ifdef HAVE_SYS_XATTR_H
--# include <sys/xattr.h>
-+#include <sys/xattr.h>
- #endif
- 
- #include "tst_test.h"
 @@ -28,7 +33,15 @@
  #define VALUE	"test"
  #define VALUE_SIZE	(sizeof(VALUE) - 1)

--- a/tests/ltp/patches/listxattr03.patch
+++ b/tests/ltp/patches/listxattr03.patch
@@ -1,8 +1,8 @@
 diff --git a/testcases/kernel/syscalls/listxattr/listxattr03.c b/testcases/kernel/syscalls/listxattr/listxattr03.c
-index 4c1e7f16c..7f5a901d9 100644
+index 4c1e7f16c..e20a19b5d 100644
 --- a/testcases/kernel/syscalls/listxattr/listxattr03.c
 +++ b/testcases/kernel/syscalls/listxattr/listxattr03.c
-@@ -12,23 +12,35 @@
+@@ -12,12 +12,17 @@
  * of extended attribute names, which can be used to estimate a suitable buffer.
  */
  
@@ -19,13 +19,9 @@ index 4c1e7f16c..7f5a901d9 100644
 -# include <sys/xattr.h>
 +#include <sys/xattr.h>
  #endif
--
-+#include <sys/mount.h>
- #include "tst_test.h"
--
- #ifdef HAVE_SYS_XATTR_H
  
- #define SECURITY_KEY	"security.ltptest"
+ #include "tst_test.h"
+@@ -28,7 +33,15 @@
  #define VALUE	"test"
  #define VALUE_SIZE	(sizeof(VALUE) - 1)
  
@@ -42,28 +38,29 @@ index 4c1e7f16c..7f5a901d9 100644
  
  static int check_suitable_buf(const char *name, long size)
  {
-@@ -58,6 +70,10 @@ static void verify_listxattr(unsigned int n)
+@@ -58,6 +71,10 @@ static void verify_listxattr(unsigned int n)
  
  static void setup(void)
  {
-+        rmdir(MNTPOINT);
-+        SAFE_MKDIR(MNTPOINT, DIR_MODE);
-+        SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
 +
  	SAFE_TOUCH(filename[0], 0644, NULL);
  
  	SAFE_TOUCH(filename[1], 0644, NULL);
-@@ -65,12 +81,20 @@ static void setup(void)
+@@ -65,12 +82,21 @@ static void setup(void)
  	SAFE_SETXATTR(filename[1], SECURITY_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
  }
  
 +static void cleanup(void)
 +{
-+        remove(TESTFILE1);
-+        remove(TESTFILE2);
-+        umount(MNTPOINT);
-+        rmdir(MNTPOINT);
++	remove(TESTFILE1);
++	remove(TESTFILE2);
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
 +}
++
  static struct tst_test test = {
  	.needs_tmpdir = 1,
  	.needs_root = 1,


### PR DESCRIPTION
Issue: Tests are related to xattr. But as xattr support is not used while mounting the tests were failing. 
Fix: Mount root file system using user_xattr option and use it for tests.