### PR TITLE
LTP: Fix for setsid01 testcase

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -869,7 +869,7 @@
 /ltp/testcases/kernel/syscalls/setrlimit/setrlimit04
 /ltp/testcases/kernel/syscalls/setrlimit/setrlimit05
 /ltp/testcases/kernel/syscalls/setrlimit/setrlimit06
-/ltp/testcases/kernel/syscalls/setsid/setsid01
+#/ltp/testcases/kernel/syscalls/setsid/setsid01
 /ltp/testcases/kernel/syscalls/setsockopt/setsockopt01
 /ltp/testcases/kernel/syscalls/setsockopt/setsockopt02
 #/ltp/testcases/kernel/syscalls/setsockopt/setsockopt03

--- a/tests/ltp/patches/setsid01.patch
+++ b/tests/ltp/patches/setsid01.patch
@@ -1,0 +1,260 @@
+diff --git a/testcases/kernel/syscalls/setsid/setsid01.c b/testcases/kernel/syscalls/setsid/setsid01.c
+index ed8f0e4ad..67f086ad7 100644
+--- a/testcases/kernel/syscalls/setsid/setsid01.c
++++ b/testcases/kernel/syscalls/setsid/setsid01.c
+@@ -39,6 +39,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include "test.h"
++#include <pthread.h>
+ 
+ #define INVAL_FLAG	-1
+ #define USER2		301
+@@ -53,161 +54,113 @@ int TST_TOTAL = 1;
+ static char *argv0;
+ #endif
+ 
+-void do_child_1(void);
+-void do_child_2(void);
+ void setup(void);
+ void cleanup(void);
+ 
++static void* do_child_thread(void* arg);
++static void* do_master_thread(void* arg);
++
++
+ int main(int ac, char **av)
+ {
+-	int pid;
+-	int fail = 0;
+-	int ret, status;
+-	int exno = 0;
+-
+-	int lc;
++  int fail = 0;
++  int lc;
+ 
+-	tst_parse_opts(ac, av, NULL, NULL);
++  tst_parse_opts(ac, av, NULL, NULL);
+ #ifdef UCLINUX
+-	argv0 = av[0];
++  argv0 = av[0];
+ 
+-	maybe_run_child(&do_child_1, "n", 1);
+-	maybe_run_child(&do_child_2, "n", 2);
++  maybe_run_child(&do_child_1, "n", 1);
++  maybe_run_child(&do_child_2, "n", 2);
+ #endif
+ 
+-	/*
+-	 * perform global setup for the test
+-	 */
+-	setup();
+-
+-	for (lc = 0; TEST_LOOPING(lc); lc++) {
+-
+-		/* reset tst_count in case we are looping */
+-		tst_count = 0;
++  /*
++   * perform global setup for the test
++   */
++  setup();
++
++  for (lc = 0; TEST_LOOPING(lc); lc++) {
++
++    /* reset tst_count in case we are looping */
++    tst_count = 0;
++
++    /*
++     * When the process group having forked of a child
++     * and then it attached itself to another process
++     * group and tries to setsid
++     */
++    int s;
++
++    pthread_t master_tid;
++
++    s = pthread_create(&master_tid, NULL, do_master_thread, NULL);
++
++    if (s == 0)
++    {
++      printf("%s(): thread created fine ...\n", __FUNCTION__);
++      pthread_join(master_tid, NULL);
++    }
++    else
++    {
++      printf("%s(): thread created error ...\n", __FUNCTION__);
++      tst_resm(TFAIL, "Pthread create failed");
++      fail = 1;
++    }
++
++    if (!fail) {
++      tst_resm(TPASS, "all misc tests passed");
++    }
++  }
++  cleanup();
++  tst_exit();
+ 
+-		/*
+-		 * When the process group having forked of a child
+-		 * and then it attached itself to another process
+-		 * group and tries to setsid
+-		 */
+-		pid = FORK_OR_VFORK();
+-
+-		if (pid == 0) {
+-			if ((pid = FORK_OR_VFORK()) == -1) {
+-				tst_resm(TFAIL, "Fork failed");
++}
+ 
+-			}
+-			if (pid == 0) {
+-#ifdef UCLINUX
+-				if (self_exec(argv0, "n", 1) < 0) {
+-					tst_resm(TFAIL, "self_exec failed");
+ 
+-				}
+-#else
+-				do_child_1();
+-#endif
+-			} else {
+-				if (setpgid(0, 0) < 0) {
+-					tst_resm(TFAIL,
+-						 "setpgid(parent) failed: %s",
+-						 strerror(errno));
+-					fail = 1;
+-				}
+-
+-				if ((ret = wait(&status)) > 0) {
+-					if (status != 0) {
+-						tst_resm(TFAIL,
+-							 "Test {%d} exited "
+-							 "status 0x%0x (wanted 0x0)",
+-							 ret, status);
+-						fail = 1;
+-					}
+-				}
+-			}
+-			exit(0);
+-		} else {
+-			if ((ret = wait(&status)) > 0) {
+-				if (status != 0) {
+-					tst_resm(TFAIL, "Test {%d} exited "
+-						 "status 0x%0x (wanted 0x0)",
+-						 ret, status);
+-					fail = 1;
+-				}
+-			}
+-		}
+-
+-		if (!(fail || exno)) {
+-			tst_resm(TPASS, "all misc tests passed");
+-		}
+-	}
+-	cleanup();
+-	tst_exit();
++static void* do_master_thread(void* arg)
++{
++  int s;
++  pthread_t child_tid;
+ 
+-}
++  setpgid(0,0);
+ 
+-/*
+- * do_child_1()
+- */
+-void do_child_1(void)
+-{
+-	int exno = 0;
+-	int retval, ret, status;
+-	int pid;
++  s = pthread_create(&child_tid, NULL, do_child_thread, NULL);
+ 
+-	sleep(1);
++  if (s == 0)
++  {
++    printf("%s(): thread created fine ...\n", __FUNCTION__);
++    pthread_join(child_tid, NULL);
++  }
++  else
++    printf("%s(): thread created error ...\n", __FUNCTION__);
+ 
+-	if (setpgid(0, 0) < 0) {
+-		tst_resm(TFAIL, "setpgid(0,0) failed: %s", strerror(errno));
+-		exno = 1;
+-	}
++  pthread_exit(NULL);
+ 
+-	if ((pid = FORK_OR_VFORK()) == -1) {
+-		tst_brkm(TFAIL, NULL, "Fork failed");
+-	}
+-	if (pid == 0) {
+-#ifdef UCLINUX
+-		if (self_exec(argv0, "n", 2) < 0) {
+-			tst_brkm(TFAIL, NULL, "self_exec failed");
+-		}
+-#else
+-		do_child_2();
+-#endif
+-	} else {
+-		retval = setpgid(0, getppid());
+-		if (retval < 0) {
+-			tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
+-			exno = 2;
+-		}
+-
+-		retval = setsid();
+-
+-		if (errno == EPERM) {
+-			tst_resm(TPASS, "setsid SUCCESS to set "
+-				 "errno to EPERM");
+-		} else {
+-			tst_resm(TFAIL, "setsid failed, expected %d,"
+-				 "return %d", -1, errno);
+-			exno = 3;
+-		}
+-		kill(pid, SIGKILL);
+-		if ((ret = wait(&status)) > 0) {
+-			if (status != 9) {
+-				tst_resm(TFAIL,
+-					 "Test {%d} exited status 0x%-x (wanted 0x9)",
+-					 ret, status);
+-				exno = 4;
+-			}
+-		}
+-	}
+-	exit(exno);
+ }
+ 
+-/*
+- * do_child_2()
+- */
+-void do_child_2(void)
++
++static void* do_child_thread(void* arg)
+ {
+-	for (;;) ;
++  int retval;
++
++  retval = setpgid(0, getppid());
++  
++  if (retval < 0) {
++    tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
++  }
++
++  retval = setsid();
++
++  if (errno == EPERM) {
++    tst_resm(TPASS, "setsid SUCCESS to set "
++        "errno to EPERM");
++  } else {
++    tst_resm(TFAIL, "setsid failed, expected %d,"
++        "return %d", -1, errno);
++  }
++  
++  pthread_exit(NULL);
++
+ }
+ 
+ /*

--- a/tests/ltp/patches/setsid01.patch
+++ b/tests/ltp/patches/setsid01.patch
@@ -1,16 +1,17 @@
 diff --git a/testcases/kernel/syscalls/setsid/setsid01.c b/testcases/kernel/syscalls/setsid/setsid01.c
-index ed8f0e4ad..67f086ad7 100644
+index ed8f0e4ad..dc6353b14 100644
 --- a/testcases/kernel/syscalls/setsid/setsid01.c
 +++ b/testcases/kernel/syscalls/setsid/setsid01.c
-@@ -39,6 +39,7 @@
+@@ -39,6 +39,8 @@
  #include <sys/types.h>
  #include <sys/stat.h>
  #include "test.h"
 +#include <pthread.h>
++#include <tst_safe_pthread.h>
  
  #define INVAL_FLAG	-1
  #define USER2		301
-@@ -53,161 +54,113 @@ int TST_TOTAL = 1;
+@@ -53,161 +55,127 @@ int TST_TOTAL = 1;
  static char *argv0;
  #endif
  
@@ -29,71 +30,71 @@ index ed8f0e4ad..67f086ad7 100644
 -	int fail = 0;
 -	int ret, status;
 -	int exno = 0;
--
--	int lc;
-+  int fail = 0;
-+  int lc;
++    int fail = 0;
++    int lc;
  
+-	int lc;
+-
 -	tst_parse_opts(ac, av, NULL, NULL);
-+  tst_parse_opts(ac, av, NULL, NULL);
++    tst_parse_opts(ac, av, NULL, NULL);
  #ifdef UCLINUX
 -	argv0 = av[0];
-+  argv0 = av[0];
++    argv0 = av[0];
  
 -	maybe_run_child(&do_child_1, "n", 1);
 -	maybe_run_child(&do_child_2, "n", 2);
-+  maybe_run_child(&do_child_1, "n", 1);
-+  maybe_run_child(&do_child_2, "n", 2);
++    maybe_run_child(&do_child_1, "n", 1);
++    maybe_run_child(&do_child_2, "n", 2);
  #endif
  
 -	/*
 -	 * perform global setup for the test
 -	 */
 -	setup();
