### PR TITLE
Kill hanging sgx-lkl-run-oe process to continue to test run

### DIFF
--- a/.azure-pipelines/scripts/test_utils.sh
+++ b/.azure-pipelines/scripts/test_utils.sh
@@ -25,9 +25,19 @@ function ChangeDirectory()
 
 function CheckNotRunning()
 {
-    if pgrep -x sgx-lkl-run-oe >/dev/null; then
+    process="sgx-lkl-run-oe"
+    if pgrep -x $process >/dev/null; then
         echo "SGX-LKL still running:"
-        ps -aux | grep sgx-lkl-run-oe
-        exit 1
+        ps -aux | grep $process
+        echo "Trying to kill hanging $process process"
+        pkill -9 $process
+        pkill_exit=$?
+        if [[ $pkill_exit -ne 0 ]]; then
+            echo "Failed to kill hanging $process process. Exit code: $pkill_exit"
+            exit $pkill_exit
+        else
+	    echo "Killed the hanging $process process successfully"
+	    ps -aux | grep sgx-lkl-run-oe
+        fi
     fi
 }


### PR DESCRIPTION
Fixing test issue : https://github.com/lsds/sgx-lkl/issues/336
When a test times out, it is possible that sgx-lkl-run-oe process is still running/hanging

Existing test harness logic was exiting if sgx-lkl-run-oe process exists and rest of the tests were not running. The failed/timed out test already reported. There is no point exiting test harness.

We can kill hanging process and output logs and continue running remaining tests. 

cc @letmaik  @jxyang  @SeanTAllen 