### PR TITLE
Remove libc dependencies from enclave/sgxlkl_app_config

### DIFF
--- a/src/enclave/sgxlkl_app_config.c
+++ b/src/enclave/sgxlkl_app_config.c
@@ -11,6 +11,7 @@
 #include "openenclave/corelibc/oemalloc.h"
 #include "openenclave/corelibc/oestdio.h"
 #include "openenclave/corelibc/oestring.h"
+#include "openenclave/internal/safecrt.h"
 
 static const char* STRING_KEYS[] = {"run",
                                     "cwd",
@@ -28,19 +29,19 @@ static int assert_entry_type(const char* key, struct json_object* value)
 {
     int err = 0;
     for (int i = 0; i < sizeof(STRING_KEYS) / sizeof(STRING_KEYS[0]); i++)
-        if (!strcmp(STRING_KEYS[i], key))
+        if (!oe_strcmp(STRING_KEYS[i], key))
             err = json_object_get_type(value) != json_type_string;
 
     for (int i = 0; i < sizeof(BOOL_KEYS) / sizeof(BOOL_KEYS[0]); i++)
-        if (!strcmp(BOOL_KEYS[i], key))
+        if (!oe_strcmp(BOOL_KEYS[i], key))
             err = json_object_get_type(value) != json_type_boolean;
 
     for (int i = 0; i < sizeof(INT_KEYS) / sizeof(INT_KEYS[0]); i++)
-        if (!strcmp(INT_KEYS[i], key))
+        if (!oe_strcmp(INT_KEYS[i], key))
             err = json_object_get_type(value) != json_type_int;
 
     for (int i = 0; i < sizeof(ARRAY_KEYS) / sizeof(ARRAY_KEYS[0]); i++)
-        if (!strcmp(ARRAY_KEYS[i], key))
+        if (!oe_strcmp(ARRAY_KEYS[i], key))
             err = json_object_get_type(value) != json_type_array;
 
     if (err)
@@ -94,7 +95,7 @@ static int parse_env(sgxlkl_app_config_t* config, struct json_object* env_val)
             return 1;
         const char* str_val = json_object_get_string(val);
         size_t kv_len =
-            strlen(key) + strlen(str_val) + 2 /* for '=' and '\0' */;
+            oe_strlen(key) + oe_strlen(str_val) + 2 /* for '=' and '\0' */;
         char* env_kv = oe_malloc(kv_len);
         if (!env_kv)
             sgxlkl_fail(
@@ -117,17 +118,21 @@ static int parse_enclave_disk_config_entry(
     if (assert_entry_type(key, value))
         return 1;
 
-    if (!strcmp("disk", key))
+    if (!oe_strcmp("disk", key))
     {
         const char* mnt_point = json_object_get_string(value);
-        if (strlen(mnt_point) > SGXLKL_DISK_MNT_MAX_PATH_LEN)
+        if (oe_strlen(mnt_point) > SGXLKL_DISK_MNT_MAX_PATH_LEN)
             sgxlkl_warn(
                 "Truncating configured disk mount point...\n"); // TODO pass
                                                                 // back to
                                                                 // client.
-        strncpy(disk->mnt, mnt_point, SGXLKL_DISK_MNT_MAX_PATH_LEN);
+        oe_strncpy_s(
+            disk->mnt,
+            SGXLKL_DISK_MNT_MAX_PATH_LEN + 1,
+            mnt_point,
+            SGXLKL_DISK_MNT_MAX_PATH_LEN);
     }
-    else if (!strcmp("key", key))
+    else if (!oe_strcmp("key", key))
     {
         const char* enc_key = json_object_get_string(value);
         ssize_t key_len = hex_to_bytes(enc_key, &disk->key);
@@ -139,23 +144,23 @@ static int parse_enclave_disk_config_entry(
             disk->enc = 1;
         }
     }
-    else if (!strcmp("roothash", key))
+    else if (!oe_strcmp("roothash", key))
     {
         disk->roothash = oe_strdup(json_object_get_string(value));
     }
-    else if (!strcmp("roothash_offset", key))
+    else if (!oe_strcmp("roothash_offset", key))
     {
         disk->roothash_offset = json_object_get_int64(value);
     }
-    else if (!strcmp("readonly", key))
+    else if (!oe_strcmp("readonly", key))
     {
         disk->ro = json_object_get_boolean(value);
     }
-    else if (!strcmp("create", key))
+    else if (!oe_strcmp("create", key))
     {
         disk->create = json_object_get_boolean(value);
     }
-    else if (!strcmp("size", key))
+    else if (!oe_strcmp("size", key))
     {
         disk->size = json_object_get_int64(value);
     }
@@ -216,15 +221,15 @@ static int parse_enclave_wg_peer_config_entry(
     if (assert_entry_type(key, value))
         return 1;
 
-    if (!strcmp("key", key))
+    if (!oe_strcmp("key", key))
     {
         peer->key = oe_strdup(json_object_get_string(value));
     }
-    else if (!strcmp("allowedips", key))
+    else if (!oe_strcmp("allowedips", key))
     {
         peer->allowed_ips = oe_strdup(json_object_get_string(value));
     }
-    else if (!strcmp("endpoint", key))
+    else if (!oe_strcmp("endpoint", key))
     {
         peer->endpoint = oe_strdup(json_object_get_string(value));
     }
@@ -251,7 +256,7 @@ static int parse_network(
     {
         // For now, the only acceptable field is 'peers' which is expected to
         // contain an array of wireguard peer configurations.
-        if (strcmp(key, "peers"))
+        if (oe_strcmp(key, "peers"))
             continue;
         if (assert_entry_type(key, value))
             return 1;
@@ -300,7 +305,7 @@ static int parse_sgxlkl_app_config_entry(
     int err = 0;
     sgxlkl_app_config_t* config = (sgxlkl_app_config_t*)arg;
 
-    if (!strcmp("run", key))
+    if (!oe_strcmp("run", key))
     {
         if (json_object_get_type(value) != json_type_string)
         {
@@ -309,7 +314,7 @@ static int parse_sgxlkl_app_config_entry(
         }
         config->run = oe_strdup(json_object_get_string(value));
     }
-    else if (!strcmp("cwd", key))
+    else if (!oe_strcmp("cwd", key))
     {
         if (json_object_get_type(value) != json_type_string)
         {
@@ -318,15 +323,15 @@ static int parse_sgxlkl_app_config_entry(
         }
         config->cwd = oe_strdup(json_object_get_string(value));
     }
-    else if (!strcmp("args", key))
+    else if (!oe_strcmp("args", key))
     {
         err = parse_args(config, value);
     }
-    else if (!strcmp("environment", key))
+    else if (!oe_strcmp("environment", key))
     {
         err = parse_env(config, value);
     }
-    else if (!strcmp("exit_status", key))
+    else if (!oe_strcmp("exit_status", key))
     {
         if (json_object_get_type(value) != json_type_string)
         {
@@ -334,15 +339,15 @@ static int parse_sgxlkl_app_config_entry(
                 "Appconfig error: String expected for 'exit_status'.\n");
         }
 
-        if (!strcmp("full", json_object_get_string(value)))
+        if (!oe_strcmp("full", json_object_get_string(value)))
         {
             sgxlkl_enclave->exit_status = EXIT_STATUS_FULL;
         }
-        else if (!strcmp("binary", json_object_get_string(value)))
+        else if (!oe_strcmp("binary", json_object_get_string(value)))
         {
             sgxlkl_enclave->exit_status = EXIT_STATUS_BINARY;
         }
-        else if (!strcmp("none", json_object_get_string(value)))
+        else if (!oe_strcmp("none", json_object_get_string(value)))
         {
             sgxlkl_enclave->exit_status = EXIT_STATUS_NONE;
         }
@@ -352,11 +357,11 @@ static int parse_sgxlkl_app_config_entry(
                         "\"full\"|\"binary\"|\"none\".\n");
         }
     }
-    else if (!strcmp("disk_config", key))
+    else if (!oe_strcmp("disk_config", key))
     {
         err = parse_disks(config, value);
     }
-    else if (!strcmp("network_config", key))
+    else if (!oe_strcmp("network_config", key))
     {
         err = parse_network(config, value);
     }
@@ -401,9 +406,7 @@ int validate_sgxlkl_app_config(sgxlkl_app_config_t* config)
     if (!config->argv)
     {
         if (!(config->argv = oe_malloc(sizeof(config->argv) * 2)))
-            sgxlkl_fail(
-                "Failed to allocate memory for app config argv: %s\n",
-                strerror(errno));
+            sgxlkl_fail("Failed to allocate memory for app config argv\n");
         config->argc = 1;
         config->argv[1] = NULL;
     }
@@ -411,9 +414,7 @@ int validate_sgxlkl_app_config(sgxlkl_app_config_t* config)
     if (!config->envp)
     {
         if (!(config->envp = oe_malloc(sizeof(config->envp))))
-            sgxlkl_fail(
-                "Failed to allocate memory for app config envp: %s\n",
-                strerror(errno));
+            sgxlkl_fail("Failed to allocate memory for app config envp\n");
         config->envp[0] = NULL;
     }
 

--- a/src/include/openenclave/corelibc/oestring.h
+++ b/src/include/openenclave/corelibc/oestring.h
@@ -1,6 +1,8 @@
 #ifndef __OE_STRING_INCLUDED__
 #define __OE_STRING_INCLUDED__
 
+int oe_strcmp(const char* s1, const char* s2);
 char *oe_strdup(const char *s);
+size_t oe_strlen(const char* s);
 
 #endif

--- a/src/include/openenclave/internal/safecrt.h
+++ b/src/include/openenclave/internal/safecrt.h
@@ -1,0 +1,45 @@
+// Copyright (c) Open Enclave SDK contributors.
+// Licensed under the MIT License.
+
+#ifndef _OE_SAFECRT_H
+#define _OE_SAFECRT_H
+
+#include <openenclave/bits/defs.h>
+#include <openenclave/bits/result.h>
+#include <openenclave/bits/types.h>
+
+OE_EXTERNC_BEGIN
+
+oe_result_t oe_memcpy_s(
+    void* dst,
+    size_t dst_size,
+    const void* src,
+    size_t num_bytes);
+
+oe_result_t oe_memmove_s(
+    void* dst,
+    size_t dst_size,
+    const void* src,
+    size_t num_bytes);
+
+oe_result_t oe_memset_s(
+    void* dst,
+    size_t dst_size,
+    int value,
+    size_t num_bytes);
+
+oe_result_t oe_strncat_s(
+    char* dst,
+    size_t dst_size,
+    const char* src,
+    size_t num_bytes);
+
+oe_result_t oe_strncpy_s(
+    char* dst,
+    size_t dst_size,
+    const char* src,
+    size_t num_bytes);
+
+OE_EXTERNC_END
+
+#endif // _OE_SAFECRT_H


### PR DESCRIPTION
Removes libc dependencies except for memset which would be emitted
by the compiler.
                                                                                                                                   
This is part of the work for #151