--
++    /*
++     * perform global setup for the test
++     */
++    setup();
++
++    for (lc = 0; TEST_LOOPING(lc); lc++) {
++
++        /* reset tst_count in case we are looping */
++        tst_count = 0;
++
++        /*
++         * When the process group having forked of a child
++         * and then it attached itself to another process
++         * group and tries to setsid
++         */
++        int s;
++
++        pthread_t master_tid;
++
++        s = SAFE_PTHREAD_CREATE(&master_tid, NULL, do_master_thread, NULL);
++
++        if (s == 0)
++        {
++            tst_resm(TINFO, "master thread created fine ...\n");
++            SAFE_PTHREAD_JOIN(master_tid, NULL);
++        }
++        else
++        {
++            tst_resm(TFAIL, "master thread create failed");
++            fail = 1;
++        }
++
++        if (!fail) {
++            tst_resm(TPASS, "all misc tests passed");
++        }
++    }
++    cleanup();
++    tst_exit();
+ 
 -	for (lc = 0; TEST_LOOPING(lc); lc++) {
--
++}
+ 
 -		/* reset tst_count in case we are looping */
 -		tst_count = 0;
-+  /*
-+   * perform global setup for the test
-+   */
-+  setup();
-+
-+  for (lc = 0; TEST_LOOPING(lc); lc++) {
-+
-+    /* reset tst_count in case we are looping */
-+    tst_count = 0;
-+
-+    /*
-+     * When the process group having forked of a child
-+     * and then it attached itself to another process
-+     * group and tries to setsid
-+     */
-+    int s;
-+
-+    pthread_t master_tid;
-+
-+    s = pthread_create(&master_tid, NULL, do_master_thread, NULL);
-+
-+    if (s == 0)
-+    {
-+      printf("%s(): thread created fine ...\n", __FUNCTION__);
-+      pthread_join(master_tid, NULL);
-+    }
-+    else
-+    {
-+      printf("%s(): thread created error ...\n", __FUNCTION__);
-+      tst_resm(TFAIL, "Pthread create failed");
-+      fail = 1;
-+    }
-+
-+    if (!fail) {
-+      tst_resm(TPASS, "all misc tests passed");
-+    }
-+  }
-+  cleanup();
-+  tst_exit();
  
 -		/*
 -		 * When the process group having forked of a child
@@ -101,17 +102,29 @@ index ed8f0e4ad..67f086ad7 100644
 -		 * group and tries to setsid
 -		 */
 -		pid = FORK_OR_VFORK();
