### PR TITLE
Fix incorrect one shot timer handling

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -571,9 +571,15 @@ static int timer_set_oneshot(void* _timer, unsigned long ns)
 
         if (timer->next_delay_ns)
         {
-            sgxlkl_fail("Bug: next_delay_ns already set for timer\n");
+            if (ns < timer->next_delay_ns)
+            {
+                timer->next_delay_ns = ns;
+            }
         }
-        timer->next_delay_ns = ns;
+        else
+        {
+            timer->next_delay_ns = ns;
+        }
     }
     else
     {


### PR DESCRIPTION
It should be possible to reset a one shot timer. Why this invariant
existed isn't something that either David Chisnall nor myself were
able to determine.

It is possible that at some point in the past, this invariant made sense,
however, given the current state of sgx-lkl, it doesn't.

Closes #334