### PR TITLE
Use exit code of LTP tests for pass/fail decision

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -308,7 +308,7 @@
 /ltp/testcases/kernel/syscalls/getitimer/getitimer02
 #/ltp/testcases/kernel/syscalls/getitimer/getitimer03
 #/ltp/testcases/kernel/syscalls/getpagesize/getpagesize01
-#/ltp/testcases/kernel/syscalls/getpeername/getpeername01
+/ltp/testcases/kernel/syscalls/getpeername/getpeername01
 #/ltp/testcases/kernel/syscalls/getpgid/getpgid01
 #/ltp/testcases/kernel/syscalls/getpgid/getpgid02
 #/ltp/testcases/kernel/syscalls/getpgrp/getpgrp01

--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -34,7 +34,7 @@
 #/ltp/testcases/kernel/syscalls/chdir/chdir01
 /ltp/testcases/kernel/syscalls/chdir/chdir02
 #/ltp/testcases/kernel/syscalls/chdir/chdir03
-#/ltp/testcases/kernel/syscalls/chdir/chdir04
+/ltp/testcases/kernel/syscalls/chdir/chdir04
 #/ltp/testcases/kernel/syscalls/chmod/chmod01
 #/ltp/testcases/kernel/syscalls/chmod/chmod02
 /ltp/testcases/kernel/syscalls/chmod/chmod03
@@ -48,7 +48,7 @@
 #/ltp/testcases/kernel/syscalls/chown/chown04
 #/ltp/testcases/kernel/syscalls/chown/chown05
 /ltp/testcases/kernel/syscalls/chroot/chroot01
-#/ltp/testcases/kernel/syscalls/chroot/chroot02
+/ltp/testcases/kernel/syscalls/chroot/chroot02
 /ltp/testcases/kernel/syscalls/chroot/chroot03
 #/ltp/testcases/kernel/syscalls/chroot/chroot04
 #/ltp/testcases/kernel/syscalls/clock_adjtime/clock_adjtime01
@@ -198,8 +198,8 @@
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl09
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl10
 /ltp/testcases/kernel/syscalls/fcntl/fcntl11
-#/ltp/testcases/kernel/syscalls/fcntl/fcntl12
-#/ltp/testcases/kernel/syscalls/fcntl/fcntl13
+/ltp/testcases/kernel/syscalls/fcntl/fcntl12
+/ltp/testcases/kernel/syscalls/fcntl/fcntl13
 /ltp/testcases/kernel/syscalls/fcntl/fcntl14
 /ltp/testcases/kernel/syscalls/fcntl/fcntl15
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl16
@@ -332,14 +332,14 @@
 /ltp/testcases/kernel/syscalls/getrlimit/getrlimit02
 #/ltp/testcases/kernel/syscalls/getrlimit/getrlimit03
 #/ltp/testcases/kernel/syscalls/getrusage/getrusage01
-#/ltp/testcases/kernel/syscalls/getrusage/getrusage02
+/ltp/testcases/kernel/syscalls/getrusage/getrusage02
 /ltp/testcases/kernel/syscalls/getrusage/getrusage03
 /ltp/testcases/kernel/syscalls/getrusage/getrusage03_child
 /ltp/testcases/kernel/syscalls/getrusage/getrusage04
 #/ltp/testcases/kernel/syscalls/getsid/getsid01
 #/ltp/testcases/kernel/syscalls/getsid/getsid02
-#/ltp/testcases/kernel/syscalls/getsockname/getsockname01
-#/ltp/testcases/kernel/syscalls/getsockopt/getsockopt01
+/ltp/testcases/kernel/syscalls/getsockname/getsockname01
+/ltp/testcases/kernel/syscalls/getsockopt/getsockopt01
 /ltp/testcases/kernel/syscalls/getsockopt/getsockopt02
 #/ltp/testcases/kernel/syscalls/gettid/gettid01
 /ltp/testcases/kernel/syscalls/gettimeofday/gettimeofday01
@@ -484,7 +484,7 @@
 #/ltp/testcases/kernel/syscalls/lseek/lseek07
 /ltp/testcases/kernel/syscalls/lseek/lseek11
 #/ltp/testcases/kernel/syscalls/lstat/lstat01