--
++static void* do_master_thread(void* arg)
++{
++    int s;
++    pthread_t child_tid;
+ 
 -		if (pid == 0) {
 -			if ((pid = FORK_OR_VFORK()) == -1) {
 -				tst_resm(TFAIL, "Fork failed");
-+}
++    if (setpgid(0, 0) < 0) {
++		tst_resm(TFAIL, "master thread: setpgid(0,0) failed with error: %s", strerror(errno));
++        pthread_exit(NULL);
++	}
++    else 
++    {
++		tst_resm(TINFO, "master thread: setpgid(0,0) success");
++	}
  
 -			}
 -			if (pid == 0) {
 -#ifdef UCLINUX
 -				if (self_exec(argv0, "n", 1) < 0) {
 -					tst_resm(TFAIL, "self_exec failed");
++    s = SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child_thread, NULL);
  
 -				}
 -#else
@@ -153,38 +166,48 @@ index ed8f0e4ad..67f086ad7 100644
 -	}
 -	cleanup();
 -	tst_exit();
-+static void* do_master_thread(void* arg)
-+{
-+  int s;
-+  pthread_t child_tid;
++    if (s == 0)
++    {
++        tst_resm(TINFO, "child thread created fine ...\n");
++        SAFE_PTHREAD_JOIN(child_tid, NULL);
++    }
++    else
++    {
++        tst_resm(TFAIL, "child thread create failed ...\n");
++        SAFE_PTHREAD_JOIN(child_tid, NULL);
++    }
++
++    pthread_exit(NULL);
  
--}
-+  setpgid(0,0);
+ }
  
 -/*
 - * do_child_1()
 - */
 -void do_child_1(void)
