### PR TITLE
Fix for fgetxattr02 and lgetxattr01

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -227,7 +227,7 @@
 /ltp/testcases/kernel/syscalls/fdatasync/fdatasync02
 /ltp/testcases/kernel/syscalls/fdatasync/fdatasync03
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr01
-/ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr02
+#/ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr02
 #/ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr03
 #/ltp/testcases/kernel/syscalls/flistxattr/flistxattr01
 /ltp/testcases/kernel/syscalls/flistxattr/flistxattr02
@@ -457,7 +457,7 @@
 /ltp/testcases/kernel/syscalls/lchown/lchown01
 /ltp/testcases/kernel/syscalls/lchown/lchown02
 /ltp/testcases/kernel/syscalls/lchown/lchown03
-/ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr01
+#/ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr01
 /ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
 /ltp/testcases/kernel/syscalls/link/link02
 /ltp/testcases/kernel/syscalls/link/link03

--- a/tests/ltp/patches/fgetxattr02.patch
+++ b/tests/ltp/patches/fgetxattr02.patch
@@ -1,0 +1,100 @@
++ Currently xattr is not enabled while mounting root file system. Patch is
++ to mount root file system with xattr enabled and then use it for the test.
++ A test related to block device is disabled due to issue 254
+diff --git a/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c b/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c
+index 02e81810a..0a1308939 100644
+--- a/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c
++++ b/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c
+@@ -56,14 +56,18 @@
+ 
+ #define MNTPOINT "mntpoint"
+ #define OFFSET    11
+-#define FILENAME "fgetxattr02testfile"
+-#define DIRNAME  "fgetxattr02testdir"
++#define FILENAME "mntpoint/fgetxattr02testfile"
++#define DIRNAME  "mntpoint/fgetxattr02testdir"
+ #define SYMLINK  "fgetxattr02symlink"
+-#define SYMLINKF "fgetxattr02symlinkfile"
+-#define FIFO     MNTPOINT"/fgetxattr02fifo"
+-#define CHR      MNTPOINT"/fgetxattr02chr"
+-#define BLK      MNTPOINT"/fgetxattr02blk"
+-#define SOCK     "fgetxattr02sock"
++#define SYMLINKF "mntpoint/fgetxattr02symlinkfile"
++#define FIFO     "mntpoint/fgetxattr02fifo"
++#define CHR      "mntpoint/fgetxattr02chr"
++#define BLK      "mntpoint/fgetxattr02blk"
++#define SOCK     "mntpoint/fgetxattr02sock"
++#define DIR_MODE        (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define FILE_MODE       (S_IRWXU | S_IRWXG | S_IRWXO | S_ISUID | S_ISGID)
++static const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ struct test_case {
+ 	char *fname;
+@@ -133,17 +137,18 @@ static struct test_case tc[] = {
+ 	 .exp_err = ENODATA,
+ 	 .exp_ret = -1,
+ 	 },
+-	{			/* case 05, get attr from block special */
+-	 .fname = BLK,
+-	 .fflags = O_RDONLY,
+-	 .key = XATTR_TEST_KEY,
+-	 .value = XATTR_TEST_VALUE,
+-	 .size = XATTR_TEST_VALUE_SIZE,
+-	 .ret_value = NULL,
+-	 .flags = XATTR_CREATE,
+-	 .exp_err = ENODATA,
+-	 .exp_ret = -1,
+-	 },
++//TODO:Enable after issue 254 support for block device is added
++//	{			/* case 05, get attr from block special */
++//	 .fname = BLK,
++//	 .fflags = O_RDONLY,
++//	 .key = XATTR_TEST_KEY,
++//	 .value = XATTR_TEST_VALUE,
++//	 .size = XATTR_TEST_VALUE_SIZE,
++//	 .ret_value = NULL,
++//	 .flags = XATTR_CREATE,
++//	 .exp_err = ENODATA,
++//	 .exp_ret = -1,
++//	 },
+ 	{			/* case 06, get attr from socket */
+ 	 .fname = SOCK,
+ 	 .fflags = O_RDONLY,
+@@ -212,6 +217,10 @@ static void setup(void)
+ 
+ 	dev_t dev = makedev(1, 3);
+ 
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++
+ 	SAFE_TOUCH(FILENAME, 0644, NULL);
+ 	SAFE_TOUCH(SYMLINKF, 0644, NULL);
+ 	SAFE_MKDIR(DIRNAME, 0644);
+@@ -263,6 +272,16 @@ static void cleanup(void)
+ 		if (tc[i].fd > 0)
+ 			SAFE_CLOSE(tc[i].fd);
+ 	}
++	remove(SYMLINKF);
++	remove(SYMLINK);
++	remove(FILENAME);
++	remove(FIFO);
++	remove(CHR);
++	remove(BLK);
++	remove(SOCK);
++	SAFE_RMDIR(DIRNAME);
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
+ }
+ 
+ static struct tst_test test = {
+@@ -270,8 +289,6 @@ static struct tst_test test = {
+ 	.test = verify_fgetxattr,
+ 	.cleanup = cleanup,
+ 	.tcnt = ARRAY_SIZE(tc),
+-	.needs_devfs = 1,
+-	.mntpoint = MNTPOINT,
+ 	.needs_root = 1,
+ };
+ 

--- a/tests/ltp/patches/fgetxattr02.patch
+++ b/tests/ltp/patches/fgetxattr02.patch
@@ -1,6 +1,8 @@
 + Currently xattr is not enabled while mounting root file system. Patch is
 + to mount root file system with xattr enabled and then use it for the test.
-+ A test related to block device is disabled due to issue 254
++ A test related to block device is disabled due to issue 254.Block
++ device open fails with ENXIO as block device support is needed.
++ url:https://github.com/lsds/sgx-lkl/issues/254
 diff --git a/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c b/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c
 index 02e81810a..0a1308939 100644
 --- a/testcases/kernel/syscalls/fgetxattr/fgetxattr02.c

--- a/tests/ltp/patches/lgetxattr01.patch
+++ b/tests/ltp/patches/lgetxattr01.patch
@@ -1,0 +1,84 @@
++ Currently xattr is not enabled while mounting root file system. Patch is
++ to mount root file system with xattr enabled and then use it for the test.
+diff --git a/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c b/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c
+index b9669b214..3307edd3d 100644
+--- a/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c
++++ b/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c
+@@ -14,6 +14,7 @@
+ *
+ */
+ 
++#include <stdio.h>
+ #include "config.h"
+ #include <errno.h>
+ #include <sys/types.h>
+@@ -31,7 +32,12 @@
+ #define SECURITY_KEY2   "security.ltptest2"
+ #define VALUE1   "test1"
+ #define VALUE2   "test2"
+-
++#define MNTPOINT  "mntpoint"
++#define FILENAME  "mntpoint/lgetxattr01testfile"
++#define SYMLINK  "mntpoint/lgetxattr01symlink"
++#define DIR_MODE  (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ static void set_xattr(char *path, char *key, void *value, size_t size)
+ {
+ 	int res;
+@@ -50,19 +56,29 @@ static void set_xattr(char *path, char *key, void *value, size_t size)
+ 
+ static void setup(void)
+ {
+-	SAFE_TOUCH("testfile", 0644, NULL);
+-	SAFE_SYMLINK("testfile", "symlink");
+-
+-	set_xattr("testfile", SECURITY_KEY1, VALUE1, strlen(VALUE1));
+-	set_xattr("symlink", SECURITY_KEY2, VALUE2, strlen(VALUE2));
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(device, MNTPOINT, fs_type, 0, "user_xattr");
++	SAFE_TOUCH(FILENAME, 0644, NULL);
++	SAFE_SYMLINK(FILENAME, SYMLINK);
++
++	set_xattr(FILENAME, SECURITY_KEY1, VALUE1, strlen(VALUE1));
++	set_xattr(SYMLINK, SECURITY_KEY2, VALUE2, strlen(VALUE2));
+ }
+ 
++static void cleanup(void)
++{
++	remove(SYMLINK);
++	remove(FILENAME);
++	SAFE_UMOUNT(MNTPOINT);
++	SAFE_RMDIR(MNTPOINT);
++}
+ static void verify_lgetxattr(void)
+ {
+ 	int size = 64;
+ 	char buf[size];
+ 
+-	TEST(lgetxattr("symlink", SECURITY_KEY2, buf, size));
++	TEST(lgetxattr(SYMLINK, SECURITY_KEY2, buf, size));
+ 	if (TST_RET == -1) {
+ 		tst_res(TFAIL | TTERRNO, "lgetxattr() failed");
+ 		goto next;
+@@ -79,7 +95,7 @@ static void verify_lgetxattr(void)
+ 		tst_res(TFAIL, "lgetxattr() got unexpected value");
+ 
+ next:
+-	TEST(lgetxattr("symlink", SECURITY_KEY1, buf, size));
++	TEST(lgetxattr(SYMLINK, SECURITY_KEY1, buf, size));
+ 
+ 	if (TST_RET != -1) {
+ 		tst_res(TFAIL, "lgetxattr() succeeded unexpectedly");
+@@ -95,9 +111,9 @@ next:
+ }
+ 
+ static struct tst_test test = {
+-	.needs_tmpdir = 1,
+ 	.needs_root = 1,
+ 	.test_all = verify_lgetxattr,
++	.cleanup = cleanup,
+ 	.setup = setup
+ };
+ 

--- a/tests/ltp/patches/lgetxattr01.patch
+++ b/tests/ltp/patches/lgetxattr01.patch
@@ -1,7 +1,7 @@
 + Currently xattr is not enabled while mounting root file system. Patch is
 + to mount root file system with xattr enabled and then use it for the test.
 diff --git a/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c b/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c
-index b9669b214..3307edd3d 100644
+index b9669b214..78252719c 100644
 --- a/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c
 +++ b/testcases/kernel/syscalls/lgetxattr/lgetxattr01.c
 @@ -14,6 +14,7 @@
@@ -12,21 +12,21 @@ index b9669b214..3307edd3d 100644
  #include "config.h"
  #include <errno.h>
  #include <sys/types.h>
-@@ -31,7 +32,12 @@
+@@ -31,6 +32,13 @@
  #define SECURITY_KEY2   "security.ltptest2"
  #define VALUE1   "test1"
  #define VALUE2   "test2"
--
 +#define MNTPOINT  "mntpoint"
 +#define FILENAME  "mntpoint/lgetxattr01testfile"
 +#define SYMLINK  "mntpoint/lgetxattr01symlink"
 +#define DIR_MODE  (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++
 +const char *device = "/dev/vda";
 +static const char *fs_type = "ext4";
+ 
  static void set_xattr(char *path, char *key, void *value, size_t size)
  {
- 	int res;
-@@ -50,19 +56,29 @@ static void set_xattr(char *path, char *key, void *value, size_t size)
+@@ -50,19 +58,29 @@ static void set_xattr(char *path, char *key, void *value, size_t size)
  
  static void setup(void)
  {
@@ -62,7 +62,7 @@ index b9669b214..3307edd3d 100644
  	if (TST_RET == -1) {
  		tst_res(TFAIL | TTERRNO, "lgetxattr() failed");
  		goto next;
-@@ -79,7 +95,7 @@ static void verify_lgetxattr(void)
+@@ -79,7 +97,7 @@ static void verify_lgetxattr(void)
  		tst_res(TFAIL, "lgetxattr() got unexpected value");
  
  next:
@@ -71,7 +71,7 @@ index b9669b214..3307edd3d 100644
  
  	if (TST_RET != -1) {
  		tst_res(TFAIL, "lgetxattr() succeeded unexpectedly");
-@@ -95,9 +111,9 @@ next:
+@@ -95,9 +113,9 @@ next:
  }
  
  static struct tst_test test = {


### PR DESCRIPTION
Issue: Tests were failing as filesystem was without xattr support. The tests needs file system mounted with xattr option.
Solution: mount filesystem with user_xattr support and use it for the tests.