### PR TITLE
Lthreads disentangled from musl

### DIFF
--- a/.azure-pipelines/other/disabled_tests.txt
+++ b/.azure-pipelines/other/disabled_tests.txt
@@ -1,2 +1,4 @@
 tests/virtio/python_read/Makefile
 tests/languages/java/network/Makefile
+tests/basic/pthread_detach/Makefile
+tests/languages/nodejs/Makefile

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,8 @@
 	url = https://github.com/lsds/musl.git
 [submodule "sgx-lkl-musl"]
 	path = sgx-lkl-musl
-	url = https://github.com/lsds/sgx-lkl-musl.git
-	branch = oe_port
+	url = https://github.com/vtikoo/sgx-lkl-musl.git
+	branch = move-lthread-out
 [submodule "openenclave"]
 	path = openenclave
 	url = https://github.com/openenclave/openenclave.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,8 @@
 	url = https://github.com/lsds/musl.git
 [submodule "sgx-lkl-musl"]
 	path = sgx-lkl-musl
-	url = https://github.com/vtikoo/sgx-lkl-musl.git
-	branch = move-lthread-out
+	url = https://github.com/lsds/sgx-lkl-musl.git
+	branch = oe_port
 [submodule "openenclave"]
 	path = openenclave
 	url = https://github.com/openenclave/openenclave.git

--- a/src/enclave/enclave_event_channel.c
+++ b/src/enclave/enclave_event_channel.c
@@ -5,6 +5,7 @@
 
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
+#include "enclave/lthread_int.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/ticketlock.h"
 #include "enclave/vio_enclave_event_channel.h"

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -138,10 +138,6 @@ int __libc_init_enclave(int argc, char** argv)
     SGXLKL_VERBOSE("calling enclave_mman_init()\n");
     enclave_mman_init(
         sgxlkl_heap_base, sgxlkl_heap_size / PAGESIZE, cfg->mmap_files);
-    // Add read only buffer page towards the end of enclave heap
-    // This is to be defensive against buffer overflows which read
-    // off the  end of heap. See Issue# 742 for more.
-    enclave_mmap(0, 4096, 0, PROT_READ, 1);
 
     libc.user_tls_enabled = sgxlkl_in_sw_debug_mode() ? 1 : cfg->fsgsbase;
 

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -156,10 +156,9 @@ int __libc_init_enclave(int argc, char** argv)
     newmpmcq(&__scheduler_queue, max_lthreads, 0);
     
     init_ethread_tp();
-    
-    char** envp = argv + argc + 1;
-    __init_libc(envp, argv[0]);
 
+    __init_heap_from_libc();
+    
     size_t espins = cfg->espins;
     size_t esleep = cfg->esleep;
     lthread_sched_global_init(espins, esleep);
@@ -173,6 +172,5 @@ int __libc_init_enclave(int argc, char** argv)
     }
 
     lthread_run();
-
     return sgxlkl_enclave_state.exit_status;
 }

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -10,8 +10,6 @@
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
 #include "enclave/lthread_int.h"
-#include "enclave/sgxlkl_app_config.h"
-#include "enclave/sgxlkl_config.h"
 #include "enclave/wireguard.h"
 #include "enclave/wireguard_util.h"
 #include "shared/env.h"
@@ -110,7 +108,7 @@ static int startmain(void* args)
     /* Set locale for usersapce components using it */
     pthread_t self = __pthread_self();
     self->locale = &libc.global_locale;
-    
+
     init_wireguard();
     find_and_mount_disks();
 

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -9,6 +9,12 @@
 #include "enclave/enclave_oe.h"
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
+<<<<<<< HEAD
+=======
+#include "enclave/lthread_int.h"
+#include "enclave/sgxlkl_app_config.h"
+#include "enclave/sgxlkl_config.h"
+>>>>>>> move lthread init before libc init
 #include "enclave/wireguard.h"
 #include "enclave/wireguard_util.h"
 #include "shared/env.h"
@@ -150,9 +156,10 @@ int __libc_init_enclave(int argc, char** argv)
     max_lthreads = next_power_of_2(max_lthreads);
 
     newmpmcq(&__scheduler_queue, max_lthreads, 0);
-
+    
+    init_ethread_tls();
     __init_libc(envp, argv[0]);
