### PR TITLE
Add additional output to clone test

### DIFF
--- a/tests/basic/clone/clone.c
+++ b/tests/basic/clone/clone.c
@@ -89,6 +89,9 @@ int parallelthr(void* arg)
 			__atomic_compare_exchange_n(&counter, &v, v+1, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 		}
 	}
+
+	fprintf(stderr, "Thread %d finished\n", odd);
+
 	return 0;
 }
 
@@ -130,10 +133,12 @@ int main(int argc, char** argv)
 	fprintf(stderr, "\nIf this test hangs after waking up one thread, check you have at least 2 ethreads\n");
 	fprintf(stderr, "This test is checking that LKL is able to wake up two cloned threads and leaving them running in parallel\n\n");
 	futex_wake(&barrier);
+	fprintf(stderr, "Waiting for for Thread 0 to finish\n");
 	futex_wait(&ctid_futex1, ctid1);
+	fprintf(stderr, "Waiting for for Thread 1 to finish\n");
 	futex_wait(&ctid_futex2, ctid2);
 
 	fprintf(stderr, "\nTEST_PASSED\n");
 
-    return 0;
+	return 0;
 }


### PR DESCRIPTION
In case this ends up hanging on someone, this additional output could
be used to provide a better idea of where things went wrong for someone
trying to get started with diagnosing.