### PR TITLE
Adding run-hw-single-gdb and run-sw-single-gdb to Makefile

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -56,6 +56,12 @@ run-hw-single: $(ROOT_FS)
 run-sw-single: $(ROOT_FS)
 	${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 
+run-hw-single-gdb: $(ROOT_FS)
+	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
+
+run-sw-single-gdb: $(ROOT_FS)
+	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
+
 clean:
 	@test -f $(ALPINE_TAR) && rm $(ALPINE_TAR) || true
 	@test -f $(ROOT_FS) && rm $(ROOT_FS) || true

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -56,6 +56,12 @@ run-hw-single: $(ROOT_FS)
 run-sw-single: $(ROOT_FS)
 	${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 
+run-hw-single-gdb: $(ROOT_FS)
+	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
+
+run-sw-single-gdb: $(ROOT_FS)
+	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
+
 clean:
 	@test -f $(ALPINE_TAR) && rm $(ALPINE_TAR) || true
 	@test -f $(ROOT_FS) && rm $(ROOT_FS) || true


### PR DESCRIPTION
Adding support for debugging one LTP test with run-hw or run-sw

Usage: 
make run-hw-single-gdb test=/ltp/testcases/kernel/syscalls/chmod/chmod06
make run-sw-single-gdb test=/ltp/testcases/kernel/syscalls/chmod/chmod06

cc @SeanTAllen @letmaik 