### PR TITLE
Replace snprintf usage in enclave with oe_snprintf

### DIFF
--- a/src/enclave/enclave_util.c
+++ b/src/enclave/enclave_util.c
@@ -1,8 +1,6 @@
 #include "enclave/enclave_util.h"
 
-#include <stdarg.h>
-#include <stdlib.h>
-
+#include "openenclave/corelibc/oestdio.h"
 #include "openenclave/internal/print.h"
 
 #define OE_STDERR_FILENO 1
@@ -86,54 +84,54 @@ static void parse_epoll_event_flags(
     size_t written = 0;
     if (evt->events & EPOLLIN)
     {
-        written = snprintf(buf, buf_len - written, "EPOLLIN");
+        written = oe_snprintf(buf, buf_len - written, "EPOLLIN");
         buf += written;
     }
     if (evt->events & EPOLLOUT)
     {
-        written =
-            snprintf(buf, buf_len - written, "%sEPOLLOUT", written ? "|" : "");
+        written = oe_snprintf(
+            buf, buf_len - written, "%sEPOLLOUT", written ? "|" : "");
         buf += written;
     }
     if (evt->events & EPOLLRDHUP)
     {
-        written = snprintf(
+        written = oe_snprintf(
             buf, buf_len - written, "%sEPOLLRDHUP", written ? "|" : "");
         buf += written;
     }
     if (evt->events & EPOLLPRI)
     {
-        written =
-            snprintf(buf, buf_len - written, "%sEPOLLPRI", written ? "|" : "");
+        written = oe_snprintf(
+            buf, buf_len - written, "%sEPOLLPRI", written ? "|" : "");
         buf += written;
     }
     if (evt->events & EPOLLERR)
     {
-        written =
-            snprintf(buf, buf_len - written, "%sEPOLLERR", written ? "|" : "");
+        written = oe_snprintf(
+            buf, buf_len - written, "%sEPOLLERR", written ? "|" : "");
         buf += written;
     }
     if (evt->events & EPOLLHUP)
     {
-        written =
-            snprintf(buf, buf_len - written, "%sEPOLLHUP", written ? "|" : "");
+        written = oe_snprintf(
+            buf, buf_len - written, "%sEPOLLHUP", written ? "|" : "");
         buf += written;
     }
     if (evt->events & EPOLLET)
     {
-        written =
-            snprintf(buf, buf_len - written, "%sEPOLLET", written ? "|" : "");
+        written = oe_snprintf(
+            buf, buf_len - written, "%sEPOLLET", written ? "|" : "");
         buf += written;
     }
     if (evt->events & EPOLLONESHOT)
     {
-        written = snprintf(
+        written = oe_snprintf(
             buf, buf_len - written, "%sEPOLLONESHOT", written ? "|" : "");
         buf += written;
     }
     if (evt->events & EPOLLWAKEUP)
     {
-        written = snprintf(
+        written = oe_snprintf(
             buf, buf_len - written, "%sEPOLLWAKEUP", written ? "|" : "");
         buf += written;
     }
@@ -179,7 +177,7 @@ void __sgxlkl_log_syscall(int type, long n, long res, int params_len, ...)
     if (name == NULL)
         name = "### INVALID ###";
     if (res < 0)
-        snprintf(errmsg, sizeof(errmsg), " (%s) <--- !", lkl_strerror(res));
+        oe_snprintf(errmsg, sizeof(errmsg), " (%s) <--- !", lkl_strerror(res));
 
     int tid = lthread_self() ? lthread_self()->tid : 0;
     if (type == SGXLKL_REDIRECT_SYSCALL)

--- a/src/enclave/sgxlkl_app_config.c
+++ b/src/enclave/sgxlkl_app_config.c
@@ -1,6 +1,5 @@
 #include <errno.h>
 #include <json-c/json_object.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "enclave/enclave_util.h"
@@ -10,6 +9,7 @@
 #include "shared/json_util.h"
 
 #include "openenclave/corelibc/oemalloc.h"
+#include "openenclave/corelibc/oestdio.h"
 #include "openenclave/corelibc/oestring.h"
 
 static const char* STRING_KEYS[] = {"run",
@@ -99,7 +99,7 @@ static int parse_env(sgxlkl_app_config_t* config, struct json_object* env_val)
         if (!env_kv)
             sgxlkl_fail(
                 "Failed to allocate memory for environment key value pair.\n");
-        snprintf(env_kv, kv_len, "%s=%s", key, str_val);
+        oe_snprintf(env_kv, kv_len, "%s=%s", key, str_val);
         config->envp[i++] = env_kv;
     }
 

--- a/src/include/openenclave/corelibc/oestdio.h
+++ b/src/include/openenclave/corelibc/oestdio.h
@@ -1,0 +1,6 @@
+#ifndef __OE_STDIO_INCLUDED__
+#define __OE_STDIO_INCLUDED__
+
+int oe_snprintf(char* str, size_t size, const char* format, ...);
+
+#endif


### PR DESCRIPTION
This is part of the work on #151. We're removing direct libc dependencies
from src/enclave.