-#/ltp/testcases/kernel/syscalls/lstat/lstat02
+/ltp/testcases/kernel/syscalls/lstat/lstat02
 /ltp/testcases/kernel/syscalls/madvise/madvise01
 /ltp/testcases/kernel/syscalls/madvise/madvise02
 /ltp/testcases/kernel/syscalls/madvise/madvise05

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -627,7 +627,7 @@
 /ltp/testcases/kernel/syscalls/open/open13
 /ltp/testcases/kernel/syscalls/open/open14
 #/ltp/testcases/kernel/syscalls/openat/openat01
-#/ltp/testcases/kernel/syscalls/openat/openat02
+/ltp/testcases/kernel/syscalls/openat/openat02
 /ltp/testcases/kernel/syscalls/openat/openat02_child
 /ltp/testcases/kernel/syscalls/openat/openat03
 #/ltp/testcases/kernel/syscalls/pathconf/pathconf01
@@ -671,7 +671,7 @@
 #/ltp/testcases/kernel/syscalls/pread/pread02
 #/ltp/testcases/kernel/syscalls/pread/pread03
 #/ltp/testcases/kernel/syscalls/preadv/preadv01
-#/ltp/testcases/kernel/syscalls/preadv/preadv02
+/ltp/testcases/kernel/syscalls/preadv/preadv02
 /ltp/testcases/kernel/syscalls/preadv/preadv03
 #/ltp/testcases/kernel/syscalls/preadv2/preadv201
 /ltp/testcases/kernel/syscalls/preadv2/preadv202
@@ -687,11 +687,11 @@
 /ltp/testcases/kernel/syscalls/ptrace/ptrace05
 /ltp/testcases/kernel/syscalls/ptrace/ptrace07
 #/ltp/testcases/kernel/syscalls/pwrite/pwrite01
-#/ltp/testcases/kernel/syscalls/pwrite/pwrite02
+/ltp/testcases/kernel/syscalls/pwrite/pwrite02
 #/ltp/testcases/kernel/syscalls/pwrite/pwrite03
 #/ltp/testcases/kernel/syscalls/pwrite/pwrite04
 #/ltp/testcases/kernel/syscalls/pwritev/pwritev01
-#/ltp/testcases/kernel/syscalls/pwritev/pwritev02
+/ltp/testcases/kernel/syscalls/pwritev/pwritev02
 /ltp/testcases/kernel/syscalls/pwritev/pwritev03
 #/ltp/testcases/kernel/syscalls/pwritev2/pwritev201
 /ltp/testcases/kernel/syscalls/pwritev2/pwritev202
@@ -707,7 +707,7 @@
 #/ltp/testcases/kernel/syscalls/readdir/readdir01
 /ltp/testcases/kernel/syscalls/readdir/readdir21
 #/ltp/testcases/kernel/syscalls/readlink/readlink01
-#/ltp/testcases/kernel/syscalls/readlink/readlink03
+/ltp/testcases/kernel/syscalls/readlink/readlink03
 #/ltp/testcases/kernel/syscalls/readlinkat/readlinkat01
 #/ltp/testcases/kernel/syscalls/readlinkat/readlinkat02
 #/ltp/testcases/kernel/syscalls/readv/readv01
@@ -754,7 +754,7 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction02
 #/ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03
 #/ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
-#/ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02
+/ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02
 /ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
 /ltp/testcases/kernel/syscalls/rt_sigsuspend/rt_sigsuspend01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
@@ -812,7 +812,7 @@
 /ltp/testcases/kernel/syscalls/set_thread_area/set_thread_area01
 /ltp/testcases/kernel/syscalls/set_tid_address/set_tid_address01
 #/ltp/testcases/kernel/syscalls/setdomainname/setdomainname01
-#/ltp/testcases/kernel/syscalls/setdomainname/setdomainname02
+/ltp/testcases/kernel/syscalls/setdomainname/setdomainname02
 #/ltp/testcases/kernel/syscalls/setdomainname/setdomainname03
 #/ltp/testcases/kernel/syscalls/setegid/setegid01
 #/ltp/testcases/kernel/syscalls/setegid/setegid02
