### PR TITLE
Fix null-pointer dereference.

### DIFF
--- a/src/enclave/enclave_signal.c
+++ b/src/enclave/enclave_signal.c
@@ -113,7 +113,8 @@ static uint64_t sgxlkl_enclave_signal_handler(
     struct ucontext uctx;
     struct oe_hw_exception_map trap_info;
     oe_context_t* oe_ctx = exception_record->context;
-    uint16_t opcode = *((uint16_t*)exception_record->context->rip);
+    uint16_t *instr_addr = ((uint16_t*)exception_record->context->rip);
+    uint16_t opcode = instr_addr ? *instr_addr : 0;
 
     SGXLKL_TRACE_SIGNAL(
         "sgxlkl_enclave_signal_handler:: code=%d address=0x%lx opcode=0x%x\n",


### PR DESCRIPTION
If we get a null pointer dereference in instruction fetch, OE injects a
trap for us and we try to give a helpful error message by disassembling
the instruction.  Doing so, we dereference a null pointer and get a
trap.  Bad things ensue.