--{
++
++static void* do_child_thread(void* arg)
+ {
 -	int exno = 0;
 -	int retval, ret, status;
 -	int pid;
-+  s = pthread_create(&child_tid, NULL, do_child_thread, NULL);
++    int retval;
  
 -	sleep(1);
-+  if (s == 0)
-+  {
-+    printf("%s(): thread created fine ...\n", __FUNCTION__);
-+    pthread_join(child_tid, NULL);
-+  }
-+  else
-+    printf("%s(): thread created error ...\n", __FUNCTION__);
++    /* Since thread is being used , need to replace getppid() with getpid() */
++    retval = setpgid(0, getpid());
  
 -	if (setpgid(0, 0) < 0) {
 -		tst_resm(TFAIL, "setpgid(0,0) failed: %s", strerror(errno));
 -		exno = 1;
 -	}
-+  pthread_exit(NULL);
++    if (retval < 0) {
++        tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
++    }
++    else
++    {
++        tst_resm(TINFO, "setpgid for child thread success");
++    }
  
 -	if ((pid = FORK_OR_VFORK()) == -1) {
 -		tst_brkm(TFAIL, NULL, "Fork failed");
@@ -225,36 +248,40 @@ index ed8f0e4ad..67f086ad7 100644
 -		}
 -	}
 -	exit(exno);
- }
+-}
++    retval = setsid();
++
++    if (errno == EPERM) {
++        tst_resm(TPASS, "setsid SUCCESS to set "
++                "errno to EPERM");
++    } else {
++        tst_resm(TFAIL, "setsid failed, expected %d,"
++                "return %d", -1, errno);
++    }
++
++    pthread_exit(NULL);
  
 -/*
 - * do_child_2()
 - */
 -void do_child_2(void)
