### PR TITLE
Move enclave_util.* into lkl

### DIFF
--- a/src/enclave/enclave_event_channel.c
+++ b/src/enclave/enclave_event_channel.c
@@ -5,7 +5,7 @@
 
 #include <lkl/virtio.h>
 
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/lthread.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/ticketlock.h"

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -13,7 +13,7 @@
 #include "openenclave/corelibc/oestring.h"
 
 #include "enclave/enclave_mem.h"
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/lthread.h"
 #include "enclave/sgxlkl_app_config.h"
 #include "enclave/sgxlkl_config.h"

--- a/src/enclave/enclave_mem.c
+++ b/src/enclave/enclave_mem.c
@@ -13,7 +13,7 @@
 #include "shared/bitops.h"
 
 #include "enclave/enclave_mem.h"
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/ticketlock.h"
 #include "enclave/sgxlkl_config.h"
 

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -6,7 +6,7 @@
 
 #include "enclave/enclave_oe.h"
 #include "enclave/enclave_signal.h"
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_config.h"
 #include "shared/env.h"
 

--- a/src/enclave/enclave_signal.c
+++ b/src/enclave/enclave_signal.c
@@ -1,7 +1,7 @@
 #include <openenclave/enclave.h>
 #include "openenclave/internal/calls.h"
 
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 
 #include <signal.h>
 #include <asm/sigcontext.h>

--- a/src/enclave/enclave_timer.c
+++ b/src/enclave/enclave_timer.c
@@ -1,7 +1,7 @@
 #include <host/sgxlkl_util.h>
 #include <stdatomic.h>
 #include <time.h>
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_config.h"
 #include "enclave/sgxlkl_t.h"
 

--- a/src/enclave/sgxlkl_app_config.c
+++ b/src/enclave/sgxlkl_app_config.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_app_config.h"
 #include "enclave/sgxlkl_config.h"
 #include "shared/env.h"

--- a/src/enclave/sgxlkl_config.c
+++ b/src/enclave/sgxlkl_config.c
@@ -1,6 +1,6 @@
 #include <string.h>
 
-#include <enclave/enclave_util.h>
+#include <lkl/lkl_util.h>
 #include <shared/sgxlkl_config.h>
 #include "openenclave/corelibc/oemalloc.h"
 

--- a/src/include/lkl/lkl_util.h
+++ b/src/include/lkl/lkl_util.h
@@ -1,5 +1,5 @@
-#ifndef _ENCLAVE_UTIL_H
-#define _ENCLAVE_UTIL_H
+#ifndef _LKL_UTIL_H
+#define _LKL_UTIL_H
 
 #include <openenclave/enclave.h>
 
@@ -126,4 +126,4 @@ extern int sgxlkl_trace_redirect_syscall;
 #define SGXLKL_TRACE_SYSCALL(x, ...)
 #endif
 
-#endif /* _ENCLAVE_UTIL_H */
+#endif /* _LKL_UTIL_H */

--- a/src/lkl/ext4_create.c
+++ b/src/lkl/ext4_create.c
@@ -8,7 +8,7 @@
 typedef long errcode_t;
 #include <ext2fs/ext2fs.h>
 
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "lkl/ext4_create.h"
 
 #define HANDLE_ERR(fn_name)                       \

--- a/src/lkl/lkl_util.c
+++ b/src/lkl/lkl_util.c
@@ -1,4 +1,4 @@
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 
 #include <stdarg.h>
 #include <stdlib.h>

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -20,7 +20,7 @@
 #include <lkl_host.h>
 #include <unistd.h>
 
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/wireguard.h"
 #include "enclave/wireguard_util.h"
@@ -37,7 +37,7 @@
 #include "libcryptsetup.h"
 #include "libdevmapper.h"
 
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_config.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/wireguard.h"

--- a/src/lkl/syscall-overrides-futex.c
+++ b/src/lkl/syscall-overrides-futex.c
@@ -1,7 +1,7 @@
 #include <futex.h>
 #include <sys/time.h>
 #include <time.h>
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "lkl/posix-host.h"
 #include "sched/futex.h"
 

--- a/src/lkl/virtio.c
+++ b/src/lkl/virtio.c
@@ -8,7 +8,7 @@
 #include <lkl/iomem.h>
 #include <lkl/virtio.h>
 #include <enclave/sgxlkl_t.h>
-#include <enclave/enclave_util.h>
+#include <lkl/lkl_util.h>
 #include <shared/virtio_ring_buff.h>
 #include "enclave/vio_enclave_event_channel.h"
 #include <linux/virtio_blk.h>
@@ -70,7 +70,7 @@ static int virtio_read(void* data, int offset, void* res, int size)
         memcpy(res, dev->config_data + offset, size);
         return 0;
     }
-    
+
     if (size != sizeof(uint32_t))
         return -LKL_EINVAL;
 

--- a/src/lkl/virtio_blkdev.c
+++ b/src/lkl/virtio_blkdev.c
@@ -1,7 +1,7 @@
 #include <errno.h>
 #include <linux/virtio_mmio.h>
 #include <string.h>
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_config.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/ticketlock.h"

--- a/src/lkl/virtio_console.c
+++ b/src/lkl/virtio_console.c
@@ -3,7 +3,7 @@
 #include <errno.h>
 #include <linux/virtio_mmio.h>
 #include <string.h>
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/sgxlkl_config.h"
 #include "enclave/ticketlock.h"

--- a/src/lkl/virtio_netdev.c
+++ b/src/lkl/virtio_netdev.c
@@ -3,7 +3,7 @@
 #include <errno.h>
 #include <linux/virtio_mmio.h>
 #include <string.h>
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_config.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/ticketlock.h"

--- a/src/sched/futex.c
+++ b/src/sched/futex.c
@@ -7,7 +7,7 @@
 
 #include <enclave/lthread.h>
 #include <enclave/ticketlock.h>
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/enclave_timer.h"
 

--- a/src/wireguard/wireguard_util.c
+++ b/src/wireguard/wireguard_util.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "enclave/enclave_util.h"
+#include "lkl/lkl_util.h"
 #include "enclave/wireguard.h"
 #include "shared/sgxlkl_config.h"
 


### PR DESCRIPTION
This is part of the work on #151. All the functionality is lkl rather
than enclave specific. This move removes some libc dependencies from
the enclave.