### PR TITLE
Fix for lkl_access_check issues

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -338,8 +338,8 @@
 /ltp/testcases/kernel/syscalls/getrusage/getrusage04
 #/ltp/testcases/kernel/syscalls/getsid/getsid01
 #/ltp/testcases/kernel/syscalls/getsid/getsid02
-/ltp/testcases/kernel/syscalls/getsockname/getsockname01
-/ltp/testcases/kernel/syscalls/getsockopt/getsockopt01
+#/ltp/testcases/kernel/syscalls/getsockname/getsockname01
+#/ltp/testcases/kernel/syscalls/getsockopt/getsockopt01
 /ltp/testcases/kernel/syscalls/getsockopt/getsockopt02
 #/ltp/testcases/kernel/syscalls/gettid/gettid01
 /ltp/testcases/kernel/syscalls/gettimeofday/gettimeofday01
@@ -484,7 +484,7 @@
 #/ltp/testcases/kernel/syscalls/lseek/lseek07
 /ltp/testcases/kernel/syscalls/lseek/lseek11
 #/ltp/testcases/kernel/syscalls/lstat/lstat01
-/ltp/testcases/kernel/syscalls/lstat/lstat02
+#/ltp/testcases/kernel/syscalls/lstat/lstat02
 /ltp/testcases/kernel/syscalls/madvise/madvise01
 /ltp/testcases/kernel/syscalls/madvise/madvise02
 /ltp/testcases/kernel/syscalls/madvise/madvise05
@@ -687,7 +687,7 @@
 /ltp/testcases/kernel/syscalls/ptrace/ptrace05
 /ltp/testcases/kernel/syscalls/ptrace/ptrace07
 /ltp/testcases/kernel/syscalls/pwrite/pwrite01
-/ltp/testcases/kernel/syscalls/pwrite/pwrite02
+#/ltp/testcases/kernel/syscalls/pwrite/pwrite02
 /ltp/testcases/kernel/syscalls/pwrite/pwrite03
 /ltp/testcases/kernel/syscalls/pwrite/pwrite04
 /ltp/testcases/kernel/syscalls/pwritev/pwritev01
@@ -812,7 +812,7 @@
 /ltp/testcases/kernel/syscalls/set_thread_area/set_thread_area01
 /ltp/testcases/kernel/syscalls/set_tid_address/set_tid_address01
 /ltp/testcases/kernel/syscalls/setdomainname/setdomainname01
-/ltp/testcases/kernel/syscalls/setdomainname/setdomainname02
+#/ltp/testcases/kernel/syscalls/setdomainname/setdomainname02
 /ltp/testcases/kernel/syscalls/setdomainname/setdomainname03
 /ltp/testcases/kernel/syscalls/setegid/setegid01
 /ltp/testcases/kernel/syscalls/setegid/setegid02
@@ -870,7 +870,7 @@
 /ltp/testcases/kernel/syscalls/setrlimit/setrlimit05
 /ltp/testcases/kernel/syscalls/setrlimit/setrlimit06
 /ltp/testcases/kernel/syscalls/setsid/setsid01
-/ltp/testcases/kernel/syscalls/setsockopt/setsockopt01
+#/ltp/testcases/kernel/syscalls/setsockopt/setsockopt01
 /ltp/testcases/kernel/syscalls/setsockopt/setsockopt02
 /ltp/testcases/kernel/syscalls/setsockopt/setsockopt03
 /ltp/testcases/kernel/syscalls/setsockopt/setsockopt04
@@ -905,9 +905,9 @@
 /ltp/testcases/kernel/syscalls/socketcall/socketcall02
 /ltp/testcases/kernel/syscalls/socketcall/socketcall03
 /ltp/testcases/kernel/syscalls/socketcall/socketcall04
-/ltp/testcases/kernel/syscalls/socketpair/socketpair01
+#/ltp/testcases/kernel/syscalls/socketpair/socketpair01
 /ltp/testcases/kernel/syscalls/socketpair/socketpair02
-/ltp/testcases/kernel/syscalls/sockioctl/sockioctl01
+#/ltp/testcases/kernel/syscalls/sockioctl/sockioctl01
 /ltp/testcases/kernel/syscalls/splice/splice01
 /ltp/testcases/kernel/syscalls/splice/splice02
 /ltp/testcases/kernel/syscalls/splice/splice03
@@ -976,7 +976,7 @@
 /ltp/testcases/kernel/syscalls/timer_delete/timer_delete01
 /ltp/testcases/kernel/syscalls/timer_delete/timer_delete02
 /ltp/testcases/kernel/syscalls/timer_getoverrun/timer_getoverrun01