-+
-+static void* do_child_thread(void* arg)
- {
+-{
 -	for (;;) ;
-+  int retval;
-+
-+  retval = setpgid(0, getppid());
-+  
-+  if (retval < 0) {
-+    tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
-+  }
-+
-+  retval = setsid();
-+
-+  if (errno == EPERM) {
-+    tst_resm(TPASS, "setsid SUCCESS to set "
-+        "errno to EPERM");
-+  } else {
-+    tst_resm(TFAIL, "setsid failed, expected %d,"
-+        "return %d", -1, errno);
-+  }
-+  
-+  pthread_exit(NULL);
-+
+ }
+ 
+ /*
+@@ -216,11 +184,11 @@ void do_child_2(void)
+ void setup(void)
+ {
+ 
+-	tst_sig(FORK, DEF_HANDLER, cleanup);
++    tst_sig(FORK, DEF_HANDLER, cleanup);
+ 
+-	umask(0);
++    umask(0);
+ 
+-	TEST_PAUSE;
++    TEST_PAUSE;
  }
  
  /*

--- a/tests/ltp/patches/setsid01.patch
+++ b/tests/ltp/patches/setsid01.patch
@@ -1,8 +1,8 @@
-Patch Description: Tests were failing due to unavailability of fork() support. 
-So modified the tests to use pthreads and verify the error condition for setsid().
+Description: Test is failing due to fork() unavailablity in SGX-LKL.
+So modified the test to use pthreads to verify error validation for setsid() system call
 
 diff --git a/testcases/kernel/syscalls/setsid/setsid01.c b/testcases/kernel/syscalls/setsid/setsid01.c
-index ed8f0e4ad..f891140dd 100644
+index ed8f0e4ad..00eed2c1e 100644
 --- a/testcases/kernel/syscalls/setsid/setsid01.c
 +++ b/testcases/kernel/syscalls/setsid/setsid01.c
 @@ -39,6 +39,8 @@
@@ -46,19 +46,19 @@ index ed8f0e4ad..f891140dd 100644
 +		 * Creates two threads and tries to do setsid()
  		 */
 -		pid = FORK_OR_VFORK();
-+          pthread_t master_tid;
++		pthread_t master_tid;
  
 -		if (pid == 0) {
 -			if ((pid = FORK_OR_VFORK()) == -1) {
 -				tst_resm(TFAIL, "Fork failed");
-+          SAFE_PTHREAD_CREATE(&master_tid, NULL, do_master_thread, NULL);
- 
+-
 -			}
 -			if (pid == 0) {
 -#ifdef UCLINUX
 -				if (self_exec(argv0, "n", 1) < 0) {
 -					tst_resm(TFAIL, "self_exec failed");
--
++		SAFE_PTHREAD_CREATE(&master_tid, NULL, do_master_thread, NULL);
+ 
 -				}
 -#else
 -				do_child_1();
@@ -96,7 +96,7 @@ index ed8f0e4ad..f891140dd 100644
 -		if (!(fail || exno)) {
 -			tst_resm(TPASS, "all misc tests passed");
 -		}
-+          SAFE_PTHREAD_JOIN(master_tid, NULL);
++		SAFE_PTHREAD_JOIN(master_tid, NULL);
  	}
  	cleanup();
  	tst_exit();
@@ -112,31 +112,42 @@ index ed8f0e4ad..f891140dd 100644
 -	int exno = 0;
 -	int retval, ret, status;
 -	int pid;
-+     pthread_t child_tid;
- 
+-
 -	sleep(1);
-+     if (setpgid(0, 0) < 0) {
-+          tst_resm(TFAIL, "master thread: setpgid(0,0) failed with error: %s", strerror(errno));
-+          pthread_exit(NULL);
-+     }
-+     else
-+     {
-+          tst_resm(TINFO, "master thread: setpgid(0,0) success");
-+     }
++	pthread_t child_tid;
  
--	if (setpgid(0, 0) < 0) {
+ 	if (setpgid(0, 0) < 0) {
 -		tst_resm(TFAIL, "setpgid(0,0) failed: %s", strerror(errno));
 -		exno = 1;
--	}
-+     SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child_thread, NULL);
-+
-+     SAFE_PTHREAD_JOIN(child_tid, NULL);
-+
-+     pthread_exit(NULL);
++		tst_resm(TFAIL, "master thread: setpgid(0,0) failed with error: %s", strerror(errno));
++		pthread_exit(NULL);
++	}
++	else
++	{
++		tst_resm(TINFO, "master thread: setpgid(0,0) success");
+ 	}
  
 -	if ((pid = FORK_OR_VFORK()) == -1) {
 -		tst_brkm(TFAIL, NULL, "Fork failed");
--	}
++	SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child_thread, NULL);
++
++	SAFE_PTHREAD_JOIN(child_tid, NULL);
++
++	pthread_exit(NULL);
++
++}
++
++
++static void* do_child_thread(void* arg)
++{
++	int retval;
++
++	/* Since thread is being used , need to replace getppid() with getpid() */
++	retval = setpgid(0, getpid());
++
++	if (retval < 0) {
++		tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
+ 	}
 -	if (pid == 0) {
 -#ifdef UCLINUX
 -		if (self_exec(argv0, "n", 2) < 0) {
@@ -145,7 +156,17 @@ index ed8f0e4ad..f891140dd 100644
 -#else
 -		do_child_2();
 -#endif
--	} else {
++	else
++	{
++		tst_resm(TINFO, "setpgid for child thread success");
++	}
++
++	retval = setsid();
++
++	if (errno == EPERM) {
++		tst_resm(TPASS, "setsid SUCCESS to set "
++				"errno to EPERM");
+ 	} else {
 -		retval = setpgid(0, getppid());
 -		if (retval < 0) {
 -			tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
@@ -171,42 +192,19 @@ index ed8f0e4ad..f891140dd 100644
 -				exno = 4;
 -			}
 -		}
--	}
++		tst_resm(TFAIL, "setsid failed, expected %d,"
++				"return %d", -1, errno);
+ 	}
 -	exit(exno);
- }
+-}
  
 -/*
 - * do_child_2()
 - */
 -void do_child_2(void)
