### PR TITLE
Fix memory management issues in clone host support

### DIFF
--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -290,6 +290,12 @@ extern "C"
 
     static inline void __scheduler_enqueue(struct lthread* lt)
     {
+#ifndef NDEBUG
+        // Abort if we try to schedule an exited lthread.  We cannot rely on
+        // our normal assert machinery working if this invariant is violated.
+        if (lt->attr.state & (1<<(LT_ST_EXITED)))
+            __builtin_trap();
+#endif
         if (!lt)
         {
             a_crash();
@@ -297,6 +303,11 @@ extern "C"
         for (; !mpmc_enqueue(&__scheduler_queue, lt);)
             a_spin();
     }
+
+    /**
+     * Remove a thread from the list blocking on a futex.
+     */
+    void futex_dequeue(struct lthread *lt);
 
 #ifdef __cplusplus
 }

--- a/src/sched/futex.c
+++ b/src/sched/futex.c
@@ -44,6 +44,20 @@ static uint32_t to_futex_key(int* uaddr)
     return (uint32_t)uaddr;
 }
 
+/**
+ * If a thread is being exited while blocked, remove it from the futex list.
+ */
+void futex_dequeue(struct lthread *lt)
+{
+    a_barrier();
+
+    ticket_lock(&futex_q_lock);
+
+    SLIST_REMOVE(&futex_queues, &lt->fq, futex_q, entries);
+
+    ticket_unlock(&futex_q_lock);
+}
+
 /* called on a scheduler tick to check for timed out, sleeping futexes */
 void futex_tick()
 {

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -682,7 +682,8 @@ int lthread_create_primitive(
     lt->tid = a_fetch_add(&spawned_lthreads, 1);
     lt->robust_list.head = &lt->robust_list.head;
 
-    lthread_set_funcname(lt, "cloned host task");
+    static unsigned long long n = 0;
+    snprintf(lt->funcname, 64, "cloned host task %llu", __atomic_fetch_add(&n, 1, __ATOMIC_SEQ_CST));
 
     if (new_lt)
     {


### PR DESCRIPTION
When an LKL task does an exit system call, the kernel leaves it blocking
on the scheduler semaphore then frees the semaphore.  This leaves the
corresponding lthread on the enclave futex's sleeping queue.

This fixes the root cause of the intermittent failure in the clone test
if we deleted the thread immediately, so we can now simplify this code
and delete the thread, without pivoting the stack.