### PR TITLE
Fix bug in sem_up/sem_down implementation

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -211,7 +211,7 @@ static void sem_up(struct lkl_sem* sem)
     // there may be waiters.  Wake one up.
     if (atomic_fetch_add(&sem->count, 1) == 0)
     {
-        futex_wake(&sem->count, 1);
+        futex_wake(&sem->count, INT_MAX);
     }
 }
 


### PR DESCRIPTION
Prior to this change, it is possible to lose wakeup events.
For example, 3 different things call sem_down resulting in a
sem count of 0.

On waking, only 1 would be awoken. The rest would continue to sleep.

This changes so that all are awoken and they can see which gets
the semaphore and then go back to sleep. Because all are awoken, the
other logic works.