### PR TITLE
Move the LKL host layer to using OE malloc.

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -23,6 +23,7 @@
 #include "enclave/sgxlkl_t.h"
 #include "lkl/iomem.h"
 #include "lkl/jmp_buf.h"
+#include "openenclave/corelibc/oemalloc.h"
 #include "openenclave/internal/print.h"
 #include "syscall.h"
 
@@ -189,7 +190,7 @@ static struct lkl_sem* sem_alloc(int count)
 {
     struct lkl_sem* sem;
 
-    sem = calloc(1, sizeof(*sem));
+    sem = oe_calloc(1, sizeof(*sem));
     if (!sem)
         return NULL;
 
@@ -200,7 +201,7 @@ static struct lkl_sem* sem_alloc(int count)
 
 static void sem_free(struct lkl_sem* sem)
 {
-    free(sem);
+    oe_free(sem);
 }
 
 static void sem_up(struct lkl_sem* sem)
@@ -237,7 +238,7 @@ static void sem_down(struct lkl_sem* sem)
 
 static struct lkl_mutex* mutex_alloc(int recursive)
 {
-    struct lkl_mutex* mutex = calloc(1, sizeof(struct lkl_mutex));
+    struct lkl_mutex* mutex = oe_calloc(1, sizeof(struct lkl_mutex));
 
     if (!mutex)
         return NULL;
@@ -309,7 +310,7 @@ static void mutex_unlock(struct lkl_mutex* mutex)
 
 static void mutex_free(struct lkl_mutex* _mutex)
 {
-    free(_mutex);
+    oe_free(_mutex);
 }
 
 static lkl_thread_t thread_create(void (*fn)(void*), void* arg)
@@ -420,11 +421,11 @@ static int thread_equal(lkl_thread_t a, lkl_thread_t b)
 static struct lkl_tls_key* tls_alloc(void (*destructor)(void*))
 {
     LKL_TRACE("enter (destructor=%p)\n", destructor);
-    struct lkl_tls_key* ret = malloc(sizeof(struct lkl_tls_key));
+    struct lkl_tls_key* ret = oe_malloc(sizeof(struct lkl_tls_key));
 
     if (WARN_PTHREAD(lthread_key_create(&ret->key, destructor)))
     {
-        free(ret);
+        oe_free(ret);
         return NULL;
     }
     return ret;
@@ -434,7 +435,7 @@ static void tls_free(struct lkl_tls_key* key)
 {
     LKL_TRACE("enter (key=%p)\n", key);
     WARN_PTHREAD(lthread_key_delete(key->key));
-    free(key);
+    oe_free(key);
 }
 
 static int tls_set(struct lkl_tls_key* key, void* data)
@@ -536,7 +537,7 @@ static void* timer_callback(void* _timer)
 
 static void* timer_alloc(void (*fn)(void*), void* arg)
 {
-    sgxlkl_timer* timer = calloc(sizeof(*timer), 1);
+    sgxlkl_timer* timer = oe_calloc(sizeof(*timer), 1);
 
     if (timer == NULL)
     {
@@ -633,12 +634,60 @@ static void timer_free(void* _timer)
         mutex_unlock(&timer->mtx);
     }
 
-    free(_timer);
+    oe_free(_timer);
 }
 
 static long _gettid(void)
 {
     return (long)lthread_self();
+}
+
+/**
+ * The allocation for kernel memory.
+ */
+static void *kernel_mem;
+/**
+ * The size of kernel heap area.
+ */
+static size_t kernel_mem_size;
+
+/**
+ * Allocate memory for LKL.  This is used in precisely two places as we build
+ * LKL:
+ *
+ * 1. Allocating the kernel's memory.
+ * 2. Allocating buffers for lkl_vprintf to use printing debug messages.
+ *
+ * We allocate the former from the `enclave_mmap` space, but smaller buffers
+ * from the OE heap.
+ */
+static void *host_malloc(size_t size)
+{
+	// If we're allocating over 1MB, we're probably allocating the kernel heap.
+	// Pull this out of the enclave mmap area: there isn't enough space in the
+	// OE heap for it.
+	if (size > 1024*1024)
+	{
+		SGXLKL_ASSERT(kernel_mem == NULL);
+		kernel_mem = enclave_mmap(0, size, 0, PROT_READ | PROT_WRITE, 0);
+		kernel_mem_size = size;
+		return kernel_mem;
+	}
+	return oe_malloc(size);
+}
+
+/**
+ * Free memory allocated with `host_malloc`.
+ */
+static void host_free(void *ptr)
+{
+	if (ptr == kernel_mem)
+	{
+		enclave_munmap(kernel_mem, kernel_mem_size);
+		kernel_mem = 0;
+		kernel_mem_size = 0;
+	}
+	oe_free(ptr);
 }
 
 struct lkl_host_operations sgxlkl_host_ops = {
@@ -669,8 +718,8 @@ struct lkl_host_operations sgxlkl_host_ops = {
     .timer_set_oneshot = timer_set_oneshot,
     .timer_free = timer_free,
     .print = print,
-    .mem_alloc = malloc,
-    .mem_free = free,
+    .mem_alloc = host_malloc,
+    .mem_free = host_free,
     .ioremap = lkl_ioremap,
     .iomem_access = lkl_iomem_access,
     .virtio_devices = lkl_virtio_devs,


### PR DESCRIPTION
I tried this previously, but reverted it because of crashes.  The
crashes were caused by the fact that LKL allocate memory for the kernel
and for `lkl_vprintf` buffers.  The former is larger than the OE heap,
so fails, resulting in LKL refusing to start.  To avoid this, assume
that there is only going to be one allocation > 1MiB and that this is
the kernel heap.  Special case it and provide it via `enclave_mmap`,
forward everything else to `oe_malloc`.  Other structures should be safe
to allocate via `oe_malloc`.