### PR TITLE
LTP: removexattr01 fix

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -723,7 +723,7 @@
 /ltp/testcases/kernel/syscalls/recvmsg/recvmsg03
 /ltp/testcases/kernel/syscalls/remap_file_pages/remap_file_pages01
 /ltp/testcases/kernel/syscalls/remap_file_pages/remap_file_pages02
-/ltp/testcases/kernel/syscalls/removexattr/removexattr01
+#/ltp/testcases/kernel/syscalls/removexattr/removexattr01
 /ltp/testcases/kernel/syscalls/removexattr/removexattr02
 #/ltp/testcases/kernel/syscalls/rename/rename01
 #/ltp/testcases/kernel/syscalls/rename/rename02

--- a/tests/ltp/patches/removexattr01.patch
+++ b/tests/ltp/patches/removexattr01.patch
@@ -21,7 +21,7 @@ index ddbcba698..f5b077ad6 100644
  	char buf[size];
  
 -	n = setxattr("testfile", USER_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
-+	n = setxattr( FILENAME, USER_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
++	n = setxattr(FILENAME, USER_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
  	if (n == -1) {
  		if (errno == ENOTSUP) {
  			tst_brkm(TCONF, cleanup, "no xattr support in fs or "
@@ -30,14 +30,14 @@ index ddbcba698..f5b077ad6 100644
  	}
  
 -	TEST(removexattr("testfile", USER_KEY));
-+	TEST(removexattr( FILENAME, USER_KEY));
++	TEST(removexattr(FILENAME, USER_KEY));
  	if (TEST_RETURN != 0) {
  		tst_resm(TFAIL | TTERRNO, "removexattr() failed");
  		return;
  	}
  
 -	n = getxattr("testfile", USER_KEY, buf, size);
-+	n = getxattr( FILENAME, USER_KEY, buf, size);
++	n = getxattr(FILENAME, USER_KEY, buf, size);
  	if (n != -1) {
  		tst_resm(TFAIL, "getxattr() succeeded for deleted key");
  		return;

--- a/tests/ltp/patches/removexattr01.patch
+++ b/tests/ltp/patches/removexattr01.patch
@@ -9,8 +9,8 @@ index ddbcba698..f5b077ad6 100644
  #define VALUE	"test"
  #define VALUE_SIZE	(sizeof(VALUE) - 1)
 +#define MNTPOINT       "mntpoint"
-+#define FILENAME "mntpoint/removexattr01testfile"
-+#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILENAME       "mntpoint/removexattr01testfile"
++#define DIR_MODE       (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
 +const char *device = "/dev/vda";
 +static const char *fs_type = "ext4";
  
@@ -49,8 +49,8 @@ index ddbcba698..f5b077ad6 100644
 -
 -	SAFE_TOUCH(cleanup, "testfile", 0644, NULL);
 +	rmdir(MNTPOINT);
-+	SAFE_MKDIR(cleanup,MNTPOINT, DIR_MODE);
-+	SAFE_MOUNT(cleanup,device, MNTPOINT, fs_type, 0, "user_xattr");
++	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, "user_xattr");
 +	SAFE_TOUCH(cleanup, FILENAME, 0644, NULL);
  }
  
@@ -58,8 +58,8 @@ index ddbcba698..f5b077ad6 100644
  {
 -	tst_rmdir();
 +	remove(FILENAME);
-+	SAFE_UMOUNT(NULL,MNTPOINT);
-+	SAFE_RMDIR(NULL,MNTPOINT);
++	SAFE_UMOUNT(NULL, MNTPOINT);
++	SAFE_RMDIR(NULL, MNTPOINT);
 +
  }
  

--- a/tests/ltp/patches/removexattr01.patch
+++ b/tests/ltp/patches/removexattr01.patch
@@ -1,0 +1,66 @@
++ Currently xattr is not enabled while mounting root file system. Patch is
++ to mount root file system with xattr enabled and then use it for the test.
+diff --git a/testcases/kernel/syscalls/removexattr/removexattr01.c b/testcases/kernel/syscalls/removexattr/removexattr01.c
+index ddbcba698..f5b077ad6 100644
+--- a/testcases/kernel/syscalls/removexattr/removexattr01.c
++++ b/testcases/kernel/syscalls/removexattr/removexattr01.c
+@@ -40,6 +40,11 @@ char *TCID = "removexattr01";
+ #define USER_KEY	"user.test"
+ #define VALUE	"test"
+ #define VALUE_SIZE	(sizeof(VALUE) - 1)
++#define MNTPOINT       "mntpoint"
++#define FILENAME "mntpoint/removexattr01testfile"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ static void verify_removexattr(void);
+ static void setup(void);
+@@ -71,7 +76,7 @@ static void verify_removexattr(void)
+ 	int size = 64;
+ 	char buf[size];
+ 
+-	n = setxattr("testfile", USER_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
++	n = setxattr( FILENAME, USER_KEY, VALUE, VALUE_SIZE, XATTR_CREATE);
+ 	if (n == -1) {
+ 		if (errno == ENOTSUP) {
+ 			tst_brkm(TCONF, cleanup, "no xattr support in fs or "
+@@ -81,13 +86,13 @@ static void verify_removexattr(void)
+ 		}
+ 	}
+ 
+-	TEST(removexattr("testfile", USER_KEY));
++	TEST(removexattr( FILENAME, USER_KEY));
+ 	if (TEST_RETURN != 0) {
+ 		tst_resm(TFAIL | TTERRNO, "removexattr() failed");
+ 		return;
+ 	}
+ 
+-	n = getxattr("testfile", USER_KEY, buf, size);
++	n = getxattr( FILENAME, USER_KEY, buf, size);
+ 	if (n != -1) {
+ 		tst_resm(TFAIL, "getxattr() succeeded for deleted key");
+ 		return;
+@@ -106,14 +111,18 @@ static void setup(void)
+ 
+ 	TEST_PAUSE;
+ 
+-	tst_tmpdir();
+-
+-	SAFE_TOUCH(cleanup, "testfile", 0644, NULL);
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(cleanup,MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(cleanup,device, MNTPOINT, fs_type, 0, "user_xattr");
++	SAFE_TOUCH(cleanup, FILENAME, 0644, NULL);
+ }
+ 
+ static void cleanup(void)
+ {
+-	tst_rmdir();
++	remove(FILENAME);
++	SAFE_UMOUNT(NULL,MNTPOINT);
++	SAFE_RMDIR(NULL,MNTPOINT);
++
+ }
+ 
+ #else /* HAVE_SYS_XATTR_H */


### PR DESCRIPTION
Issue: Root file system is not mounted with xattr option so test was failing as it needs xattr support.
Solution: Mount file system with user_xattr enabled and run the test using it. 