### PR TITLE
Clear the timer next value before firing the callback.

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -520,6 +520,7 @@ static void* timer_callback(void* _timer)
         // Check if the timer has triggered
         if (did_timeout)
         {
+            timer->next_delay_ns = 0;
             timer->callback_fn(timer->callback_arg);
             // If the callback function itself resets the timer,
             // timer->next_delay_ns will be non-zero.


### PR DESCRIPTION
If the timer's callback function invokes `timer_set_oneshot`, there is a
check that `next_delay_ns` is not set and we abort.

Fixes #334