### PR TITLE
Fix for fsetxattr01 and 02

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -254,8 +254,8 @@
 /ltp/testcases/kernel/syscalls/fpathconf/fpathconf01
 /ltp/testcases/kernel/syscalls/fremovexattr/fremovexattr01
 /ltp/testcases/kernel/syscalls/fremovexattr/fremovexattr02
-/ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr01
-/ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr02
+#/ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr01
+#/ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr02
 /ltp/testcases/kernel/syscalls/fstat/fstat02
 /ltp/testcases/kernel/syscalls/fstat/fstat03
 /ltp/testcases/kernel/syscalls/fstatat/fstatat01

--- a/tests/ltp/patches/fsetxattr01.patch
+++ b/tests/ltp/patches/fsetxattr01.patch
@@ -1,0 +1,70 @@
+
++ Currently xattr is not enabled while mounting root file system. Patch is
++ to mount root file system with xattr enabled and then use it for the test.
++ Also a subtest related to EFAULT is disabled due to issue 169
+index b37dba57b..3c56d9fb9 100644
+--- a/testcases/kernel/syscalls/fsetxattr/fsetxattr01.c
++++ b/testcases/kernel/syscalls/fsetxattr/fsetxattr01.c
+@@ -45,6 +45,8 @@
+ #endif
+ #include "tst_test.h"
+ 
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
+ #ifdef HAVE_SYS_XATTR_H
+ #define XATTR_NAME_MAX 255
+ #define XATTR_NAME_LEN (XATTR_NAME_MAX + 2)
+@@ -128,14 +130,18 @@ struct test_case tc[] = {
+ 	 .flags = XATTR_CREATE,
+ 	 .exp_err = ERANGE,
+ 	},
+-	{			/* case 08, NULL key */
+-	 .value = &xattr_value,
+-	 .size = XATTR_TEST_VALUE_SIZE,
+-	 .flags = XATTR_CREATE,
+-	 .exp_err = EFAULT,
+-	},
++//TODO: Enable back after issue 169 fixed
++//	{			/* case 08, NULL key */
++//	 .value = &xattr_value,
++//	 .size = XATTR_TEST_VALUE_SIZE,
++//	 .flags = XATTR_CREATE,
++//	 .exp_err = EFAULT,
++//	},
+ };
+ 
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
++
+ static void verify_fsetxattr(unsigned int i)
+ {
+ 	/* some tests might require existing keys for each iteration */
+@@ -190,11 +196,18 @@ static void cleanup(void)
+ {
+ 	if (fd > 0)
+ 		SAFE_CLOSE(fd);
++	remove(FNAME);
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
+ }
+ 
+ static void setup(void)
+ {
+ 	size_t i = 0;
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++
+ 
+ 	snprintf(long_key, 6, "%s", "user.");
+ 	memset(long_key + 5, 'k', XATTR_NAME_LEN - 5);
+@@ -218,9 +231,6 @@ static struct tst_test test = {
+ 	.test = verify_fsetxattr,
+ 	.cleanup = cleanup,
+ 	.tcnt = ARRAY_SIZE(tc),
+-	.mntpoint = MNTPOINT,
+-	.mount_device = 1,
+-	.all_filesystems = 1,
+ 	.needs_tmpdir = 1,
+ 	.needs_root = 1,
+ };

--- a/tests/ltp/patches/fsetxattr02.patch
+++ b/tests/ltp/patches/fsetxattr02.patch
@@ -1,0 +1,86 @@
++ Currently xattr is not enabled while mounting root file system. Patch is
++ to mount root file system with xattr enabled and then use it for the test.
++ A test related to block device is disabled due to issue 254
+index 205e80c95..2bbb4330f 100644
+--- a/testcases/kernel/syscalls/fsetxattr/fsetxattr02.c
++++ b/testcases/kernel/syscalls/fsetxattr/fsetxattr02.c
+@@ -57,6 +57,10 @@
+ #define CHR      MNTPOINT"/fsetxattr02chr"
+ #define BLK      MNTPOINT"/fsetxattr02blk"
+ #define SOCK     "fsetxattr02sock"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ struct test_case {
+ 	char *fname;
+@@ -117,15 +121,16 @@ static struct test_case tc[] = {
+ 	 .flags = XATTR_CREATE,
+ 	 .exp_err = EPERM,
+ 	 },
+-	{			/* case 05, set attr to block special */
+-	 .fname = BLK,
+-	 .fflags = O_RDONLY,
+-	 .key = XATTR_TEST_KEY,
+-	 .value = XATTR_TEST_VALUE,
+-	 .size = XATTR_TEST_VALUE_SIZE,
+-	 .flags = XATTR_CREATE,
+-	 .exp_err = EPERM,
+-	 },
++//TODO:Enable after issue 254 support for block device is added
++//	{			/* case 05, set attr to block special */
++//	 .fname = BLK,
++//	 .fflags = O_RDONLY,
++//	 .key = XATTR_TEST_KEY,
++//	 .value = XATTR_TEST_VALUE,
++//	 .size = XATTR_TEST_VALUE_SIZE,
++//	 .flags = XATTR_CREATE,
++//	 .exp_err = EPERM,
++//	 },
+ 	{			/* case 06, set attr to socket */
+ 	 .fname = SOCK,
+ 	 .fflags = O_RDONLY,
+@@ -198,6 +203,9 @@ static void setup(void)
+ 	struct sockaddr_un sun;
+ 
+ 	dev_t dev = makedev(1, 3);
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
+ 
+ 	SAFE_TOUCH(FILENAME, 0644, NULL);
+ 	SAFE_MKDIR(DIRNAME, 0644);
+@@ -239,22 +247,25 @@ static void cleanup(void)
+ 		if (tc[i].fd > 0)
+ 			SAFE_CLOSE(tc[i].fd);
+ 	}
++	remove(FILENAME);
++	remove(SYMLINK);
++	remove(FIFO);
++	remove(CHR);
++	remove(BLK);
++	remove(SOCK);
++	SAFE_RMDIR(DIRNAME);
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
++
+ }
+ 
+-static const char *const needed_drivers[] = {
+-	"brd",
+-	NULL,
+-};
+ 
+ static struct tst_test test = {
+ 	.setup = setup,
+ 	.test = verify_fsetxattr,
+ 	.cleanup = cleanup,
+ 	.tcnt = ARRAY_SIZE(tc),
+-	.needs_devfs = 1,
+-	.mntpoint = MNTPOINT,
+ 	.needs_root = 1,
+-	.needs_drivers = needed_drivers,
+ };
+ 
+ #else /* HAVE_SYS_XATTR_H */


### PR DESCRIPTION
Issue: As root file system was not mounted with xattr support tests were failing. 
Solution : mount file system with user_xattr support and do the tests. Also disable EFAULT related tests (issue 169) and block device tests (issue 254)