### PR TITLE
Fix for fgetxattr03 and flistxattr01

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -228,8 +228,8 @@
 /ltp/testcases/kernel/syscalls/fdatasync/fdatasync03
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr01
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr02
-/ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr03
-/ltp/testcases/kernel/syscalls/flistxattr/flistxattr01
+#/ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr03
+#/ltp/testcases/kernel/syscalls/flistxattr/flistxattr01
 /ltp/testcases/kernel/syscalls/flistxattr/flistxattr02
 /ltp/testcases/kernel/syscalls/flistxattr/flistxattr03
 /ltp/testcases/kernel/syscalls/flock/flock01

--- a/tests/ltp/patches/fgetxattr03.patch
+++ b/tests/ltp/patches/fgetxattr03.patch
@@ -1,0 +1,40 @@
++ Currently xattr is not enabled while mounting root file system. Patch is
++ to mount root file system with xattr enabled and then use it for the test.
+diff --git a/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c b/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
+index d293ffca9..66394be3b 100644
+--- a/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
++++ b/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
+@@ -29,7 +29,11 @@
+ #define XATTR_TEST_KEY "user.testkey"
+ #define XATTR_TEST_VALUE "this is a test value"
+ #define XATTR_TEST_VALUE_SIZE 20
+-#define FILENAME "fgetxattr03testfile"
++#define FILENAME MNTPOINT"/fgetxattr03testfile"
++#define MNTPOINT       "mntpoint"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ static int fd = -1;
+ 
+@@ -47,6 +51,10 @@ static void verify_fgetxattr(void)
+ 
+ static void setup(void)
+ {
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++
+ 	SAFE_TOUCH(FILENAME, 0644, NULL);
+ 	fd = SAFE_OPEN(FILENAME, O_RDONLY, NULL);
+ 
+@@ -58,6 +66,9 @@ static void cleanup(void)
+ {
+ 	if (fd > 0)
+ 		SAFE_CLOSE(fd);
++	remove(FILENAME);
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
+ }
+ 
+ static struct tst_test test = {

--- a/tests/ltp/patches/fgetxattr03.patch
+++ b/tests/ltp/patches/fgetxattr03.patch
@@ -1,7 +1,7 @@
 + Currently xattr is not enabled while mounting root file system. Patch is
 + to mount root file system with xattr enabled and then use it for the test.
 diff --git a/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c b/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
-index d293ffca9..66394be3b 100644
+index d293ffca9..df4ea79f3 100644
 --- a/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
 +++ b/testcases/kernel/syscalls/fgetxattr/fgetxattr03.c
 @@ -29,7 +29,11 @@
@@ -9,7 +9,7 @@ index d293ffca9..66394be3b 100644
  #define XATTR_TEST_VALUE "this is a test value"
  #define XATTR_TEST_VALUE_SIZE 20
 -#define FILENAME "fgetxattr03testfile"
-+#define FILENAME MNTPOINT"/fgetxattr03testfile"
++#define FILENAME "mntpoint/fgetxattr03testfile"
 +#define MNTPOINT       "mntpoint"
 +#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
 +const char *device = "/dev/vda";

--- a/tests/ltp/patches/flistxattr01.patch
+++ b/tests/ltp/patches/flistxattr01.patch
@@ -1,7 +1,7 @@
 + Currently xattr is not enabled while mounting root file system. Patch is
 + to mount root file system with xattr enabled and then use it for the test.
 diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr01.c b/testcases/kernel/syscalls/flistxattr/flistxattr01.c
-index 98a6fa254..a5b8473a1 100644
+index 98a6fa254..599f3cc56 100644
 --- a/testcases/kernel/syscalls/flistxattr/flistxattr01.c
 +++ b/testcases/kernel/syscalls/flistxattr/flistxattr01.c
 @@ -13,7 +13,7 @@
@@ -31,9 +31,9 @@ index 98a6fa254..a5b8473a1 100644
  static void setup(void)
  {
 -	fd = SAFE_OPEN("testfile", O_RDWR | O_CREAT, 0644);
-+        rmdir(MNTPOINT);
-+        SAFE_MKDIR(MNTPOINT, DIR_MODE);
-+        SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
 +
 +	fd = SAFE_OPEN(TESTFILE, O_RDWR | O_CREAT, 0644);
  
@@ -43,9 +43,9 @@ index 98a6fa254..a5b8473a1 100644
  {
  	if (fd > 0)
  		SAFE_CLOSE(fd);
-+        remove(TESTFILE);
-+        SAFE_UMOUNT(MNTPOINT);
-+        SAFE_RMDIR(MNTPOINT);
++	remove(TESTFILE);
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
 +
  }
  

--- a/tests/ltp/patches/flistxattr01.patch
+++ b/tests/ltp/patches/flistxattr01.patch
@@ -1,0 +1,52 @@
++ Currently xattr is not enabled while mounting root file system. Patch is
++ to mount root file system with xattr enabled and then use it for the test.
+diff --git a/testcases/kernel/syscalls/flistxattr/flistxattr01.c b/testcases/kernel/syscalls/flistxattr/flistxattr01.c
+index 98a6fa254..a5b8473a1 100644
+--- a/testcases/kernel/syscalls/flistxattr/flistxattr01.c
++++ b/testcases/kernel/syscalls/flistxattr/flistxattr01.c
+@@ -13,7 +13,7 @@
+ * associated with the file itself in the filesystem.
+ *
+ */
+-
++#include <stdio.h>
+ #include "config.h"
+ #include <errno.h>
+ #include <sys/types.h>
+@@ -31,6 +31,12 @@
+ #define VALUE	"test"
+ #define VALUE_SIZE	(sizeof(VALUE) - 1)
+ #define KEY_SIZE    (sizeof(SECURITY_KEY1) - 1)
++#define MNTPOINT        "mntpoint"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++#define TESTFILE "mntpoint/flistxattr01testfile"
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ static int fd;
+ 
+@@ -66,7 +72,11 @@ static void verify_flistxattr(void)
+ 
+ static void setup(void)
+ {
+-	fd = SAFE_OPEN("testfile", O_RDWR | O_CREAT, 0644);
++        rmdir(MNTPOINT);
++        SAFE_MKDIR(MNTPOINT, DIR_MODE);
++        SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++
++	fd = SAFE_OPEN(TESTFILE, O_RDWR | O_CREAT, 0644);
+ 
+ 	SAFE_FSETXATTR(fd, SECURITY_KEY1, VALUE, VALUE_SIZE, XATTR_CREATE);
+ }
+@@ -75,6 +85,10 @@ static void cleanup(void)
+ {
+ 	if (fd > 0)
+ 		SAFE_CLOSE(fd);
++        remove(TESTFILE);
++        SAFE_UMOUNT(MNTPOINT);
++        SAFE_RMDIR(MNTPOINT);
++
+ }
+ 
+ static struct tst_test test = {


### PR DESCRIPTION
Issue: These tests were failing as filesystem was mounted without user_xattr
Solution: Mount filesystem to a temporary mount point with user_xattr option and use it for the tests.