-/ltp/testcases/kernel/syscalls/timer_gettime/timer_gettime01
+#/ltp/testcases/kernel/syscalls/timer_gettime/timer_gettime01
 /ltp/testcases/kernel/syscalls/timer_settime/timer_settime01
 /ltp/testcases/kernel/syscalls/timer_settime/timer_settime02
 /ltp/testcases/kernel/syscalls/timerfd/timerfd01
@@ -1020,7 +1020,7 @@
 /ltp/testcases/kernel/syscalls/utime/utime05
 #/ltp/testcases/kernel/syscalls/utime/utime06
 /ltp/testcases/kernel/syscalls/utimensat/utimensat01
-/ltp/testcases/kernel/syscalls/utimes/utimes01
+#/ltp/testcases/kernel/syscalls/utimes/utimes01
 /ltp/testcases/kernel/syscalls/vfork/vfork01
 /ltp/testcases/kernel/syscalls/vfork/vfork02
 /ltp/testcases/kernel/syscalls/vhangup/vhangup01

--- a/tests/ltp/patches/getsockname01.patch
+++ b/tests/ltp/patches/getsockname01.patch
@@ -1,19 +1,11 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
+
 diff --git a/testcases/kernel/syscalls/getsockname/getsockname01.c b/testcases/kernel/syscalls/getsockname/getsockname01.c
-index cce1543fd..060026965 100644
+index cce1543fd..c8880b3a7 100644
 --- a/testcases/kernel/syscalls/getsockname/getsockname01.c
 +++ b/testcases/kernel/syscalls/getsockname/getsockname01.c
-@@ -39,6 +39,10 @@
-  *  None.
-  */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- #include <stdio.h>
- #include <unistd.h>
- #include <errno.h>
-@@ -83,21 +87,6 @@ struct test_case_t {		/* test case structure */
+@@ -83,21 +83,23 @@ struct test_case_t {		/* test case structure */
  	PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&fsin1,
  		    &sinlen, -1, ENOTSOCK, setup0, cleanup0,
  		    "bad file descriptor"},
@@ -32,6 +24,23 @@ index cce1543fd..060026965 100644
 -		    (socklen_t *) 1, -1, EFAULT, setup1, cleanup1,
 -		    "invalid unaligned salen"},
 -#endif
++//TODO: uncomment below 15 lines after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//#ifndef UCLINUX
++//	    /* Skip since uClinux does not implement memory protection */
++//	{
++//	PF_INET, SOCK_STREAM, 0, NULL,
++//		    &sinlen, -1, EFAULT, setup1, cleanup1,
++//		    "invalid socket buffer"}, {
++//		/* invalid salen test for aligned input */
++//	PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&fsin1,
++//		    NULL, -1, EFAULT, setup1, cleanup1,
++//		    "invalid aligned salen"}, {
++//		/* invalid salen test for unaligned input */
++//	PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&fsin1,
++//		    (socklen_t *) 1, -1, EFAULT, setup1, cleanup1,
++//		    "invalid unaligned salen"},
++//#endif
  };
  
  int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);

--- a/tests/ltp/patches/getsockname01.patch
+++ b/tests/ltp/patches/getsockname01.patch
@@ -1,0 +1,37 @@
+diff --git a/testcases/kernel/syscalls/getsockname/getsockname01.c b/testcases/kernel/syscalls/getsockname/getsockname01.c
+index cce1543fd..060026965 100644
+--- a/testcases/kernel/syscalls/getsockname/getsockname01.c
++++ b/testcases/kernel/syscalls/getsockname/getsockname01.c
+@@ -39,6 +39,10 @@
+  *  None.
+  */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <errno.h>
+@@ -83,21 +87,6 @@ struct test_case_t {		/* test case structure */
+ 	PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&fsin1,
+ 		    &sinlen, -1, ENOTSOCK, setup0, cleanup0,
+ 		    "bad file descriptor"},
+-#ifndef UCLINUX
+-	    /* Skip since uClinux does not implement memory protection */
+-	{
+-	PF_INET, SOCK_STREAM, 0, NULL,
+-		    &sinlen, -1, EFAULT, setup1, cleanup1,
+-		    "invalid socket buffer"}, {
+-		/* invalid salen test for aligned input */
+-	PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&fsin1,
+-		    NULL, -1, EFAULT, setup1, cleanup1,
+-		    "invalid aligned salen"}, {
+-		/* invalid salen test for unaligned input */
+-	PF_INET, SOCK_STREAM, 0, (struct sockaddr *)&fsin1,
+-		    (socklen_t *) 1, -1, EFAULT, setup1, cleanup1,
+-		    "invalid unaligned salen"},
+-#endif
+ };
+ 
+ int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);

