### PR TITLE
Fix race condition in clone test

### DIFF
--- a/tests/basic/clone/clone.c
+++ b/tests/basic/clone/clone.c
@@ -77,9 +77,13 @@ int parallelthr(void* arg)
 	// the SGX-LKL host interface that backs the clone system call causes
 	// host tasks to become serialised.
 	// Note: This test will work only with 2+ ethreads.
-	while (__atomic_load_n(&counter, __ATOMIC_SEQ_CST) < 100)
+	while (1)
 	{
 		int v = __atomic_load_n(&counter, __ATOMIC_SEQ_CST);
+
+		if (v == 100)
+			break;
+
 		if (v % 2 == odd)
 		{
 			__atomic_compare_exchange_n(&counter, &v, v+1, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);


### PR DESCRIPTION
Prior to this change, it was possible for the final result of the addition
to end up as 101 instead of 100 which would subsequently cause the test
to hang as it would later wait on the value being 100.

The race condition was this:

Between when a thread read that the value of counter was less than 100 and when it
incremented the value, the value might have been changed in the other thread.