@@ -870,7 +870,7 @@
 /ltp/testcases/kernel/syscalls/setrlimit/setrlimit05
 /ltp/testcases/kernel/syscalls/setrlimit/setrlimit06
 /ltp/testcases/kernel/syscalls/setsid/setsid01
-#/ltp/testcases/kernel/syscalls/setsockopt/setsockopt01
+/ltp/testcases/kernel/syscalls/setsockopt/setsockopt01
 /ltp/testcases/kernel/syscalls/setsockopt/setsockopt02
 #/ltp/testcases/kernel/syscalls/setsockopt/setsockopt03
 #/ltp/testcases/kernel/syscalls/setsockopt/setsockopt04
@@ -905,9 +905,9 @@
 #/ltp/testcases/kernel/syscalls/socketcall/socketcall02
 #/ltp/testcases/kernel/syscalls/socketcall/socketcall03
 #/ltp/testcases/kernel/syscalls/socketcall/socketcall04
-#/ltp/testcases/kernel/syscalls/socketpair/socketpair01
+/ltp/testcases/kernel/syscalls/socketpair/socketpair01
 #/ltp/testcases/kernel/syscalls/socketpair/socketpair02
-#/ltp/testcases/kernel/syscalls/sockioctl/sockioctl01
+/ltp/testcases/kernel/syscalls/sockioctl/sockioctl01
 #/ltp/testcases/kernel/syscalls/splice/splice01
 /ltp/testcases/kernel/syscalls/splice/splice02
 #/ltp/testcases/kernel/syscalls/splice/splice03
@@ -976,7 +976,7 @@
 /ltp/testcases/kernel/syscalls/timer_delete/timer_delete01
 #/ltp/testcases/kernel/syscalls/timer_delete/timer_delete02
 #/ltp/testcases/kernel/syscalls/timer_getoverrun/timer_getoverrun01
-#/ltp/testcases/kernel/syscalls/timer_gettime/timer_gettime01
+/ltp/testcases/kernel/syscalls/timer_gettime/timer_gettime01
 /ltp/testcases/kernel/syscalls/timer_settime/timer_settime01
 /ltp/testcases/kernel/syscalls/timer_settime/timer_settime02
 /ltp/testcases/kernel/syscalls/timerfd/timerfd01
@@ -1020,7 +1020,7 @@
 /ltp/testcases/kernel/syscalls/utime/utime05
 /ltp/testcases/kernel/syscalls/utime/utime06
 /ltp/testcases/kernel/syscalls/utimensat/utimensat01
-#/ltp/testcases/kernel/syscalls/utimes/utimes01
+/ltp/testcases/kernel/syscalls/utimes/utimes01
 /ltp/testcases/kernel/syscalls/vfork/vfork01
 /ltp/testcases/kernel/syscalls/vfork/vfork02
 #/ltp/testcases/kernel/syscalls/vhangup/vhangup01

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -797,7 +797,7 @@
 /ltp/testcases/kernel/syscalls/sendfile/sendfile05
 /ltp/testcases/kernel/syscalls/sendfile/sendfile06
 #/ltp/testcases/kernel/syscalls/sendfile/sendfile07
-#/ltp/testcases/kernel/syscalls/sendfile/sendfile08
+/ltp/testcases/kernel/syscalls/sendfile/sendfile08
 /ltp/testcases/kernel/syscalls/sendfile/sendfile09
 #/ltp/testcases/kernel/syscalls/sendmmsg/sendmmsg01
 /ltp/testcases/kernel/syscalls/sendmsg/sendmsg01

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -79,7 +79,7 @@ for file in ${ltp_tests[@]}; do
     if [[ $exit_code -eq  124 ]]; then
         echo "$SGX_LKL_RUN_CMD $file : TIMED OUT after $timeout secs"
         echo "TIMED OUT after $timeout secs. TEST_FAILED" >> "$stderr_file"
-    elif [[ $exit_code -ne 0 ]]
+    elif [[ $exit_code -ne 0 ]]; then
         echo "TEST_FAILED EXIT CODE: $exit_code" >> "$stderr_file"
     else
         echo "$SGX_LKL_RUN_CMD $file: RETURNED EXIT CODE: $exit_code"

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -79,6 +79,8 @@ for file in ${ltp_tests[@]}; do
     if [[ $exit_code -eq  124 ]]; then
         echo "$SGX_LKL_RUN_CMD $file : TIMED OUT after $timeout secs"
         echo "TIMED OUT after $timeout secs. TEST_FAILED" >> "$stderr_file"