-+
-+static void* do_child_thread(void* arg)
- {
+-{
 -	for (;;) ;
-+     int retval;
-+
-+     /* Since thread is being used , need to replace getppid() with getpid() */
-+     retval = setpgid(0, getpid());
-+
-+     if (retval < 0) {
-+          tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
-+     }
-+     else
-+     {
-+          tst_resm(TINFO, "setpgid for child thread success");
-+     }
-+
-+     retval = setsid();
-+
-+     if (errno == EPERM) {
-+          tst_resm(TPASS, "setsid SUCCESS to set "
-+                    "errno to EPERM");
-+     } else {
-+          tst_resm(TFAIL, "setsid failed, expected %d,"
-+                    "return %d", -1, errno);
-+     }
-+
-+     pthread_exit(NULL);
++	pthread_exit(NULL);
  }
  
  /*

--- a/tests/ltp/patches/setsid01.patch
+++ b/tests/ltp/patches/setsid01.patch
@@ -1,5 +1,5 @@
 diff --git a/testcases/kernel/syscalls/setsid/setsid01.c b/testcases/kernel/syscalls/setsid/setsid01.c
-index ed8f0e4ad..dc6353b14 100644
+index ed8f0e4ad..1e40e7b21 100644
 --- a/testcases/kernel/syscalls/setsid/setsid01.c
 +++ b/testcases/kernel/syscalls/setsid/setsid01.c
 @@ -39,6 +39,8 @@
@@ -11,7 +11,7 @@ index ed8f0e4ad..dc6353b14 100644
  
  #define INVAL_FLAG	-1
  #define USER2		301
-@@ -53,161 +55,127 @@ int TST_TOTAL = 1;
+@@ -53,161 +55,102 @@ int TST_TOTAL = 1;
  static char *argv0;
  #endif
  
@@ -30,71 +30,38 @@ index ed8f0e4ad..dc6353b14 100644
 -	int fail = 0;
 -	int ret, status;
 -	int exno = 0;
-+    int fail = 0;
-+    int lc;
- 
--	int lc;
 -
+-	int lc;
++     int lc;
+ 
 -	tst_parse_opts(ac, av, NULL, NULL);
-+    tst_parse_opts(ac, av, NULL, NULL);
++     tst_parse_opts(ac, av, NULL, NULL);
  #ifdef UCLINUX
 -	argv0 = av[0];
-+    argv0 = av[0];
++     argv0 = av[0];
  
 -	maybe_run_child(&do_child_1, "n", 1);
 -	maybe_run_child(&do_child_2, "n", 2);
-+    maybe_run_child(&do_child_1, "n", 1);
-+    maybe_run_child(&do_child_2, "n", 2);
++     maybe_run_child(&do_child_1, "n", 1);
++     maybe_run_child(&do_child_2, "n", 2);
  #endif
  
 -	/*
 -	 * perform global setup for the test
 -	 */
 -	setup();
-+    /*
-+     * perform global setup for the test
-+     */
-+    setup();
-+
-+    for (lc = 0; TEST_LOOPING(lc); lc++) {
-+
-+        /* reset tst_count in case we are looping */
-+        tst_count = 0;
-+
-+        /*
-+         * When the process group having forked of a child
-+         * and then it attached itself to another process
-+         * group and tries to setsid
-+         */
-+        int s;
-+
-+        pthread_t master_tid;
-+
-+        s = SAFE_PTHREAD_CREATE(&master_tid, NULL, do_master_thread, NULL);
-+
-+        if (s == 0)
-+        {
-+            tst_resm(TINFO, "master thread created fine ...\n");
-+            SAFE_PTHREAD_JOIN(master_tid, NULL);
-+        }
-+        else
-+        {
-+            tst_resm(TFAIL, "master thread create failed");
-+            fail = 1;
-+        }
-+
-+        if (!fail) {
-+            tst_resm(TPASS, "all misc tests passed");
-+        }
-+    }
-+    cleanup();
-+    tst_exit();
++     /*
++      * perform global setup for the test
++      */
++     setup();
  
 -	for (lc = 0; TEST_LOOPING(lc); lc++) {
-+}
++     for (lc = 0; TEST_LOOPING(lc); lc++) {
  
 -		/* reset tst_count in case we are looping */
 -		tst_count = 0;
++          /* reset tst_count in case we are looping */
++          tst_count = 0;
  
 -		/*
 -		 * When the process group having forked of a child
@@ -102,29 +69,24 @@ index ed8f0e4ad..dc6353b14 100644
 -		 * group and tries to setsid
 -		 */
 -		pid = FORK_OR_VFORK();
-+static void* do_master_thread(void* arg)
-+{
-+    int s;
-+    pthread_t child_tid;
++          /*
++           * When the process group having forked of a child
++           * and then it attached itself to another process
++           * group and tries to setsid
++           */
++          pthread_t master_tid;
  
 -		if (pid == 0) {
 -			if ((pid = FORK_OR_VFORK()) == -1) {
 -				tst_resm(TFAIL, "Fork failed");
-+    if (setpgid(0, 0) < 0) {
-+		tst_resm(TFAIL, "master thread: setpgid(0,0) failed with error: %s", strerror(errno));
-+        pthread_exit(NULL);
-+	}
-+    else 
-+    {
-+		tst_resm(TINFO, "master thread: setpgid(0,0) success");
-+	}
++          SAFE_PTHREAD_CREATE(&master_tid, NULL, do_master_thread, NULL);
  
 -			}
 -			if (pid == 0) {
 -#ifdef UCLINUX
 -				if (self_exec(argv0, "n", 1) < 0) {
 -					tst_resm(TFAIL, "self_exec failed");
-+    s = SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child_thread, NULL);
++          SAFE_PTHREAD_JOIN(master_tid, NULL);
  
 -				}
 -#else
@@ -166,18 +128,9 @@ index ed8f0e4ad..dc6353b14 100644
 -	}
 -	cleanup();
 -	tst_exit();
-+    if (s == 0)
-+    {
-+        tst_resm(TINFO, "child thread created fine ...\n");
-+        SAFE_PTHREAD_JOIN(child_tid, NULL);
-+    }
-+    else
-+    {
-+        tst_resm(TFAIL, "child thread create failed ...\n");
-+        SAFE_PTHREAD_JOIN(child_tid, NULL);
-+    }
-+
-+    pthread_exit(NULL);
++     }
++     cleanup();
++     tst_exit();
  
  }
  
@@ -186,28 +139,32 @@ index ed8f0e4ad..dc6353b14 100644
 - */
 -void do_child_1(void)
 +
-+static void* do_child_thread(void* arg)
++static void* do_master_thread(void* arg)
  {
 -	int exno = 0;
 -	int retval, ret, status;
 -	int pid;
-+    int retval;
++     pthread_t child_tid;
  
 -	sleep(1);
-+    /* Since thread is being used , need to replace getppid() with getpid() */
-+    retval = setpgid(0, getpid());
++     if (setpgid(0, 0) < 0) {
++          tst_resm(TFAIL, "master thread: setpgid(0,0) failed with error: %s", strerror(errno));
++          pthread_exit(NULL);
++     }
++     else 
++     {
++          tst_resm(TINFO, "master thread: setpgid(0,0) success");
++     }
  
 -	if (setpgid(0, 0) < 0) {
 -		tst_resm(TFAIL, "setpgid(0,0) failed: %s", strerror(errno));
 -		exno = 1;
 -	}
-+    if (retval < 0) {
-+        tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
-+    }
-+    else
-+    {
-+        tst_resm(TINFO, "setpgid for child thread success");
-+    }
++     SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child_thread, NULL);
++
++     SAFE_PTHREAD_JOIN(child_tid, NULL);
++
++     pthread_exit(NULL);
  
 -	if ((pid = FORK_OR_VFORK()) == -1) {
 -		tst_brkm(TFAIL, NULL, "Fork failed");
@@ -248,40 +205,56 @@ index ed8f0e4ad..dc6353b14 100644
 -		}
 -	}
 -	exit(exno);