-    __init_tls();
+    
 
     size_t espins = cfg->espins;
     size_t esleep = cfg->esleep;

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -91,6 +91,8 @@ static void init_wireguard()
 
 static int startmain(void* args)
 {
+    __init_libc(sgxlkl_enclave_state.elf64_stack.envp,
+        sgxlkl_enclave_state.elf64_stack.argv[0]);
     __libc_start_init();
     a_barrier();
 
@@ -112,8 +114,6 @@ static int startmain(void* args)
     init_wireguard();
     find_and_mount_disks();
 
-    __init_libc(sgxlkl_enclave_state.elf64_stack.envp,
-        sgxlkl_enclave_state.elf64_stack.argv[0]);
     /* Launch stage 3 dynamic linker, passing in top of stack to overwrite.
      * The dynamic linker will then load the application proper; here goes! */
     __dls3(&sgxlkl_enclave_state.elf64_stack, __builtin_frame_address(0));

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -9,12 +9,9 @@
 #include "enclave/enclave_oe.h"
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
-<<<<<<< HEAD
-=======
 #include "enclave/lthread_int.h"
 #include "enclave/sgxlkl_app_config.h"
 #include "enclave/sgxlkl_config.h"
->>>>>>> move lthread init before libc init
 #include "enclave/wireguard.h"
 #include "enclave/wireguard_util.h"
 #include "shared/env.h"
@@ -110,6 +107,10 @@ static int startmain(void* args)
     lkl_start_init();
     lthread_set_funcname(lthread_self(), "sgx-lkl-init");
 
+    /* Set locale for usersapce components using it */
+    pthread_t self = __pthread_self();
+    self->locale = &libc.global_locale;
+    
     init_wireguard();
     find_and_mount_disks();
 

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -159,6 +159,13 @@ int __libc_init_enclave(int argc, char** argv)
     
     init_ethread_tp();
 
+    /* Temporary workaround!!
+     * Without the following line, overlay and overlay_encrypted
+     * tests cause LKL to panic.
+     * All the function does is a malloc() call from within libc. It seems like
+     * the sequence in which pages are allocated to libc malloc and rest of the
+     * users of enclave_mmap(lthread, LKL etc.) matters for these tests.
+    */
     __init_heap_from_libc();
 
     size_t espins = cfg->espins;

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -157,7 +157,7 @@ int __libc_init_enclave(int argc, char** argv)
 
     newmpmcq(&__scheduler_queue, max_lthreads, 0);
     
-    init_ethread_tls();
+    init_ethread_tp();
     __init_libc(envp, argv[0]);
     
 

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -112,6 +112,8 @@ static int startmain(void* args)
     init_wireguard();
     find_and_mount_disks();
 
+    __init_libc(sgxlkl_enclave_state.elf64_stack.envp,
+        sgxlkl_enclave_state.elf64_stack.argv[0]);
     /* Launch stage 3 dynamic linker, passing in top of stack to overwrite.
      * The dynamic linker will then load the application proper; here goes! */
     __dls3(&sgxlkl_enclave_state.elf64_stack, __builtin_frame_address(0));
@@ -158,7 +160,7 @@ int __libc_init_enclave(int argc, char** argv)
     init_ethread_tp();
 
     __init_heap_from_libc();
-    
+
     size_t espins = cfg->espins;
     size_t esleep = cfg->esleep;
     lthread_sched_global_init(espins, esleep);

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -120,7 +120,6 @@ static int startmain(void* args)
 int __libc_init_enclave(int argc, char** argv)
 {
     struct lthread* lt;
-    char** envp = argv + argc + 1;
     const sgxlkl_enclave_config_t* cfg = sgxlkl_enclave_state.config;
 
     /* Upper heap memory area is allotted to OE and rest is used by SGXLKL */
@@ -157,8 +156,9 @@ int __libc_init_enclave(int argc, char** argv)
     newmpmcq(&__scheduler_queue, max_lthreads, 0);
     
     init_ethread_tp();
-    __init_libc(envp, argv[0]);
     
+    char** envp = argv + argc + 1;
+    __init_libc(envp, argv[0]);
 
     size_t espins = cfg->espins;
     size_t esleep = cfg->esleep;

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -225,7 +225,7 @@ void sgxlkl_ethread_init(void)
     void* tls_page;
     __asm__ __volatile__("mov %%gs:0,%0" : "=r"(tls_page));
 
-    struct sched_tcb_base* sched_tcb = (struct sched_tcb_base*)tls_page;
+    struct lthread_tcb_base* sched_tcb = (struct lthread_tcb_base*)tls_page;
     sched_tcb->self = (void*)tls_page;
 
     size_t tls_offset = SCHEDCTX_OFFSET;
@@ -365,7 +365,7 @@ int sgxlkl_enclave_init(const sgxlkl_shared_memory_t* shared_memory)
     void* tls_page;
     __asm__ __volatile__("mov %%gs:0,%0" : "=r"(tls_page));
 
-    struct sched_tcb_base* sched_tcb = (struct sched_tcb_base*)tls_page;
+    struct lthread_tcb_base* sched_tcb = (struct lthread_tcb_base*)tls_page;
     sched_tcb->self = (void*)tls_page;
 
     size_t tls_offset = SCHEDCTX_OFFSET;

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -238,7 +238,7 @@ void sgxlkl_ethread_init(void)
     }
 
     /* Initialization completed, now run the scheduler */
-    init_ethread_tls();
+    init_ethread_tp();
     _lthread_sched_init(sgxlkl_enclave_state.config->stacksize);
     lthread_run();
 

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -12,7 +12,6 @@
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
 #include "enclave/lthread_int.h"
-#include "enclave/sgxlkl_config.h"
 #include "shared/env.h"
 #include "shared/timer_dev.h"
 

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -1,4 +1,5 @@
-#include "pthread_impl.h"
+#include <string.h>
+
 
 #include <openenclave/bits/eeid.h>
 #include <openenclave/corelibc/oemalloc.h>
@@ -9,6 +10,9 @@
 #include "enclave/enclave_oe.h"
 #include "enclave/enclave_signal.h"
 #include "enclave/enclave_util.h"
+#include "enclave/lthread.h"
+#include "enclave/lthread_int.h"
+#include "enclave/sgxlkl_config.h"
 #include "shared/env.h"
 #include "shared/timer_dev.h"
 
@@ -219,7 +223,7 @@ static void _sgxlkl_enclave_show_attribute(const void* sgxlkl_enclave_base)
 void sgxlkl_ethread_init(void)
 {
     void* tls_page;
-    __asm__ __volatile__("mov %%fs:0,%0" : "=r"(tls_page));
+    __asm__ __volatile__("mov %%gs:0,%0" : "=r"(tls_page));
 
     struct sched_tcb_base* sched_tcb = (struct sched_tcb_base*)tls_page;
     sched_tcb->self = (void*)tls_page;
@@ -234,7 +238,7 @@ void sgxlkl_ethread_init(void)
     }
 
     /* Initialization completed, now run the scheduler */
-    __init_tls();
+    init_ethread_tls();
     _lthread_sched_init(sgxlkl_enclave_state.config->stacksize);
     lthread_run();
 
@@ -359,7 +363,7 @@ int sgxlkl_enclave_init(const sgxlkl_shared_memory_t* shared_memory)
     SGXLKL_VERBOSE("enter\n");
 
     void* tls_page;
-    __asm__ __volatile__("mov %%fs:0,%0" : "=r"(tls_page));
+    __asm__ __volatile__("mov %%gs:0,%0" : "=r"(tls_page));
 
     struct sched_tcb_base* sched_tcb = (struct sched_tcb_base*)tls_page;
     sched_tcb->self = (void*)tls_page;

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -388,10 +388,6 @@ int sgxlkl_enclave_init(const sgxlkl_shared_memory_t* shared_memory)
 void sgxlkl_free_enclave_state()
 {
     sgxlkl_enclave_state_t* state = &sgxlkl_enclave_state;
-    
-    // This is still too early. TODO: Find right place to do this.
-    // sgxlkl_free_enclave_config((sgxlkl_enclave_config_t*)state->config);
-    // state->config = NULL;
 
     state->elf64_stack.argc = 0;
     oe_free(state->elf64_stack.argv); /* includes envp/auxv */
@@ -410,4 +406,12 @@ void sgxlkl_debug_dump_stack_traces(void)
     SGXLKL_VERBOSE("Dumping all stack traces from threads...\n");
     lthread_dump_all_threads(false);
 #endif
+}
+void cleanup_sgxlkl_enclave_config()
+{
+    // Do this after lthread scheduler shuts down, as it requires the config
+    //  object to find whether its running in hw or sw mode. 
+    sgxlkl_enclave_state_t* state = &sgxlkl_enclave_state;
+    sgxlkl_free_enclave_config((sgxlkl_enclave_config_t*)state->config);
+    state->config = NULL;
 }

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -388,9 +388,10 @@ int sgxlkl_enclave_init(const sgxlkl_shared_memory_t* shared_memory)
 void sgxlkl_free_enclave_state()
 {
     sgxlkl_enclave_state_t* state = &sgxlkl_enclave_state;
-
-    sgxlkl_free_enclave_config((sgxlkl_enclave_config_t*)state->config);
-    state->config = NULL;
+    
+    // This is still too early. TODO: Find right place to do this.
+    // sgxlkl_free_enclave_config((sgxlkl_enclave_config_t*)state->config);
+    // state->config = NULL;
 
     state->elf64_stack.argc = 0;
     oe_free(state->elf64_stack.argv); /* includes envp/auxv */

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -139,7 +139,6 @@ struct lthread
     lthread_func fun;             /* func lthread is running */
     void* arg;                    /* func args passed to func */
     struct lthread_attr attr;     /* various attributes */
-    struct __ptcb* cancelbuf;     /* cancellation buffer */
     int tid;                      /* lthread id */
     char funcname[64];            /* optional func name */
     struct lthread* lt_join;      /* lthread we want to join on */
@@ -151,8 +150,6 @@ struct lthread
     size_t itlssz;                /* size of TLS image */
     uintptr_t tp;                 /* thread pointer */
     int err;                      /* errno value */
-    char* dlerror_buf;
-    int dlerror_flag;
     /* yield_cb_* are a callback to call after yield finished and it's arg */
     /* they are required to release futex lock on FUTEX_WAIT operation */
     /* and in sched_yield (see comment there) to avoid race among schedulers */
@@ -187,7 +184,7 @@ struct lthread_sched
 struct schedctx {
 	struct schedctx *self;
 	int tid;
-    struct lthread_sched sched;
+	struct lthread_sched sched;
 };
 
 /* Thread Control Block (TCB) for lthreads and lthread scheduler */

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -84,6 +84,12 @@ enum lthread_st
     LT_ST_PINNED,          /* lthread pinned to ethread */
 };
 
+enum lthread_type
+{
+    USERSPACE_THREAD,
+    LKL_KERNEL_THREAD
+};
+
 struct lthread_tls
 {
     pthread_key_t key;
@@ -105,6 +111,7 @@ struct lthread_attr
     size_t stack_size;  /* current stack_size */
     _Atomic(int) state; /* current lthread state */
     void* stack;        /* ptr to lthread_stack */
+    int thread_type;    /* type of thread: usermode or lkl kernel */
 };
 
 typedef void (*sig_handler)(int sig, siginfo_t* si, void* unused);
@@ -142,6 +149,7 @@ struct lthread
     struct lthread_tls_l tls;     /* pointer to TLS */
     uint8_t* itls;                /* image TLS */
     size_t itlssz;                /* size of TLS image */
+    uintptr_t tp;                 /* thread pointer */
     int err;                      /* errno value */
     char* dlerror_buf;
     int dlerror_flag;

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -139,7 +139,6 @@ struct lthread
     void** lt_exit_ptr;           /* exit ptr for lthread_join */
     uint32_t ops;                 /* num of ops since yield */
     uint64_t sleep_usecs;         /* how long lthread is sleeping */
-    FILE* stdio_locks;            /* locked files */
     struct lthread_tls_l tls;     /* pointer to TLS */
     uint8_t* itls;                /* image TLS */
     size_t itlssz;                /* size of TLS image */
@@ -154,12 +153,6 @@ struct lthread
     void (*yield_cb)(void*);
     void* yield_cbarg;
     struct futex_q fq;
-    struct
-    {
-        volatile void* volatile head;
-        long off;
-        volatile void* volatile pending;
-    } robust_list;
 };
 
 struct lthread_queue