+    elif [[ $exit_code -ne 0 ]]
+        echo "TEST_FAILED EXIT CODE: $exit_code" >> "$stderr_file"
     else
         echo "$SGX_LKL_RUN_CMD $file: RETURNED EXIT CODE: $exit_code"
     fi

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -52,9 +52,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ltp_tests=($(grep -vf ./ltp_disabled_tests.txt  ./.c_binaries_list))
 total_tests=${#ltp_tests[@]}
 
-current_failure_identifiers=()
-while IFS= read -r line; do current_failure_identifiers+=("$line"); done < $DIR/failure_identifiers.txt
-
 for file in ${ltp_tests[@]}; do
     temp_test_name=${file}
     temp_test_name="${temp_test_name//.\//}"
@@ -85,40 +82,17 @@ for file in ${ltp_tests[@]}; do
         echo "$SGX_LKL_RUN_CMD $file: RETURNED EXIT CODE: $exit_code"
     fi
 
-    total_failures=0
-    total_pass=0
-    for ((i = 0; i < ${#current_failure_identifiers[@]}; i++))
-    do
-        failure="${current_failure_identifiers[$i]}"
-        failure_count=$(cat "$stdout_file" | grep "$failure" | wc -l)
-        total_failures=$(($total_failures + $failure_count))
-        if [[ $failure_count -gt 0 ]]; then
-            echo "Failure : '$failure' observed in '$stdout_file'"
-        fi
-
-        if [ ! -z $stderr_file ]; then
-            failure_count=$(cat "$stderr_file" | grep "$failure" | wc -l)
-            total_failures=$(($total_failures + $failure_count))
-            if [[ $failure_count -gt 0 ]]; then
-                echo "Failure : '$failure' observed in '$stderr_file'"
-            fi
-        fi
-    done
-    pass_count=$(cat "$stdout_file" "$stderr_file" | grep PASS | wc -l)
-    if [[ $total_failures -eq 0 && $pass_count -eq  0 ]]; then
-        echo "None of FAILURE IDENTIFIERS matched. Logs doesn't have PASS either. Assuming test FAILED. This can be false negative. Investigate. You can output  PASS to console in the test"
-    fi
-    if [[ $total_failures -eq 0 && $pass_count -gt 0 ]]; then
+    if [[ $exit_code -eq 0 ]]; then
         total_passed=$(($total_passed + 1))
-        echo "'$test_name' passed. Failure Count = $total_failures, Pass Count = $pass_count"
-        echo "'$test_name' passed. Failure Count = $total_failures, Pass Count = $pass_count" > "$error_message_file_path"
+        echo "'$test_name' passed."
+        echo "'$test_name' passed." > "$error_message_file_path"
         echo "$counter, $test_name, $stdout_file, $stderr_file, Pass"
         echo "$counter, $ltp_testcase_name, $stdout_file, $stderr_file, Pass" >> $csv_filename
         JunitTestFinished "$test_name" "passed" "$test_class" "$test_suite"
     else
         total_failed=$(($total_failed + 1))
-        echo "'$test_name' failed. Failure Count = $total_failures, Pass Count = $pass_count"
-        echo "'$test_name' failed. Failure Count = $total_failures, Pass Count = $pass_count" > "$error_message_file_path"
+        echo "'$test_name' failed."
+        echo "'$test_name' failed." > "$error_message_file_path"
         echo "'make $test_mode-single test=$file' can be used to test this individually failing ltp test"
         echo "'make $test_mode-single test=$file' can be used to test this individually failing ltp test" >> "$error_message_file_path"
         echo "$counter, $test_name, $stdout_file, $stderr_file, Failed"


### PR DESCRIPTION
- Use exit code to decide LTP test pass/failure
- Remove failure identifier logic
- Disabling 23 failing tests after enabling exit code which were false positives.  We will investigate further these 23 tests and will fix the test issues and enable later (https://github.com/lsds/sgx-lkl/issues/296)
- LTP test count dropped from 461 downto 438 due to these 23 disabled tests. 