### PR TITLE
LTP: fix testcase sendfile02 issue

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -791,7 +791,7 @@
 #/ltp/testcases/kernel/syscalls/select/select03
 #/ltp/testcases/kernel/syscalls/select/select04
 /ltp/testcases/kernel/syscalls/send/send01
-/ltp/testcases/kernel/syscalls/sendfile/sendfile02
+#/ltp/testcases/kernel/syscalls/sendfile/sendfile02
 #/ltp/testcases/kernel/syscalls/sendfile/sendfile03
 /ltp/testcases/kernel/syscalls/sendfile/sendfile04
 /ltp/testcases/kernel/syscalls/sendfile/sendfile05

--- a/tests/ltp/patches/fix_sendfile_sendfile02.patch
+++ b/tests/ltp/patches/fix_sendfile_sendfile02.patch
@@ -1,0 +1,85 @@
+The original test case create a child process to test
+Sendfile system call. But, sgx-lkl environment supports single process.
+Hence, the test case is modified to use pthread instead of a child
+process.
+
+diff --git a/testcases/kernel/syscalls/sendfile/sendfile02.c b/testcases/kernel/syscalls/sendfile/sendfile02.c
+index e5f115146..b434d27c4 100644
+--- a/testcases/kernel/syscalls/sendfile/sendfile02.c
++++ b/testcases/kernel/syscalls/sendfile/sendfile02.c
+@@ -56,8 +56,10 @@
+ #include <arpa/inet.h>
+ #include <unistd.h>
+ #include <inttypes.h>
++#include <pthread.h>
+ #include "test.h"
+ #include "safe_macros.h"
++#include "tst_safe_pthread.h"
+ 
+ #ifndef OFF_T
+ #define OFF_T off_t
+@@ -72,9 +74,10 @@ int out_fd;
+ pid_t child_pid;
+ static int sockfd, s;
+ static struct sockaddr_in sin1;	/* shared between do_child and create_server */
++pthread_t ptid;
+ 
+ void cleanup(void);
+-void do_child(void);
++void* do_child(void* parm);
+ void setup(void);
+ int create_server(void);
+ 
+@@ -130,7 +133,7 @@ void do_sendfile(OFF_T offset, int i)
+ 			 "expected value, expected: %d, "
+ 			 "got: %ld", testcases[i].exp_retval,
+ 			 TEST_RETURN);
+-		kill(child_pid, SIGKILL);
++		pthread_cancel(ptid);
+ 	} else if (offset != testcases[i].exp_updated_offset) {
+ 		tst_resm(TFAIL, "sendfile(2) failed to update "
+ 			 "OFFSET parameter to expected value, "
+@@ -145,7 +148,7 @@ void do_sendfile(OFF_T offset, int i)
+ 	} else {
+ 		tst_resm(TPASS, "functionality of sendfile() is "
+ 			 "correct");
+-		wait_status = waitpid(-1, &wait_stat, 0);
++		SAFE_PTHREAD_JOIN(ptid, NULL);
+ 	}
+ 
+ 	close(in_fd);
+@@ -154,7 +157,7 @@ void do_sendfile(OFF_T offset, int i)
+ /*
+  * do_child
+  */
+-void do_child(void)
++void* do_child(void* parm)
+ {
+ 	int lc;
+ 	socklen_t length;
+@@ -165,7 +168,7 @@ void do_child(void)
+ 		recvfrom(sockfd, rbuf, 4096, 0, (struct sockaddr *)&sin1,
+ 			 &length);
+ 	}
+-	exit(0);
++	pthread_exit(0);
+ }
+ 
+ /*
+@@ -244,7 +247,7 @@ int create_server(void)
+ 
+ 		}
+ #else
+-		do_child();
++		SAFE_PTHREAD_CREATE(&ptid, NULL, do_child, NULL);
+ #endif
+ 	}
+ 
+@@ -270,7 +273,6 @@ int main(int ac, char **av)
+ 	argv0 = av[0];
+ 	maybe_run_child(&do_child, "");
+ #endif
+-
+ 	setup();
+ 
+ 	/*


### PR DESCRIPTION
The original test case create a child process to test
Sendfile system call. But, sgx-lkl environment supports single
process. Hence, the test case is modified to use pthread instead
of a child process.