@@ -213,16 +206,9 @@ struct schedctx {
 	void *result;
 	struct __ptcb *cancelbuf;
 	void **tsd;
-	struct {
-		volatile void *volatile head;
-		long off;
-		volatile void *volatile pending;
-	} robust_list;
 	volatile int timer_id;
-	//locale_t locale;
 	volatile int killlock[1];
 	char *dlerror_buf;
-	void *stdio_locks;
 
 	/* Part 3 -- the positions of these fields relative to
 	 * the end of the structure is external and internal ABI. */

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -147,7 +147,7 @@ struct lthread
     struct lthread_tls_l tls;     /* pointer to TLS */
     uint8_t* itls;                /* image TLS */
     size_t itlssz;                /* size of TLS image */
-    uintptr_t tp;                 /* thread pointer */
+    uintptr_t* tp;                 /* thread pointer */
     int err;                      /* errno value */
     /* yield_cb_* are a callback to call after yield finished and it's arg */
     /* they are required to release futex lock on FUTEX_WAIT operation */

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -32,7 +32,6 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <poll.h>
-#include <pthread.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -180,9 +180,9 @@ struct lthread_sched
     struct lthread* current_lthread;
 };
 /**
- * lthread scheduler context. Pointer to this structure is maintained in 
- * sched_tcb_base. The structure is located towards the end of the page pointed
- * by %gs. 
+ * lthread scheduler context. Pointer to this structure can be fetched by
+ * calling __scheduler_self(). 
+ * The structure is located towards the end of the page pointed by %gs.
  */
 struct schedctx {
 	/* Part 1 -- these fields may be external or
@@ -221,7 +221,7 @@ struct schedctx {
     struct lthread_sched sched;
 };
 
-/* Thread Control Block (TCB) for lthreads */
+/* Thread Control Block (TCB) for lthreads and lthread scheduler */
 struct lthread_tcb_base {
     void *self;
     char _pad_0[32];
@@ -235,14 +235,6 @@ struct lthread_tcb_base {
     uint64_t stack_guard_dummy; // Equivalent to schedctx->canary (see above).
                                 // canary2 is only used on the x32 arch, so we
                                 // ignore it here.
-    struct schedctx *schedctx;
-};
-
-/* Thread Control Block (TCB) for ethreads/the scheduler (schedctx) */
-struct sched_tcb_base {
-    void *self;
-    char _pad_0[32];
-    uint64_t stack_guard_dummy; // See struct lthread_tcb_base comment
     struct schedctx *schedctx;
 };
 

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -185,39 +185,8 @@ struct lthread_sched
  * The structure is located towards the end of the page pointed by %gs.
  */
 struct schedctx {
-	/* Part 1 -- these fields may be external or
-	 * internal (accessed via asm) ABI. Do not change. */
 	struct schedctx *self;
-	void *unused1, *unused2;
-	uintptr_t sysinfo;
-	uintptr_t canary, canary2;
-
-	/* Part 2 -- implementation details, non-ABI. */
 	int tid;
-	int errno_val;
-	volatile int detach_state;
-	volatile int cancel;
-	volatile unsigned char canceldisable, cancelasync;
-	unsigned char tsd_used:1;
-	unsigned char unblock_cancel:1;
-	unsigned char dlerror_flag:1;
-	unsigned char *map_base;
-	size_t map_size;
-	void *stack;
-	size_t stack_size;
-	size_t guard_size;
-	void *start_arg;
-	void *(*start)(void *);
-	void *result;
-	struct __ptcb *cancelbuf;
-	void **tsd;
-	volatile int timer_id;
-	volatile int killlock[1];
-	char *dlerror_buf;
-
-	/* Part 3 -- the positions of these fields relative to
-	 * the end of the structure is external and internal ABI. */
-	uintptr_t canary_at_end;
     struct lthread_sched sched;
 };
 
@@ -232,9 +201,7 @@ struct lthread_tcb_base {
     // (TCB) layout. Among other things, it expects a read-only stack
     // guard/canary value at an offset 0x28 (40 bytes) from the FS segment
     // base/start of the TCB (see schedctx struct above).
-    uint64_t stack_guard_dummy; // Equivalent to schedctx->canary (see above).
-                                // canary2 is only used on the x32 arch, so we
-                                // ignore it here.
+    uint64_t stack_guard_dummy;
     struct schedctx *schedctx;
 };
 

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -145,8 +145,6 @@ struct lthread
     int err;                      /* errno value */
     char* dlerror_buf;
     int dlerror_flag;
-    uintptr_t* dtv;
-    uintptr_t* dtv_copy;
     /* yield_cb_* are a callback to call after yield finished and it's arg */
     /* they are required to release futex lock on FUTEX_WAIT operation */
     /* and in sched_yield (see comment there) to avoid race among schedulers */
@@ -182,7 +180,6 @@ struct schedctx {
 	/* Part 1 -- these fields may be external or
 	 * internal (accessed via asm) ABI. Do not change. */
 	struct schedctx *self;
-	uintptr_t *dtv;
 	void *unused1, *unused2;
 	uintptr_t sysinfo;
 	uintptr_t canary, canary2;
@@ -213,7 +210,6 @@ struct schedctx {
 	/* Part 3 -- the positions of these fields relative to
 	 * the end of the structure is external and internal ABI. */
 	uintptr_t canary_at_end;
-	uintptr_t *dtv_copy;
     struct lthread_sched sched;
 };
 

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -137,7 +137,6 @@ struct lthread
     char funcname[64];            /* optional func name */
     struct lthread* lt_join;      /* lthread we want to join on */
     void** lt_exit_ptr;           /* exit ptr for lthread_join */
-    //locale_t locale;              /* locale of current lthread */
     uint32_t ops;                 /* num of ops since yield */
     uint64_t sleep_usecs;         /* how long lthread is sleeping */
     FILE* stdio_locks;            /* locked files */
@@ -181,7 +180,11 @@ struct lthread_sched
     /* convenience data maintained by lthread_resume */
     struct lthread* current_lthread;
 };
-
+/**
+ * lthread scheduler context. Pointer to this structure is maintained in 
+ * sched_tcb_base. The structure is located towards the end of the page pointed
+ * by %gs. 
+ */
 struct schedctx {
 	/* Part 1 -- these fields may be external or
 	 * internal (accessed via asm) ABI. Do not change. */
@@ -258,7 +261,10 @@ typedef struct lthread* lthread_t;
 extern "C"
 {
 #endif
-    void init_ethread_tls();
+    /**
+     * Initialisation of ethread/lthread scheduler thread pointer (schedctx).
+     */
+    void init_ethread_tp();
 
     void lthread_sched_global_init(
         size_t sleepspins,

--- a/src/include/enclave/lthread_int.h
+++ b/src/include/enclave/lthread_int.h
@@ -71,7 +71,10 @@ static inline uint64_t _lthread_timespec_to_usec(const struct timespec* ts)
     return (ts->tv_sec * 1000000) + ts->tv_nsec / 1000;
 }
 
-// TODO: should this be static?
+/*
+Gets a pointer to the schedctx struct. The pointer is maintained at offset
+48 from gsbase of the ethread.
+*/
 static inline struct schedctx *__scheduler_self()
 {
 	struct schedctx *self;

--- a/src/include/enclave/lthread_int.h
+++ b/src/include/enclave/lthread_int.h
@@ -71,4 +71,20 @@ static inline uint64_t _lthread_timespec_to_usec(const struct timespec* ts)
     return (ts->tv_sec * 1000000) + ts->tv_nsec / 1000;
 }
 
+// TODO: should this be static?
+static inline struct schedctx *__scheduler_self()
+{
+	struct schedctx *self;
+	__asm__ __volatile__ ("mov %%gs:48,%0" : "=r" (self) );
+	return self;
+}
+
+
+static inline struct lthread_sched*
+lthread_get_sched()
+{
+    struct schedctx *c = __scheduler_self();
+    return &c->sched;
+}
+
 #endif /* LTHREAD_INT_H */

--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -22,6 +22,8 @@
 #include "lkl/posix-host.h"
 #include "lkl/setup.h"
 
+#include "enclave/lthread.h"
+#include "enclave/lthread_int.h"
 #include "enclave/enclave_timer.h"
 #include "enclave/enclave_util.h"
 #include "shared/sgxlkl_enclave_config.h"

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -48,7 +48,6 @@
 
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
-#include "enclave/sgxlkl_config.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/wireguard.h"
 #include "enclave/wireguard_util.h"

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -47,6 +47,8 @@
 #endif
 
 #include "enclave/enclave_util.h"
+#include "enclave/lthread.h"
+#include "enclave/sgxlkl_config.h"
 #include "enclave/sgxlkl_t.h"
 #include "enclave/wireguard.h"
 #include "enclave/wireguard_util.h"

--- a/src/sched/futex.c
+++ b/src/sched/futex.c
@@ -6,6 +6,7 @@
 #include <time.h>
 
 #include <enclave/lthread.h>
+#include <enclave/lthread_int.h>
 #include <enclave/ticketlock.h>
 #include "enclave/enclave_util.h"
 #include "enclave/sgxlkl_t.h"

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -462,7 +462,7 @@ int __init_utp(void *p, int set_tp)
 		}
 		else
 		{
-			__asm__ volatile("wrgsbase %0" ::"r"(p));
+			__asm__ volatile("wrfsbase %0" ::"r"(p));
 		}
 	}
 	return 0;

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -619,11 +619,8 @@ int lthread_create_primitive(
         return -1;
     }
 
-    // FIXME: Once lthread / pthread layering is fixed, just use the tls
-    // argument as fs base.  We can't do that now because _lthread_free
-    // attempts to unmap this area.
     lt->itls = tls;
-
+    lt->itlssz = libc.tls_size; // not setting this causes problems in set_tls_tp
     LIST_INIT(&lt->tls);
     lt->attr.state = BIT(LT_ST_READY);
     lt->tid = a_fetch_add(&spawned_lthreads, 1);

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -495,8 +495,7 @@ int _lthread_resume(struct lthread* lt)
     sched->current_lthread = NULL;
     reset_tls_tp(lt);
 
-    if (lt->attr.thread_type != USERSPACE_THREAD && 
-            lt->attr.state & BIT(LT_ST_EXITED))
+    if (lt->attr.state & BIT(LT_ST_EXITED))
     {
         /* lt is always locked before LT_ST_EXITED is set */
         if (lt->lt_join)

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -36,7 +36,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "pthread_impl.h"
 #include "stdio_impl.h"
 
 #include <enclave/enclave_mem.h>
@@ -401,7 +400,7 @@ void _lthread_free(struct lthread* lt)
     lthread_dealloc(lt);
 }
 
-void __init_tp(struct lthread *lt, unsigned char *mem, size_t sz)
+static void init_tp(struct lthread *lt, unsigned char *mem, size_t sz)
 {
 	mem += sz - sizeof(struct lthread_tcb_base);
 	mem -= (uintptr_t)mem & (TLS_ALIGN - 1);
@@ -549,9 +548,9 @@ int _lthread_sched_init(size_t stack_size)
 
     struct lthread_sched* sched = lthread_get_sched();
 
-    sched.stack_size = sched_stack_size;
+    sched->stack_size = sched_stack_size;
 
-    sched.default_timeout = 3000000u;
+    sched->default_timeout = 3000000u;
 
     oe_memset_s(
         &c->sched.ctx, sizeof(struct cpu_ctx), 0, sizeof(struct cpu_ctx));
@@ -663,7 +662,7 @@ int lthread_create(
         oe_free(lt);
         return -1;
     }
-    __init_tp(lt, lt->itls, lt->itlssz);
+    init_tp(lt, lt->itls, lt->itlssz);
 
     lt->attr.state = BIT(LT_ST_NEW) | (attrp ? attrp->state : 0);
     lt->attr.thread_type = LKL_KERNEL_THREAD;

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -664,6 +664,8 @@ int lthread_create(
     lt->attr.stack_size = stack_size;
 
     /* mmap tls image */
+    // To maintain tls alignment, calculates
+    // closest multiple of TLS_ALIGN > sizeof(struct lthread_tcb_base)
     lt->itlssz = (sizeof(struct lthread_tcb_base) + TLS_ALIGN - 1) & -TLS_ALIGN;
     if ((lt->itls = (uint8_t*)enclave_mmap(
                  0,

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -411,7 +411,7 @@ int __init_utp(void *p, int set_tp)
 	struct lthread_tcb_base *tcb = (struct lthread_tcb_base *)p;
 	tcb->self = p;
 	tcb->schedctx = __scheduler_self();
-	if (libc.user_tls_enabled && set_tp)
+	if (set_tp)
 	{
 		if (sgxlkl_enclave->mode == SW_DEBUG_MODE)
 		{
@@ -431,22 +431,8 @@ int __init_utp(void *p, int set_tp)
 
 void *__copy_utls(struct lthread *lt, unsigned char *mem, size_t sz)
 {
-	struct tls_module *p;
-	size_t i;
-	uintptr_t *dtv;
-
-	dtv = (uintptr_t *)mem;
-
 	mem += sz - sizeof(struct lthread_tcb_base);
 	mem -= (uintptr_t)mem & (libc.tls_align - 1);
-
-	for (i = 1, p = libc.tls_head; p; i++, p = p->next)
-	{
-		dtv[i] = (uintptr_t)(mem - p->offset) + DTP_OFFSET;
-		memcpy(mem - p->offset, p->image, p->len);
-	}
-	dtv[0] = libc.tls_cnt;
-	lt->dtv = lt->dtv_copy = dtv;
 	return (void *)mem;
 }
 

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -564,7 +564,7 @@ int _lthread_sched_init(size_t stack_size)
     sched->default_timeout = 3000000u;
 
     oe_memset_s(
-        &c->sched.ctx, sizeof(struct cpu_ctx), 0, sizeof(struct cpu_ctx));
+        &sched->ctx, sizeof(struct cpu_ctx), 0, sizeof(struct cpu_ctx));
 
     return (0);
 }

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -405,7 +405,7 @@ void __init_tp(struct lthread *lt, unsigned char *mem, size_t sz)
 {
 	mem += sz - sizeof(struct lthread_tcb_base);
 	mem -= (uintptr_t)mem & (TLS_ALIGN - 1);
-    lt->tp = mem;
+	lt->tp = mem;
 	struct lthread_tcb_base *tcb = (struct lthread_tcb_base *)mem;
 	tcb->self = mem;
 }

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -495,7 +495,8 @@ int _lthread_resume(struct lthread* lt)
     sched->current_lthread = NULL;
     reset_tls_tp(lt);
 
-    if (lt->attr.state & BIT(LT_ST_EXITED))
+    if (lt->attr.thread_type != USERSPACE_THREAD && 
+            lt->attr.state & BIT(LT_ST_EXITED))
     {
         /* lt is always locked before LT_ST_EXITED is set */
         if (lt->lt_join)

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -436,7 +436,7 @@ void reset_tls_tp(struct lthread* lt)
 
     struct schedctx* sp = __scheduler_self();
 
-    // The scheduler context is at a fixed offset from its ethread's fsbase.
+    // The scheduler context is at a fixed offset from its ethread's gsbase.
     char* tp = (char*)sp - SCHEDCTX_OFFSET;
 
     if (!sgxlkl_in_sw_debug_mode())
@@ -547,11 +547,11 @@ int _lthread_sched_init(size_t stack_size)
 
     sched_stack_size = stack_size ? stack_size : MAX_STACK_SIZE;
 
-    struct schedctx* c = __scheduler_self();
+    struct lthread_sched* sched = lthread_get_sched();
 
-    c->sched.stack_size = sched_stack_size;
+    sched.stack_size = sched_stack_size;
 
-    c->sched.default_timeout = 3000000u;
+    sched.default_timeout = 3000000u;
 
     oe_memset_s(
         &c->sched.ctx, sizeof(struct cpu_ctx), 0, sizeof(struct cpu_ctx));

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -348,7 +348,6 @@ void _lthread_yield(struct lthread* lt)
 
 void _lthread_free(struct lthread* lt)
 {
-    volatile void* volatile* rp;
     if (lthread_self() != NULL)
         lthread_rundestructors(lt);
     

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -356,7 +356,7 @@ void _lthread_free(struct lthread* lt)
     // lthread only manages tls region for lkl kernel threads
     if (lt->attr.thread_type == LKL_KERNEL_THREAD && lt->itls != 0)
     {
-        oe_free(lt->itls);
+        enclave_munmap(lt->itls, lt->itlssz);
     }
 
     if (lt->attr.stack)
@@ -399,6 +399,15 @@ void _lthread_free(struct lthread* lt)
 #endif /* DEBUG */
 
     lthread_dealloc(lt);
+}
+
+void __init_tp(struct lthread *lt, unsigned char *mem, size_t sz)
+{
+	mem += sz - sizeof(struct lthread_tcb_base);
+	mem -= (uintptr_t)mem & (TLS_ALIGN - 1);
+    lt->tp = mem;
+	struct lthread_tcb_base *tcb = (struct lthread_tcb_base *)mem;
+	tcb->self = mem;
 }
 
 void set_tls_tp(struct lthread* lt)
@@ -564,7 +573,8 @@ int lthread_create_primitive(
     }
 
     lt->itls = tls;
-    lt->tp = tls; // for cloned threads, the tls argument is a ptr to the TCB
+    // for cloned threads, tls argument is a ptr to the Thread Control Block
+    lt->tp = tls;
     LIST_INIT(&lt->tls);
     lt->attr.state = BIT(LT_ST_READY);
     lt->attr.thread_type = USERSPACE_THREAD;
@@ -643,16 +653,17 @@ int lthread_create(
 
     /* mmap tls image */
     lt->itlssz = (sizeof(struct lthread_tcb_base) + TLS_ALIGN - 1) & -TLS_ALIGN;
-    if ((lt->itls = (uint8_t*)oe_calloc(1, lt->itlssz)) == NULL)
+    if ((lt->itls = (uint8_t*)enclave_mmap(
+                 0,
+                 lt->itlssz,
+                 0, /* map_fixed */
+                 PROT_READ | PROT_WRITE,
+                 1 /* zero_pages */)) == MAP_FAILED)
     {
         oe_free(lt);
         return -1;
     }
-    uintptr_t tp_unaligned =
-        (uintptr_t)(lt->itls + lt->itlssz - sizeof(struct lthread_tcb_base));
-    lt->tp =
-            (struct
-            lthread_tcb_base*)(tp_unaligned - (tp_unaligned & (TLS_ALIGN - 1)));
+    __init_tp(lt, lt->itls, lt->itlssz);
 
     lt->attr.state = BIT(LT_ST_NEW) | (attrp ? attrp->state : 0);
     lt->attr.thread_type = LKL_KERNEL_THREAD;

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -573,6 +573,9 @@ int lthread_create_primitive(
     lt->itls = tls;
     // for cloned threads, tls argument is a ptr to the Thread Control Block
     lt->tp = tls;
+    // set self pointer for fs segment
+    struct lthread_tcb_base *tcb = (struct lthread_tcb_base *)lt->tp;
+    tcb->self = lt->tp;
     LIST_INIT(&lt->tls);
     lt->attr.state = BIT(LT_ST_READY);
     lt->attr.thread_type = USERSPACE_THREAD;

--- a/tests/basic/clone/clone.c
+++ b/tests/basic/clone/clone.c
@@ -26,6 +26,12 @@ static char *child_stack_end2 = child_stack2 + 8192;
 volatile int thread_started;
 __attribute__((weak)) int lkl_syscall(int, long*);
 
+static void set_tls_self_ptrs() {
+	child_tls[0] = &child_tls;
+	child_tls1[0] = &child_tls1;
+	child_tls2[0] = &child_tls2;
+}
+
 static void assert(int cond, const char *msg, ...)
 {
 	if (cond) return;
@@ -101,6 +107,7 @@ int parallelthr(void* arg)
 
 int main(int argc, char** argv)
 {
+	set_tls_self_ptrs();
 	unsigned flags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND
 		| CLONE_THREAD | CLONE_SYSVSEM | CLONE_SETTLS | CLONE_CHILD_SETTID
 		| CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID | CLONE_DETACHED;

--- a/tests/basic/clone/clone.c
+++ b/tests/basic/clone/clone.c
@@ -14,9 +14,9 @@
 
 static char *child_stack;
 static char *child_stack_end;
-static char child_tls[4069];
-static char child_tls1[4069];
-static char child_tls2[4069];
+static size_t child_tls[512];
+static size_t child_tls1[512];
+static size_t child_tls2[512];
 
 static char child_stack1[8192];
 static char *child_stack_end1 = child_stack1 + 8192;
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
 	fprintf(stderr, "Clone returned %d, ctid: %d ptid: %d\n", clone_ret, ctid, ptid);
 	assert(ctid == clone_ret, "ctid is %d, should be %d\n", ctid, clone_ret);
 	int futex_ret = futex_wait(&ctid, clone_ret);
-	assert(futex_ret == 0, "futex syscall returned %d\n", futex_ret);
+	assert(futex_ret == 0, "futex syscall returned %d (%s)\n", futex_ret, strerror(errno));
 	fprintf(stderr, "After futex call, ctid is %d\n", ctid);
 	assert(ctid == 0, "ctid was not zeroed during futex wait\n");
 	fprintf(stderr, "Other thread should have terminated by now.\n");

--- a/tests/basic/clone/clone.c
+++ b/tests/basic/clone/clone.c
@@ -125,7 +125,7 @@ int main(int argc, char** argv)
 	fprintf(stderr, "Clone returned %d, ctid: %d ptid: %d\n", clone_ret, ctid, ptid);
 	assert(ctid == clone_ret, "ctid is %d, should be %d\n", ctid, clone_ret);
 	int futex_ret = futex_wait(&ctid, clone_ret);
-	assert(futex_ret == 0, "futex syscall returned %d (%s)\n", strerror(errno));
+	assert(futex_ret == 0, "futex syscall returned %d\n", futex_ret);
 	fprintf(stderr, "After futex call, ctid is %d\n", ctid);
 	assert(ctid == 0, "ctid was not zeroed during futex wait\n");
 	fprintf(stderr, "Other thread should have terminated by now.\n");

--- a/tests/basic/clone/clone_loop.c
+++ b/tests/basic/clone/clone_loop.c
@@ -39,6 +39,7 @@ int main(int argc, char** argv)
 
 	pid_t ptid;
 	pid_t ctid_futex1, ctid_futex2;
+	child_tls1[0] = &child_tls1;
 	for (int i = 0; i < RUNS; i++) {
 		pid_t ctid1 = clone(newthr, child_stack_end1, 
 							flags, (void*)0, &ptid, &child_tls1,

--- a/tests/basic/clone/clone_loop.c
+++ b/tests/basic/clone/clone_loop.c
@@ -13,7 +13,7 @@
 #include <sys/mman.h>
 
 #define RUNS 10000
-static char child_tls1[4069];
+static size_t child_tls1[512];
 
 static char child_stack1[8192];
 static char *child_stack_end1 = child_stack1 + 8192;

--- a/tests/basic/pthread_detach/Dockerfile
+++ b/tests/basic/pthread_detach/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD *.c /
+RUN gcc -fPIE -pie -o pthread_detach pthread_detach.c -g
+
+FROM alpine:3.6
+
+COPY --from=builder pthread_detach .

--- a/tests/basic/pthread_detach/Makefile
+++ b/tests/basic/pthread_detach/Makefile
@@ -1,0 +1,41 @@
+include ../../common.mk
+
+PROG=pthread_detach
+PROG_SRC=$(PROG).c 
+IMAGE_SIZE=5M
+
+EXECUTION_TIMEOUT=60
+
+SGXLKL_ENV=SGXLKL_ETHREADS=4 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
+
+.DELETE_ON_ERROR:
+.PHONY: all clean
+
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
+
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
+
+run: run-hw run-sw
+
+run-gdb: run-hw-gdb
+
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+clean:
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/pthread_detach/pthread_detach.c
+++ b/tests/basic/pthread_detach/pthread_detach.c
@@ -1,0 +1,27 @@
+/*
+ * pthread_detach.c
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <syscall.h>
+
+#define RUNS 100
+void *thread1_func( void* arg )
+{
+     printf("Thread 1 in execution\n");
+}
+
+main()
+{
+     pthread_t thread1, thread2;
+     int  iret1, iret2;
+     pthread_attr_t attr;
+     pthread_attr_init(&attr);
+     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+     for (int i = 0; i < RUNS; i++)
+          iret1 = pthread_create( &thread1, &attr, thread1_func, NULL);
+     printf("TEST PASSED");
+     exit(0);
+}
+

--- a/tests/basic/pthread_tls/Dockerfile
+++ b/tests/basic/pthread_tls/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD *.c /
+RUN gcc -fPIE -pie -o pthread_tls pthread_tls.c -g
+
+FROM alpine:3.6
+
+COPY --from=builder pthread_tls .

--- a/tests/basic/pthread_tls/Makefile
+++ b/tests/basic/pthread_tls/Makefile
@@ -1,0 +1,41 @@
+include ../../common.mk
+
+PROG=pthread_tls
+PROG_SRC=$(PROG).c 
+IMAGE_SIZE=5M
+
+EXECUTION_TIMEOUT=60
+
+SGXLKL_ENV=SGXLKL_ETHREADS=8 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
+
+.DELETE_ON_ERROR:
+.PHONY: all clean
+
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
+
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
+
+run: run-hw run-sw
+
+run-gdb: run-hw-gdb
+
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+clean:
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/pthread_tls/pthread_tls.c
+++ b/tests/basic/pthread_tls/pthread_tls.c
@@ -1,0 +1,96 @@
+/*
+ * pthread_tls.c
+ *
+ * This test checks thread local variables are indeed thread local.
+ * It also tests pthreads conditional variables for thread synchronization.
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <string.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <signal.h>
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+__thread int tls_var;
+pthread_mutex_t mutex1 = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond1 = PTHREAD_COND_INITIALIZER;
+pthread_mutex_t mutex2 = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond2 = PTHREAD_COND_INITIALIZER;
+
+static void assert(int cond, const char *msg, ...)
+{
+	if (cond) return;
+	va_list ap;
+	va_start(ap, msg);
+	vfprintf(stderr, msg, ap);
+	va_end(ap);
+	fprintf(stderr, "\nTEST_FAILED\n");
+	exit(-1);
+}
+
+void *parallel_workers( void* arg )
+{
+     const int id = (long)arg;
+     tls_var = id;
+     printf("[thread %d] tls_var= %d.\n", id, tls_var);
+     if (id == 1) {
+          printf("[thread %d] acquiring mutex1.\n", id);
+          pthread_mutex_lock( &mutex1 );
+          tls_var *= 2;
+          sleep(2);
+          printf("[thread %d] After doubling, tls_var= %d.\n", id, tls_var);
+          printf("[thread %d] releasing lock. Signalling cond1.\n", id);
+          pthread_mutex_unlock(&mutex1);
+          pthread_cond_signal(&cond1); 
+
+          printf("[thread %d] wait for cond2.\n", id);
+          pthread_cond_wait(&cond2, &mutex2);
+          printf("[thread %d] woken from cond2 wait.\n", id);
+          printf("[thread %d] tls_var= %d.\n", id, tls_var);
+
+          assert(tls_var == 2, "Thread 1 TLS var got stomped");
+     } else {
+          printf("[thread %d] wait for cond1.\n", id);
+          pthread_cond_wait(&cond1, &mutex1);
+          printf("[thread %d] woken from cond1 wait.\n", id);
+          printf("[thread %d] tls_var= %d.\n", id, tls_var);
+
+          printf("[thread %d] acquiring mutex2.\n", id);
+          pthread_mutex_lock( &mutex2 );
+          tls_var *= 2;
+          sleep(2);
+          printf("[thread %d] After doubling, tls_var= %d.\n", id, tls_var);
+          printf("[thread %d] releasing lock. Signalling cond2.\n", id);
+          pthread_cond_signal(&cond2); 
+          pthread_mutex_unlock(&mutex2);
+
+          assert(tls_var == 4, "Thread 2 TLS var got stomped");
+     }
+}
+
+main()
+{
+     pthread_t thread1, thread2;
+     int  iret1, iret2;
+     int tnum1 = 1, tnum2 = 2;
+
+     iret1 = pthread_create( &thread1, NULL, parallel_workers, (void*)(long)tnum1);
+     iret2 = pthread_create( &thread2, NULL, parallel_workers, (void*)(long)tnum2);
+
+     pthread_join( thread1, NULL);
+     pthread_join( thread2, NULL); 
+
+     printf("Thread 1 returns: %d\n",iret1);
+     printf("Thread 2 returns: %d\n",iret2);
+     printf("TEST PASSED");
+     exit(0);
+}
+

--- a/tests/basic/pthread_yield/Dockerfile
+++ b/tests/basic/pthread_yield/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.6 AS builder
+
+RUN apk add --no-cache gcc musl-dev
+
+ADD *.c /
+RUN gcc -fPIE -pie -o pthread_yield pthread_yield.c -g
+
+FROM alpine:3.6
+
+COPY --from=builder pthread_yield .

--- a/tests/basic/pthread_yield/Makefile
+++ b/tests/basic/pthread_yield/Makefile
@@ -1,0 +1,41 @@
+include ../../common.mk
+
+PROG=pthread_yield
+PROG_SRC=$(PROG).c 
+IMAGE_SIZE=5M
+
+EXECUTION_TIMEOUT=60
+
+SGXLKL_ENV=SGXLKL_ETHREADS=1 SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
+
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
+
+.DELETE_ON_ERROR:
+.PHONY: all clean
+
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
+
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
+
+run: run-hw run-sw
+
+run-gdb: run-hw-gdb
+
+run-hw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+
+clean:
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/pthread_yield/pthread_yield.c
+++ b/tests/basic/pthread_yield/pthread_yield.c
@@ -1,0 +1,41 @@
+/*
+ * pthread_yield.c
+ *
+ * This test is supposed to run with SGXLKL_ETHREADS=1 and verify
+ * whether 2 threads can cooperate via yielding.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <syscall.h>
+
+void *thread1_func( void* arg )
+{
+     int err = sched_yield();
+     printf("Thread 1 in execution\n");
+     pthread_exit(NULL);
+}
+
+void *thread_func(void *arg)
+{
+     printf("Thread 2 in execution\n");
+     pthread_exit(NULL);
+}
+
+main()
+{
+     pthread_t thread1, thread2;
+     int  iret1, iret2;
+
+     iret1 = pthread_create( &thread1, NULL, thread1_func, NULL);
+     iret2 = pthread_create( &thread2, NULL, thread_func, NULL);
+
+     pthread_join( thread1, NULL);
+     pthread_join( thread2, NULL); 
+
+     printf("Thread 1 returns: %d\n",iret1);
+     printf("Thread 2 returns: %d\n",iret2);
+     printf("TEST PASSED");
+     exit(0);
+}
+

--- a/tests/languages/java/hello_world/Makefile
+++ b/tests/languages/java/hello_world/Makefile
@@ -29,5 +29,9 @@ run-sw: $(DISK_IMAGE)
 	@echo "sgx-lkl-java --sw-debug ${DISK_IMAGE} HelloWorld"
 	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} HelloWorld
 
+run-hw-gdb: $(DISK_IMAGE)
+	@echo "${SGXLKL_ENV} sgx-lkl-java --hw-debug ${DISK_IMAGE} ${PROG}"
+	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} --debug ${PROG}
+
 clean:
 	rm -f $(DISK_IMAGE)

--- a/tests/languages/java/thread/Dockerfile
+++ b/tests/languages/java/thread/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:8-alpine
 COPY ./app /app
 WORKDIR /app
-RUN javac -source 1.8 -target 1.8 *.java
+RUN javac -g -source 1.8 -target 1.8 *.java

--- a/tests/languages/java/thread/Makefile
+++ b/tests/languages/java/thread/Makefile
@@ -28,5 +28,9 @@ run-sw: $(DISK_IMAGE)
 	@echo "sgx-lkl-java --sw-debug ${DISK_IMAGE} ${PROG}"
 	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --sw-debug ${DISK_IMAGE} ${PROG}
 
+run-hw-gdb: $(DISK_IMAGE)
+	@echo "sgx-lkl-java --hw-debug ${DISK_IMAGE} ${PROG}"
+	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} --debug ${PROG}
+
 clean:
 	rm -f $(DISK_IMAGE)

--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -755,7 +755,7 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02
-#/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
+/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
 /ltp/testcases/kernel/syscalls/rt_sigsuspend/rt_sigsuspend01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -854,7 +854,7 @@
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid01
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid02
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid03
-/ltp/testcases/kernel/syscalls/setresuid/setresuid04
+#/ltp/testcases/kernel/syscalls/setresuid/setresuid04
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid05
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid01
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid02
@@ -862,7 +862,7 @@
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid04
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid05
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid06
-/ltp/testcases/kernel/syscalls/setreuid/setreuid07
+#/ltp/testcases/kernel/syscalls/setreuid/setreuid07
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit01
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit02
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit03

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -854,7 +854,7 @@
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid01
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid02
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid03
-#/ltp/testcases/kernel/syscalls/setresuid/setresuid04
+/ltp/testcases/kernel/syscalls/setresuid/setresuid04
 #/ltp/testcases/kernel/syscalls/setresuid/setresuid05
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid01
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid02
@@ -862,7 +862,7 @@
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid04
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid05
 #/ltp/testcases/kernel/syscalls/setreuid/setreuid06
-#/ltp/testcases/kernel/syscalls/setreuid/setreuid07
+/ltp/testcases/kernel/syscalls/setreuid/setreuid07
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit01
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit02
 #/ltp/testcases/kernel/syscalls/setrlimit/setrlimit03


### PR DESCRIPTION
### Summary
- Remove musl related threading code from lthreads implementation.
- Add auxiliary vector entries on the elf64 stack created during first ecall.

Fixes #156 

Corresponding sgx-lkl-musl PR: https://github.com/lsds/sgx-lkl-musl/pull/18