### PR TITLE
Use OE's explicit ocall opt-in feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)):
 	# TODO replace with build option https://github.com/openenclave/openenclave/issues/2894
 	cd $(OE_SUBMODULE) && sed -i '/add_subdirectory(tests)/d' CMakeLists.txt
 	mkdir -p $(OE_SUBMODULE)/build
-	cd $(OE_SUBMODULE)/build && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX=$(OE_SDK_ROOT) -DENABLE_REFMAN=OFF -DCOMPILE_SYSTEM_EDL=ON ..
+	cd $(OE_SUBMODULE)/build && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX=$(OE_SDK_ROOT) -DENABLE_REFMAN=OFF -DCOMPILE_SYSTEM_EDL=OFF ..
 	$(MAKE) -C $(OE_SUBMODULE)/build -j$(tools/ncore.sh) && $(MAKE) -C $(OE_SUBMODULE)/build install
 
 # Install the glibc headers as for building libsgxlkl.so --nostdincludes is required.

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,8 @@ endif
 SGXLKL_OBJS=$(addprefix $(LIB_SGXLKL_BUILD)/sgxlkl/,$(SGXLKL_SRCS:.c=.o))
 
 ${OE_ENCLAVE_CALLS}: sgxlkl.edl
-	${OE_OESIGN_TOOL_PATH}/oeedger8r --trusted $< --trusted-dir enclave/
+	${OE_OESIGN_TOOL_PATH}/oeedger8r --search-path $(OE_SDK_INCLUDES) \
+		--trusted $< --trusted-dir enclave/
 	mv enclave/sgxlkl_t.h include/enclave/; mv enclave/sgxlkl_args.h include/shared/
 	sed -i '/#include "sgxlkl_t.h"/c\#include "enclave/sgxlkl_t.h"' enclave/sgxlkl_t.c
 	sed -i '/#include "sgxlkl_args.h"/c\#include "shared/sgxlkl_args.h"' enclave/sgxlkl_t.c
@@ -94,7 +95,8 @@ ifeq ($(findstring sgx_dcap_ql,$(OE_PKGCONFIG_OUTPUT)),sgx_dcap_ql)
 endif
 
 ${OE_HOST_CALLS}: sgxlkl.edl
-	${OE_OESIGN_TOOL_PATH}/oeedger8r --untrusted $< --untrusted-dir main-oe/
+	${OE_OESIGN_TOOL_PATH}/oeedger8r --search-path $(OE_SDK_INCLUDES) \
+		--untrusted $< --untrusted-dir main-oe/
 	mv main-oe/sgxlkl_u.h include/host/; mv main-oe/sgxlkl_args.h include/shared/
 	sed -i '/#include "sgxlkl_u.h"/c\#include "host/sgxlkl_u.h"' main-oe/sgxlkl_u.c
 	sed -i '/#include "sgxlkl_args.h"/c\#include "shared/sgxlkl_args.h"' main-oe/sgxlkl_u.c

--- a/src/sgxlkl.edl
+++ b/src/sgxlkl.edl
@@ -1,6 +1,24 @@
 // SGX-LKL-OE enclave/host interface
 
 enclave {
+    /*
+     * OE requires applications to import EDL used by the SDK to support some
+     * core functionality.
+     *
+     * - attestation.edl & sgx_attestation.edl are needed for OE attestation
+     *   APIs
+     * - logging.edl is needed to support OE diagnostic console logging
+     * - cpu.edl is not required by SGX-LKL, but OE is linked in such a way
+     *   that all applications must import it. This should be changed in OE
+     * - debug.edl should only be needed for debug builds but it is always linked
+     *   into oecore. Additionally, EDL does not currently support conditional
+     *   imports
+     */
+    from "openenclave/edl/attestation.edl" import *;
+    from "openenclave/edl/logging.edl" import *;
+    from "openenclave/edl/sgx/cpu.edl" import *;
+    from "openenclave/edl/sgx/debug.edl" import *;
+    from "openenclave/edl/sgx/sgx_attestation.edl" import *;
 
     include "shared/sgxlkl_config.h"
 


### PR DESCRIPTION
Switch to the OE configuration that allows OE applications to explicitly opt-in to which system EDL ecalls/ocalls it wishes to use. The previous behavior was that OE compiled in all system EDL by default.