--}
-+    retval = setsid();
-+
-+    if (errno == EPERM) {
-+        tst_resm(TPASS, "setsid SUCCESS to set "
-+                "errno to EPERM");
-+    } else {
-+        tst_resm(TFAIL, "setsid failed, expected %d,"
-+                "return %d", -1, errno);
-+    }
-+
-+    pthread_exit(NULL);
+ }
  
 -/*
 - * do_child_2()
 - */
 -void do_child_2(void)
--{
++
++static void* do_child_thread(void* arg)
+ {
 -	for (;;) ;
++     int retval;
++
++     /* Since thread is being used , need to replace getppid() with getpid() */
++     retval = setpgid(0, getpid());
++
++     if (retval < 0) {
++          tst_resm(TFAIL, "setpgid failed, errno :%d", errno);
++     }
++     else
++     {
++          tst_resm(TINFO, "setpgid for child thread success");
++     }
++
++     retval = setsid();
++
++     if (errno == EPERM) {
++          tst_resm(TPASS, "setsid SUCCESS to set "
++                    "errno to EPERM");
++     } else {
++          tst_resm(TFAIL, "setsid failed, expected %d,"
++                    "return %d", -1, errno);
++     }
++
++     pthread_exit(NULL);
++
  }
  
  /*
-@@ -216,11 +184,11 @@ void do_child_2(void)
+@@ -216,11 +159,11 @@ void do_child_2(void)
  void setup(void)
  {
  
 -	tst_sig(FORK, DEF_HANDLER, cleanup);
-+    tst_sig(FORK, DEF_HANDLER, cleanup);
++     tst_sig(FORK, DEF_HANDLER, cleanup);
  
 -	umask(0);
-+    umask(0);
++     umask(0);
  
 -	TEST_PAUSE;
-+    TEST_PAUSE;
++     TEST_PAUSE;
  }
  
  /*

--- a/tests/ltp/patches/setsid01.patch
+++ b/tests/ltp/patches/setsid01.patch
@@ -1,5 +1,8 @@
+Patch Description: Tests were failing due to unavailability of fork() support. 
+So modified the tests to use pthreads and verify the error condition for setsid().
+
 diff --git a/testcases/kernel/syscalls/setsid/setsid01.c b/testcases/kernel/syscalls/setsid/setsid01.c
-index ed8f0e4ad..1e40e7b21 100644
+index ed8f0e4ad..f891140dd 100644
 --- a/testcases/kernel/syscalls/setsid/setsid01.c
 +++ b/testcases/kernel/syscalls/setsid/setsid01.c
 @@ -39,6 +39,8 @@
@@ -11,19 +14,18 @@ index ed8f0e4ad..1e40e7b21 100644
  
  #define INVAL_FLAG	-1
  #define USER2		301
-@@ -53,161 +55,102 @@ int TST_TOTAL = 1;
+@@ -53,18 +55,14 @@ int TST_TOTAL = 1;
  static char *argv0;
  #endif
  
 -void do_child_1(void);
 -void do_child_2(void);
- void setup(void);
- void cleanup(void);
- 
 +static void* do_child_thread(void* arg);
 +static void* do_master_thread(void* arg);
 +
-+
+ void setup(void);
+ void cleanup(void);
+ 
  int main(int ac, char **av)
  {
 -	int pid;
@@ -31,49 +33,19 @@ index ed8f0e4ad..1e40e7b21 100644
 -	int ret, status;
 -	int exno = 0;
 -
--	int lc;
-+     int lc;
+ 	int lc;
  
--	tst_parse_opts(ac, av, NULL, NULL);
-+     tst_parse_opts(ac, av, NULL, NULL);
- #ifdef UCLINUX
--	argv0 = av[0];
-+     argv0 = av[0];
+ 	tst_parse_opts(ac, av, NULL, NULL);
+@@ -86,128 +84,67 @@ int main(int ac, char **av)
+ 		tst_count = 0;
  
--	maybe_run_child(&do_child_1, "n", 1);
--	maybe_run_child(&do_child_2, "n", 2);
-+     maybe_run_child(&do_child_1, "n", 1);
-+     maybe_run_child(&do_child_2, "n", 2);
- #endif
- 
--	/*
--	 * perform global setup for the test
--	 */
--	setup();
-+     /*
-+      * perform global setup for the test
-+      */
-+     setup();
- 
--	for (lc = 0; TEST_LOOPING(lc); lc++) {
-+     for (lc = 0; TEST_LOOPING(lc); lc++) {
- 
--		/* reset tst_count in case we are looping */
--		tst_count = 0;
-+          /* reset tst_count in case we are looping */
-+          tst_count = 0;
- 
--		/*
+ 		/*
 -		 * When the process group having forked of a child
 -		 * and then it attached itself to another process
 -		 * group and tries to setsid
--		 */
++		 * Creates two threads and tries to do setsid()
+ 		 */
 -		pid = FORK_OR_VFORK();
-+          /*
-+           * When the process group having forked of a child
-+           * and then it attached itself to another process
-+           * group and tries to setsid
-+           */
 +          pthread_t master_tid;
  
 -		if (pid == 0) {
@@ -86,8 +58,7 @@ index ed8f0e4ad..1e40e7b21 100644
 -#ifdef UCLINUX
 -				if (self_exec(argv0, "n", 1) < 0) {
 -					tst_resm(TFAIL, "self_exec failed");
-+          SAFE_PTHREAD_JOIN(master_tid, NULL);
- 
+-
 -				}
 -#else
 -				do_child_1();
@@ -125,12 +96,10 @@ index ed8f0e4ad..1e40e7b21 100644
 -		if (!(fail || exno)) {
 -			tst_resm(TPASS, "all misc tests passed");
 -		}
--	}
--	cleanup();
--	tst_exit();
-+     }
-+     cleanup();
-+     tst_exit();
++          SAFE_PTHREAD_JOIN(master_tid, NULL);
+ 	}
+ 	cleanup();
+ 	tst_exit();
  
  }
  
