### PR TITLE
Make futex_dequeue removal conditional

### DIFF
--- a/src/sched/futex.c
+++ b/src/sched/futex.c
@@ -62,7 +62,7 @@ void futex_dequeue(struct lthread *lt)
             fq->futex_lt = NULL;
             a_fetch_add(&futex_sleepers, -1);
             SLIST_REMOVE(&futex_queues, fq, futex_q, entries);
-            lt->err = FUTEX_NONE;
+            break;
         }
     }
 

--- a/src/sched/futex.c
+++ b/src/sched/futex.c
@@ -49,11 +49,22 @@ static uint32_t to_futex_key(int* uaddr)
  */
 void futex_dequeue(struct lthread *lt)
 {
+    struct futex_q *fq, *tmp;
+
     a_barrier();
 
     ticket_lock(&futex_q_lock);
 
-    SLIST_REMOVE(&futex_queues, &lt->fq, futex_q, entries);
+    SLIST_FOREACH_SAFE(fq, &futex_queues, entries, tmp)
+    {
+        if (lt == fq->futex_lt)
+        {
+            fq->futex_lt = NULL;
+            a_fetch_add(&futex_sleepers, -1);
+            SLIST_REMOVE(&futex_queues, fq, futex_q, entries);
+            lt->err = FUTEX_NONE;
+        }
+    }
 
     ticket_unlock(&futex_q_lock);
 }


### PR DESCRIPTION
Prior to this commit, futex_dequeue assumed that the given lthread had an
entry in futex_queues. If that wasn't the case, a segfault would occur during
removal.

Additionally, there's bookkeeping that needs to be done when removing an item
from futex_queues that wasn't being done.