### PR TITLE
Add asserts for yielding while holding ticket locks.

### DIFF
--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -155,6 +155,9 @@ struct lthread
     void (*yield_cb)(void*);
     void* yield_cbarg;
     struct futex_q fq;
+#ifndef NDEBUG
+    int ticketlocks_held;
+#endif
 };
 
 struct lthread_queue

--- a/src/include/enclave/ticketlock.h
+++ b/src/include/enclave/ticketlock.h
@@ -29,6 +29,11 @@ static inline void ticket_lock(struct ticketlock* t)
         a_spin();
 #if DEBUG
     t->lt = NULL;
+    struct lthread *lt = lthread_self();
+    if (lt)
+    {
+        lt->ticketlocks_held++;
+    }
     // t->lt = lthread_self();
 #endif /* DEBUG */
 }
@@ -38,6 +43,11 @@ static inline void ticket_unlock(struct ticketlock* t)
     a_barrier();
     t->s.ticket++;
 #if DEBUG
+    struct lthread *lt = lthread_self();
+    if (lt)
+    {
+        lt->ticketlocks_held--;
+    }
     t->lt = NULL;
 #endif /* DEBUG */
 }
@@ -53,6 +63,11 @@ static inline int ticket_trylock(struct ticketlock* t)
     {
 #if DEBUG
         t->lt = NULL;
+        struct lthread *lt = lthread_self();
+        if (lt)
+        {
+            lt->ticketlocks_held++;
+        }
         // t->lt = lthread_self();
 #endif /* DEBUG */
         return 0;


### PR DESCRIPTION
Ticket locks are spinlocks, which do not yield.  Any code that yields
while holding a ticket lock can be a source of deadlocks.