--- a/tests/ltp/patches/getsockopt01.patch
+++ b/tests/ltp/patches/getsockopt01.patch
@@ -1,19 +1,10 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/getsockopt/getsockopt01.c b/testcases/kernel/syscalls/getsockopt/getsockopt01.c
-index d1692fcd3..f8b0a002c 100644
+index d1692fcd3..abb05d8b6 100644
 --- a/testcases/kernel/syscalls/getsockopt/getsockopt01.c
 +++ b/testcases/kernel/syscalls/getsockopt/getsockopt01.c
-@@ -17,6 +17,10 @@
-  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-  */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- /*
-  * Test Name: getsockopt01
-  *
-@@ -91,17 +95,6 @@ struct test_case_t {		/* test case structure */
+@@ -91,17 +91,19 @@ struct test_case_t {		/* test case structure */
  		    &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
  		    -1, ENOTSOCK, setup0, cleanup0, "bad file descriptor"}
  	,
@@ -28,6 +19,19 @@ index d1692fcd3..f8b0a002c 100644
 -		    EFAULT, setup1, cleanup1, "invalid optlen"}
 -	,
 -#endif /* UCLINUX */
++//TODO: uncomment below 11 lines after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//#ifndef UCLINUX
++//	{
++//	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, 0, &optlen,
++//		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
++//		    EFAULT, setup1, cleanup1, "invalid option buffer"}
++//	, {
++//	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,
++//		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
++//		    EFAULT, setup1, cleanup1, "invalid optlen"}
++//	,
++//#endif /* UCLINUX */
  	{
  	PF_INET, SOCK_STREAM, 0, 500, SO_OOBINLINE, &optval, &optlen,
  		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,

--- a/tests/ltp/patches/getsockopt01.patch
+++ b/tests/ltp/patches/getsockopt01.patch
@@ -1,0 +1,33 @@
+diff --git a/testcases/kernel/syscalls/getsockopt/getsockopt01.c b/testcases/kernel/syscalls/getsockopt/getsockopt01.c
+index d1692fcd3..f8b0a002c 100644
+--- a/testcases/kernel/syscalls/getsockopt/getsockopt01.c
++++ b/testcases/kernel/syscalls/getsockopt/getsockopt01.c
+@@ -17,6 +17,10 @@
+  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ /*
+  * Test Name: getsockopt01
+  *
+@@ -91,17 +95,6 @@ struct test_case_t {		/* test case structure */
+ 		    &optlen, (struct sockaddr *)&fsin1, sizeof(fsin1),
+ 		    -1, ENOTSOCK, setup0, cleanup0, "bad file descriptor"}
+ 	,
+-#ifndef UCLINUX
+-	{
+-	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, 0, &optlen,
+-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+-		    EFAULT, setup1, cleanup1, "invalid option buffer"}
+-	, {
+-	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,
+-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+-		    EFAULT, setup1, cleanup1, "invalid optlen"}
+-	,
+-#endif /* UCLINUX */
+ 	{
+ 	PF_INET, SOCK_STREAM, 0, 500, SO_OOBINLINE, &optval, &optlen,
+ 		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,

--- a/tests/ltp/patches/lstat02.patch
+++ b/tests/ltp/patches/lstat02.patch
@@ -1,0 +1,23 @@
+diff --git a/testcases/kernel/syscalls/lstat/lstat02.c b/testcases/kernel/syscalls/lstat/lstat02.c
+index 69d607089..c71b244d9 100644
+--- a/testcases/kernel/syscalls/lstat/lstat02.c
++++ b/testcases/kernel/syscalls/lstat/lstat02.c
+@@ -21,6 +21,10 @@
+  *	many symbolic links encountered while traversing.
+  */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ #include <errno.h>
+ #include <pwd.h>
+ #include <stdlib.h>
+@@ -50,7 +54,6 @@ static struct test_case_t {
+ } test_cases[] = {
+ 	{TEST_EACCES, EACCES},
+ 	{TEST_ENOENT, ENOENT},
+-	{NULL, EFAULT},
+ 	{longpathname, ENAMETOOLONG},
+ 	{TEST_ENOTDIR, ENOTDIR},
+ 	{elooppathname, ELOOP},

--- a/tests/ltp/patches/lstat02.patch
+++ b/tests/ltp/patches/lstat02.patch
@@ -1,23 +1,17 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/lstat/lstat02.c b/testcases/kernel/syscalls/lstat/lstat02.c
-index 69d607089..c71b244d9 100644
+index 69d607089..701a706f3 100644
 --- a/testcases/kernel/syscalls/lstat/lstat02.c
 +++ b/testcases/kernel/syscalls/lstat/lstat02.c
-@@ -21,6 +21,10 @@
-  *	many symbolic links encountered while traversing.
-  */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- #include <errno.h>
- #include <pwd.h>
- #include <stdlib.h>
-@@ -50,7 +54,6 @@ static struct test_case_t {
+@@ -50,7 +50,9 @@ static struct test_case_t {
  } test_cases[] = {
  	{TEST_EACCES, EACCES},
  	{TEST_ENOENT, ENOENT},
 -	{NULL, EFAULT},
++//TODO: uncomment below 1 line after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//	{NULL, EFAULT},
  	{longpathname, ENAMETOOLONG},
  	{TEST_ENOTDIR, ENOTDIR},
  	{elooppathname, ELOOP},

--- a/tests/ltp/patches/pwrite02.patch
+++ b/tests/ltp/patches/pwrite02.patch
@@ -1,0 +1,23 @@
+diff --git a/testcases/kernel/syscalls/pwrite/pwrite02.c b/testcases/kernel/syscalls/pwrite/pwrite02.c
+index 056d44da2..fc09cc95d 100644
+--- a/testcases/kernel/syscalls/pwrite/pwrite02.c
++++ b/testcases/kernel/syscalls/pwrite/pwrite02.c
+@@ -18,6 +18,10 @@
+  *      accessible address space, returns EFAULT.
+  */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ #define _XOPEN_SOURCE 500
+ 
+ #include <errno.h>
+@@ -46,7 +50,6 @@ static struct tcase {
+ 	{buf, sizeof(buf), &fd, -1, EINVAL},
+ 	{buf, sizeof(buf), &inv_fd, 0, EBADF},
+ 	{buf, sizeof(buf), &fd_ro, 0, EBADF},
+-	{NULL, sizeof(buf), &fd, 0, EFAULT},
+ };
+ 
+ /*

--- a/tests/ltp/patches/pwrite02.patch
+++ b/tests/ltp/patches/pwrite02.patch
@@ -1,23 +1,17 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/pwrite/pwrite02.c b/testcases/kernel/syscalls/pwrite/pwrite02.c
-index 056d44da2..fc09cc95d 100644
+index 056d44da2..0f5b1e37c 100644
 --- a/testcases/kernel/syscalls/pwrite/pwrite02.c
 +++ b/testcases/kernel/syscalls/pwrite/pwrite02.c
-@@ -18,6 +18,10 @@
-  *      accessible address space, returns EFAULT.
-  */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- #define _XOPEN_SOURCE 500
- 
- #include <errno.h>
-@@ -46,7 +50,6 @@ static struct tcase {
+@@ -46,7 +46,9 @@ static struct tcase {
  	{buf, sizeof(buf), &fd, -1, EINVAL},
  	{buf, sizeof(buf), &inv_fd, 0, EBADF},
  	{buf, sizeof(buf), &fd_ro, 0, EBADF},
 -	{NULL, sizeof(buf), &fd, 0, EFAULT},
++//TODO: uncomment below 1 line after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//	{NULL, sizeof(buf), &fd, 0, EFAULT},
  };
  
  /*

--- a/tests/ltp/patches/setdomainname02.patch
+++ b/tests/ltp/patches/setdomainname02.patch
@@ -1,0 +1,23 @@
+diff --git a/testcases/kernel/syscalls/setdomainname/setdomainname02.c b/testcases/kernel/syscalls/setdomainname/setdomainname02.c
+index 875ed0c44..de9f3581f 100644
+--- a/testcases/kernel/syscalls/setdomainname/setdomainname02.c
++++ b/testcases/kernel/syscalls/setdomainname/setdomainname02.c
+@@ -5,6 +5,10 @@
+  * Author: Saji Kumar.V.R <saji.kumar@wipro.com>
+  */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to product issue 169
++ */
++
+ #include "setdomainname.h"
+ 
+ #define ERRNO_DESC(x) .exp_errno = x, .errno_desc = #x
+@@ -20,7 +24,6 @@ struct test_case {
+ } tcases[] = {
+ 	{ "len == -1", TST_VALID_DOMAIN_NAME, -1, ERRNO_DESC(EINVAL) },
+ 	{ "len > allowed maximum", TST_VALID_DOMAIN_NAME, MAX_NAME_LENGTH + 1, ERRNO_DESC(EINVAL) },
+-	{ "name == NULL", NULL, MAX_NAME_LENGTH, ERRNO_DESC(EFAULT) }
+ };
+ 
+ void verify_setdomainname(unsigned int nr)

--- a/tests/ltp/patches/setdomainname02.patch
+++ b/tests/ltp/patches/setdomainname02.patch
@@ -1,23 +1,17 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/setdomainname/setdomainname02.c b/testcases/kernel/syscalls/setdomainname/setdomainname02.c
-index 875ed0c44..de9f3581f 100644
+index 875ed0c44..a292b21bc 100644
 --- a/testcases/kernel/syscalls/setdomainname/setdomainname02.c
 +++ b/testcases/kernel/syscalls/setdomainname/setdomainname02.c
-@@ -5,6 +5,10 @@
-  * Author: Saji Kumar.V.R <saji.kumar@wipro.com>
-  */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to product issue 169
-+ */
-+
- #include "setdomainname.h"
- 
- #define ERRNO_DESC(x) .exp_errno = x, .errno_desc = #x
-@@ -20,7 +24,6 @@ struct test_case {
+@@ -20,7 +20,9 @@ struct test_case {
  } tcases[] = {
  	{ "len == -1", TST_VALID_DOMAIN_NAME, -1, ERRNO_DESC(EINVAL) },
  	{ "len > allowed maximum", TST_VALID_DOMAIN_NAME, MAX_NAME_LENGTH + 1, ERRNO_DESC(EINVAL) },
 -	{ "name == NULL", NULL, MAX_NAME_LENGTH, ERRNO_DESC(EFAULT) }
++//TODO: uncomment below 1 line after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//	{ "name == NULL", NULL, MAX_NAME_LENGTH, ERRNO_DESC(EFAULT) }
  };
  
  void verify_setdomainname(unsigned int nr)

--- a/tests/ltp/patches/setsockopt01.patch
+++ b/tests/ltp/patches/setsockopt01.patch
@@ -1,0 +1,30 @@
+diff --git a/testcases/kernel/syscalls/setsockopt/setsockopt01.c b/testcases/kernel/syscalls/setsockopt/setsockopt01.c
+index 743c6be14..db9bf8f03 100644
+--- a/testcases/kernel/syscalls/setsockopt/setsockopt01.c
++++ b/testcases/kernel/syscalls/setsockopt/setsockopt01.c
+@@ -17,6 +17,10 @@
+  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ /*
+  * Test Name: setsockopt01
+  *
+@@ -93,14 +97,6 @@ struct test_case_t {		/* test case structure */
+ 		    sizeof(fsin1), -1, ENOTSOCK, setup0, cleanup0,
+ 		    "bad file descriptor"}
+ 	,
+-#if !defined(UCLINUX)
+-	{
+-	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, 0,
+-		    sizeof(optval), (struct sockaddr *)&fsin1,
+-		    sizeof(fsin1), -1, EFAULT, setup1, cleanup1,
+-		    "invalid option buffer"}
+-	,
+-#endif
+ 	{
+ 	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,
+ 		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,

--- a/tests/ltp/patches/setsockopt01.patch
+++ b/tests/ltp/patches/setsockopt01.patch
@@ -1,19 +1,10 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/setsockopt/setsockopt01.c b/testcases/kernel/syscalls/setsockopt/setsockopt01.c
-index 743c6be14..db9bf8f03 100644
+index 743c6be14..45fdccc1c 100644
 --- a/testcases/kernel/syscalls/setsockopt/setsockopt01.c
 +++ b/testcases/kernel/syscalls/setsockopt/setsockopt01.c
-@@ -17,6 +17,10 @@
-  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-  */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- /*
-  * Test Name: setsockopt01
-  *
-@@ -93,14 +97,6 @@ struct test_case_t {		/* test case structure */
+@@ -93,14 +93,16 @@ struct test_case_t {		/* test case structure */
  		    sizeof(fsin1), -1, ENOTSOCK, setup0, cleanup0,
  		    "bad file descriptor"}
  	,
@@ -25,6 +16,16 @@ index 743c6be14..db9bf8f03 100644
 -		    "invalid option buffer"}
 -	,
 -#endif
++//TODO: uncomment below 8 lines after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//#if !defined(UCLINUX)
++//	{
++//	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, 0,
++//		    sizeof(optval), (struct sockaddr *)&fsin1,
++//		    sizeof(fsin1), -1, EFAULT, setup1, cleanup1,
++//		    "invalid option buffer"}
++//	,
++//#endif
  	{
  	PF_INET, SOCK_STREAM, 0, SOL_SOCKET, SO_OOBINLINE, &optval, 0,
  		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,

--- a/tests/ltp/patches/socketpair01.patch
+++ b/tests/ltp/patches/socketpair01.patch
@@ -1,0 +1,26 @@
+diff --git a/testcases/kernel/syscalls/socketpair/socketpair01.c b/testcases/kernel/syscalls/socketpair/socketpair01.c
+index 7c301f681..ab938e4d5 100644
+--- a/testcases/kernel/syscalls/socketpair/socketpair01.c
++++ b/testcases/kernel/syscalls/socketpair/socketpair01.c
+@@ -10,6 +10,10 @@
+ * Verify that socketpair() returns the proper errno for various failure cases
+ */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <errno.h>
+@@ -34,10 +38,6 @@ struct test_case_t {
+ 	{PF_INET, 75, 0, fds, -1, EINVAL, "invalid type"},
+ 	{PF_UNIX, SOCK_DGRAM, 0, fds, 0, 0, "UNIX domain dgram"},
+ 	{PF_INET, SOCK_RAW, 0, fds, -1, EPROTONOSUPPORT, "raw open as non-root"},
+-#ifndef UCLINUX
+-	{PF_UNIX, SOCK_STREAM, 0, 0, -1, EFAULT, "bad aligned pointer"},
+-	{PF_UNIX, SOCK_STREAM, 0, (int *)7, -1, EFAULT, "bad unaligned pointer"},
+-#endif
+ 	{PF_INET, SOCK_DGRAM, 17, fds, -1, EOPNOTSUPP, "UDP socket"},
+ 	{PF_INET, SOCK_DGRAM, 6, fds, -1, EPROTONOSUPPORT, "TCP dgram"},
+ 	{PF_INET, SOCK_STREAM, 6, fds, -1, EOPNOTSUPP, "TCP socket"},

--- a/tests/ltp/patches/socketpair01.patch
+++ b/tests/ltp/patches/socketpair01.patch
@@ -1,19 +1,10 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/socketpair/socketpair01.c b/testcases/kernel/syscalls/socketpair/socketpair01.c
-index 7c301f681..ab938e4d5 100644
+index 7c301f681..9a3fca5e3 100644
 --- a/testcases/kernel/syscalls/socketpair/socketpair01.c
 +++ b/testcases/kernel/syscalls/socketpair/socketpair01.c
-@@ -10,6 +10,10 @@
- * Verify that socketpair() returns the proper errno for various failure cases
- */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- #include <stdio.h>
- #include <unistd.h>
- #include <errno.h>
-@@ -34,10 +38,6 @@ struct test_case_t {
+@@ -34,10 +34,12 @@ struct test_case_t {
  	{PF_INET, 75, 0, fds, -1, EINVAL, "invalid type"},
  	{PF_UNIX, SOCK_DGRAM, 0, fds, 0, 0, "UNIX domain dgram"},
  	{PF_INET, SOCK_RAW, 0, fds, -1, EPROTONOSUPPORT, "raw open as non-root"},
@@ -21,6 +12,12 @@ index 7c301f681..ab938e4d5 100644
 -	{PF_UNIX, SOCK_STREAM, 0, 0, -1, EFAULT, "bad aligned pointer"},
 -	{PF_UNIX, SOCK_STREAM, 0, (int *)7, -1, EFAULT, "bad unaligned pointer"},
 -#endif
++//TODO: uncomment below 4 lines after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//#ifndef UCLINUX
++//	{PF_UNIX, SOCK_STREAM, 0, 0, -1, EFAULT, "bad aligned pointer"},
++//	{PF_UNIX, SOCK_STREAM, 0, (int *)7, -1, EFAULT, "bad unaligned pointer"},
++//#endif
  	{PF_INET, SOCK_DGRAM, 17, fds, -1, EOPNOTSUPP, "UDP socket"},
  	{PF_INET, SOCK_DGRAM, 6, fds, -1, EPROTONOSUPPORT, "TCP dgram"},
  	{PF_INET, SOCK_STREAM, 6, fds, -1, EOPNOTSUPP, "TCP socket"},

--- a/tests/ltp/patches/sockioctl01.patch
+++ b/tests/ltp/patches/sockioctl01.patch
@@ -1,19 +1,10 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/sockioctl/sockioctl01.c b/testcases/kernel/syscalls/sockioctl/sockioctl01.c
-index 486236af9..918efb572 100644
+index 486236af9..2d3332b04 100644
 --- a/testcases/kernel/syscalls/sockioctl/sockioctl01.c
 +++ b/testcases/kernel/syscalls/sockioctl/sockioctl01.c
-@@ -17,6 +17,10 @@
-  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-  */
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- /*
-  * Test Name: sockioctl01
-  *
-@@ -87,13 +91,6 @@ struct test_case_t {
+@@ -87,13 +87,15 @@ struct test_case_t {
  		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
  		    EINVAL, setup0, cleanup0, "not a socket"}
  	,
@@ -24,10 +15,19 @@ index 486236af9..918efb572 100644
 -		    EFAULT, setup1, cleanup1, "invalid option buffer"}
 -	,
 -#endif
++//TODO: uncomment below 7 lines after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//#if !defined(UCLINUX)
++//	{
++//	PF_INET, SOCK_STREAM, 0, SIOCATMARK, 0,
++//		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
++//		    EFAULT, setup1, cleanup1, "invalid option buffer"}
++//	,
++//#endif
  	{
  	PF_INET, SOCK_DGRAM, 0, SIOCATMARK, &optval,
  		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
-@@ -106,14 +103,6 @@ struct test_case_t {
+@@ -106,14 +108,16 @@ struct test_case_t {
  	PF_INET, SOCK_DGRAM, 0, SIOCGIFFLAGS, &ifr,
  		    (struct sockaddr *)&fsin1, sizeof(fsin1), 0,
  		    0, setup3, cleanup1, "SIOCGIFFLAGS"}
@@ -39,6 +39,16 @@ index 486236af9..918efb572 100644
 -	PF_INET, SOCK_DGRAM, 0, SIOCSIFFLAGS, 0,
 -		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
 -		    EFAULT, setup3, cleanup1, "SIOCSIFFLAGS with invalid ifr"}
++//TODO: uncomment below 8 lines after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//	, {
++//	PF_INET, SOCK_DGRAM, 0, SIOCGIFFLAGS, 0,
++//		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
++//		    EFAULT, setup3, cleanup1, "SIOCGIFFLAGS with invalid ifr"}
++//	, {
++//	PF_INET, SOCK_DGRAM, 0, SIOCSIFFLAGS, 0,
++//		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
++//		    EFAULT, setup3, cleanup1, "SIOCSIFFLAGS with invalid ifr"}
  ,};
  
  int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);

--- a/tests/ltp/patches/sockioctl01.patch
+++ b/tests/ltp/patches/sockioctl01.patch
@@ -1,0 +1,44 @@
+diff --git a/testcases/kernel/syscalls/sockioctl/sockioctl01.c b/testcases/kernel/syscalls/sockioctl/sockioctl01.c
+index 486236af9..918efb572 100644
+--- a/testcases/kernel/syscalls/sockioctl/sockioctl01.c
++++ b/testcases/kernel/syscalls/sockioctl/sockioctl01.c
+@@ -17,6 +17,10 @@
+  *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ /*
+  * Test Name: sockioctl01
+  *
+@@ -87,13 +91,6 @@ struct test_case_t {
+ 		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+ 		    EINVAL, setup0, cleanup0, "not a socket"}
+ 	,
+-#if !defined(UCLINUX)
+-	{
+-	PF_INET, SOCK_STREAM, 0, SIOCATMARK, 0,
+-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+-		    EFAULT, setup1, cleanup1, "invalid option buffer"}
+-	,
+-#endif
+ 	{
+ 	PF_INET, SOCK_DGRAM, 0, SIOCATMARK, &optval,
+ 		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+@@ -106,14 +103,6 @@ struct test_case_t {
+ 	PF_INET, SOCK_DGRAM, 0, SIOCGIFFLAGS, &ifr,
+ 		    (struct sockaddr *)&fsin1, sizeof(fsin1), 0,
+ 		    0, setup3, cleanup1, "SIOCGIFFLAGS"}
+-	, {
+-	PF_INET, SOCK_DGRAM, 0, SIOCGIFFLAGS, 0,
+-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+-		    EFAULT, setup3, cleanup1, "SIOCGIFFLAGS with invalid ifr"}
+-	, {
+-	PF_INET, SOCK_DGRAM, 0, SIOCSIFFLAGS, 0,
+-		    (struct sockaddr *)&fsin1, sizeof(fsin1), -1,
+-		    EFAULT, setup3, cleanup1, "SIOCSIFFLAGS with invalid ifr"}
+ ,};
+ 
+ int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);

--- a/tests/ltp/patches/timer_gettime01.patch
+++ b/tests/ltp/patches/timer_gettime01.patch
@@ -1,0 +1,29 @@
+diff --git a/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c b/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
+index 1c75f1cf0..d4fd7e10e 100644
+--- a/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
++++ b/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
+@@ -32,6 +32,10 @@
+ char *TCID = "timer_gettime01";
+ int TST_TOTAL = 3;
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ static void cleanup(void)
+ {
+ 	tst_rmdir();
+@@ -82,13 +86,6 @@ int main(int ac, char **av)
+ 			         "timer_gettime(-1) = %li", TEST_RETURN);
+ 		}
+ 
+-		TEST(ltp_syscall(__NR_timer_gettime, timer, NULL));
+-		if (TEST_RETURN == -1 && TEST_ERRNO == EFAULT) {
+-			tst_resm(TPASS,	"timer_gettime(NULL) Failed: EFAULT");
+-		} else {
+-			tst_resm(TFAIL | TERRNO,
+-			         "timer_gettime(-1) = %li", TEST_RETURN);
+-		}
+ 	}
+ 
+ 	cleanup();

--- a/tests/ltp/patches/timer_gettime01.patch
+++ b/tests/ltp/patches/timer_gettime01.patch
@@ -1,19 +1,10 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c b/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
-index 1c75f1cf0..d4fd7e10e 100644
+index 1c75f1cf0..e6dee6eca 100644
 --- a/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
 +++ b/testcases/kernel/syscalls/timer_gettime/timer_gettime01.c
-@@ -32,6 +32,10 @@
- char *TCID = "timer_gettime01";
- int TST_TOTAL = 3;
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- static void cleanup(void)
- {
- 	tst_rmdir();
-@@ -82,13 +86,6 @@ int main(int ac, char **av)
+@@ -82,13 +82,15 @@ int main(int ac, char **av)
  			         "timer_gettime(-1) = %li", TEST_RETURN);
  		}
  
@@ -24,6 +15,15 @@ index 1c75f1cf0..d4fd7e10e 100644
 -			tst_resm(TFAIL | TERRNO,
 -			         "timer_gettime(-1) = %li", TEST_RETURN);
 -		}
++//TODO: uncomment below 7 lines after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//		TEST(ltp_syscall(__NR_timer_gettime, timer, NULL));
++//		if (TEST_RETURN == -1 && TEST_ERRNO == EFAULT) {
++//			tst_resm(TPASS,	"timer_gettime(NULL) Failed: EFAULT");
++//		} else {
++//			tst_resm(TFAIL | TERRNO,
++//			         "timer_gettime(-1) = %li", TEST_RETURN);
++//		}
  	}
  
  	cleanup();

--- a/tests/ltp/patches/utimes01.patch
+++ b/tests/ltp/patches/utimes01.patch
@@ -1,0 +1,23 @@
+diff --git a/testcases/kernel/syscalls/utimes/utimes01.c b/testcases/kernel/syscalls/utimes/utimes01.c
+index 2bfc1654b..ed9e12804 100644
+--- a/testcases/kernel/syscalls/utimes/utimes01.c
++++ b/testcases/kernel/syscalls/utimes/utimes01.c
+@@ -40,6 +40,10 @@ static struct timeval a_tv[2] = { {0, 0}, {1000, 0} };
+ static struct timeval m_tv[2] = { {1000, 0}, {0, 0} };
+ static struct timeval tv[2] = { {1000, 0}, {2000, 0} };
+ 
++/* Patch to remove the EFAULT related sub test as it currently causes
++ * enclave abort due to a product issue 169
++ */
++
+ static struct tcase {
+ 	char *pathname;
+ 	struct timeval *times;
+@@ -49,7 +53,6 @@ static struct tcase {
+ 	{ TESTFILE1, m_tv, 0 },
+ 	{ TESTFILE2, NULL, EACCES },
+ 	{ "notexistfile", tv, ENOENT },
+-	{ NULL, tv, EFAULT },
+ 	{ TESTFILE2, tv, EPERM },
+ 	{ TESTFILE3, tv, EROFS },
+ };

--- a/tests/ltp/patches/utimes01.patch
+++ b/tests/ltp/patches/utimes01.patch
@@ -1,23 +1,17 @@
++ Patch to remove the EFAULT related sub test as it currently causes
++ enclave abort due to a product issue 169
 diff --git a/testcases/kernel/syscalls/utimes/utimes01.c b/testcases/kernel/syscalls/utimes/utimes01.c
-index 2bfc1654b..ed9e12804 100644
+index 2bfc1654b..22884e9c1 100644
 --- a/testcases/kernel/syscalls/utimes/utimes01.c
 +++ b/testcases/kernel/syscalls/utimes/utimes01.c
-@@ -40,6 +40,10 @@ static struct timeval a_tv[2] = { {0, 0}, {1000, 0} };
- static struct timeval m_tv[2] = { {1000, 0}, {0, 0} };
- static struct timeval tv[2] = { {1000, 0}, {2000, 0} };
- 
-+/* Patch to remove the EFAULT related sub test as it currently causes
-+ * enclave abort due to a product issue 169
-+ */
-+
- static struct tcase {
- 	char *pathname;
- 	struct timeval *times;
-@@ -49,7 +53,6 @@ static struct tcase {
+@@ -49,7 +49,9 @@ static struct tcase {
  	{ TESTFILE1, m_tv, 0 },
  	{ TESTFILE2, NULL, EACCES },
  	{ "notexistfile", tv, ENOENT },
 -	{ NULL, tv, EFAULT },
++//TODO: uncomment below 1 line after fixing github issue 169.
++//url: https://github.com/lsds/sgx-lkl/issues/169
++//	{ NULL, tv, EFAULT },
  	{ TESTFILE2, tv, EPERM },
  	{ TESTFILE3, tv, EROFS },
  };


### PR DESCRIPTION
Issue: These tests are failing while trying to access a fault address as part of subtests. Currently sgx behaviour is to call enclave abort for fault address. This is being addressed in product issue 169.
Solution: Disable the EFAULT related subtests for these tests so rest can proceed. 