### PR TITLE
LTP: Fix test case epoll-ltp issue

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -107,7 +107,7 @@
 /ltp/testcases/kernel/syscalls/dup2/dup205
 /ltp/testcases/kernel/syscalls/dup3/dup3_01
 /ltp/testcases/kernel/syscalls/dup3/dup3_02
-/ltp/testcases/kernel/syscalls/epoll/epoll-ltp
+#/ltp/testcases/kernel/syscalls/epoll/epoll-ltp
 /ltp/testcases/kernel/syscalls/epoll_create1/epoll_create1_01
 /ltp/testcases/kernel/syscalls/epoll_ctl/epoll_ctl01
 /ltp/testcases/kernel/syscalls/epoll_ctl/epoll_ctl02

--- a/tests/ltp/patches/fix_epoll_epoll-ltp.patch
+++ b/tests/ltp/patches/fix_epoll_epoll-ltp.patch
@@ -1,8 +1,8 @@
 This change is necessary to remove the failure in test case
-“testcases/kernel/syscalls/epoll/epoll-ltp”. This 
+“testcases/kernel/syscalls/epoll/epoll-ltp”. This
 test case is failed because sgx-lkl-musl library API,
-“epoll_create” is successes unexpectedly, when negative
-value is passed to size parameter. 
+“epoll_create” is succeeds unexpectedly, when negative
+value is passed to size parameter.
 
 As per Musl library function implementation,
 size parameter is ignored. Test case is modified to print pass
@@ -10,7 +10,7 @@ message when “epoll_create” returns valid fd for –ve size
 parameter value to run in sgx-lkl environment.
 
 diff --git a/testcases/kernel/syscalls/epoll/epoll-ltp.c b/testcases/kernel/syscalls/epoll/epoll-ltp.c
-index 12504ab95..e87eeda28 100644
+index 12504ab95..00f989c37 100644
 --- a/testcases/kernel/syscalls/epoll/epoll-ltp.c
 +++ b/testcases/kernel/syscalls/epoll/epoll-ltp.c
 @@ -212,20 +212,16 @@ int test_epoll_create(unsigned int num_rand_attempts)
@@ -24,7 +24,7 @@ index 12504ab95..e87eeda28 100644
 -			 "epoll_create with negative set size succeeded unexpectedly");
 -		num_epoll_create_test_fails++;
 +		tst_resm(TPASS,
-+			 "epoll_create with negative set size succeeded");
++			 "epoll_create succeeded with negative size, musl ignores size parameter");
  		close(epoll_fd);
  	} else {
 -		if (errno != EINVAL) {
@@ -35,7 +35,7 @@ index 12504ab95..e87eeda28 100644
 -			tst_resm(TPASS, "epoll_create with negative set size");
 -		}
 +		tst_resm(TFAIL | TERRNO,
-+			 "epoll_create with negative set size failed unexpectedly");
++			 "epoll_create failed unexpectedly with negative size, musl ignores size parameter");
 +		num_epoll_create_test_fails++;
  	}
  

--- a/tests/ltp/patches/fix_epoll_epoll-ltp.patch
+++ b/tests/ltp/patches/fix_epoll_epoll-ltp.patch
@@ -1,0 +1,42 @@
+This change is necessary to remove the failure in test case
+“testcases/kernel/syscalls/epoll/epoll-ltp”. This 
+test case is failed because sgx-lkl-musl library API,
+“epoll_create” is successes unexpectedly, when negative
+value is passed to size parameter. 
+
+As per Musl library function implementation,
+size parameter is ignored. Test case is modified to print pass
+message when “epoll_create” returns valid fd for –ve size
+parameter value to run in sgx-lkl environment.
+
+diff --git a/testcases/kernel/syscalls/epoll/epoll-ltp.c b/testcases/kernel/syscalls/epoll/epoll-ltp.c
+index 12504ab95..e87eeda28 100644
+--- a/testcases/kernel/syscalls/epoll/epoll-ltp.c
++++ b/testcases/kernel/syscalls/epoll/epoll-ltp.c
+@@ -212,20 +212,16 @@ int test_epoll_create(unsigned int num_rand_attempts)
+ 	errno = 0;
+ 	fd_set_size = -1;
+ 	num_epoll_create_test_calls++;
++	// The Size parameter is ignored in musl library
+ 	epoll_fd = epoll_create(fd_set_size);
+ 	if (epoll_fd >= 0) {
+-		tst_resm(TFAIL | TERRNO,
+-			 "epoll_create with negative set size succeeded unexpectedly");
+-		num_epoll_create_test_fails++;
++		tst_resm(TPASS,
++			 "epoll_create with negative set size succeeded");
+ 		close(epoll_fd);
+ 	} else {
+-		if (errno != EINVAL) {
+-			tst_resm(TFAIL | TERRNO,
+-				 "epoll_create with negative set size didn't set errno to EINVAL");
+-			num_epoll_create_test_fails++;
+-		} else {
+-			tst_resm(TPASS, "epoll_create with negative set size");
+-		}
++		tst_resm(TFAIL | TERRNO,
++			 "epoll_create with negative set size failed unexpectedly");
++		num_epoll_create_test_fails++;
+ 	}
+ 
+ 	/* Large set sizes -- try several less than or equal to INT_MAX by some


### PR DESCRIPTION
/ltp/testcases/kernel/syscalls/epoll/epoll-ltp

This test is failed because sgx-lkl-musl library API “epoll_create” is succeeds
unexpectedly, when negative size parameter is passed to it. As per Musl library function
implementation size parameter is ignored.

Test case is modified to print pass message when “epoll_create” returns valid fd for –ve size
parameter value.