@@ -138,7 +107,6 @@ index ed8f0e4ad..1e40e7b21 100644
 - * do_child_1()
 - */
 -void do_child_1(void)
-+
 +static void* do_master_thread(void* arg)
  {
 -	int exno = 0;
@@ -151,7 +119,7 @@ index ed8f0e4ad..1e40e7b21 100644
 +          tst_resm(TFAIL, "master thread: setpgid(0,0) failed with error: %s", strerror(errno));
 +          pthread_exit(NULL);
 +     }
-+     else 
++     else
 +     {
 +          tst_resm(TINFO, "master thread: setpgid(0,0) success");
 +     }
@@ -239,22 +207,6 @@ index ed8f0e4ad..1e40e7b21 100644
 +     }
 +
 +     pthread_exit(NULL);
-+
- }
- 
- /*
-@@ -216,11 +159,11 @@ void do_child_2(void)
- void setup(void)
- {
- 
--	tst_sig(FORK, DEF_HANDLER, cleanup);
-+     tst_sig(FORK, DEF_HANDLER, cleanup);
- 
--	umask(0);
-+     umask(0);
- 
--	TEST_PAUSE;
-+     TEST_PAUSE;
  }
  
  /*


### PR DESCRIPTION
Test to check the error and trivial conditions in setsid system call. Since fork system call is not supported, the main process creates a thread which in turn creates a child thread. The child thread will try to invoke setsid() and check for the required test condition.