### PR TITLE
CI: Fix OE install

### DIFF
--- a/.azure-pipelines/azure-pipelines-master.yml
+++ b/.azure-pipelines/azure-pipelines-master.yml
@@ -13,8 +13,3 @@ extends:
   parameters:
     publish: true
     apt_repo_blob_container: apt-dev
-    # Use hosted agent for building to ensure dev-releases are always built on a fresh VM.
-    # Our own pools currently re-use VMs to decrease queueing and execution time and
-    # this makes it easier to mess with them, e.g. via external pull requests.
-    build_pool:
-      vmImage: ubuntu-latest

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -6,11 +6,6 @@ extends:
   parameters:
     publish: true
     apt_repo_blob_container: apt
-    # Use hosted agent for building to ensure releases are always built on a fresh VM.
-    # Our own pools currently re-use VMs to decrease queueing and execution time and
-    # this makes it easier to mess with them, e.g. via external pull requests.
-    build_pool:
-      vmImage: ubuntu-latest
     test_timeout_minutes: 120 # ethread==1 takes longer to run
     ethreads:
     - 1


### PR DESCRIPTION
For the main branch (`oe_port`) and release pipeline we used hosted agents to avoid unnecessary utilization of the scaleset pools. However, for reasons I can't figure out the base image of the hosted agents fails during ansible setup. This PR switches over to the scalesets for everything. In the future, separate scaleset pools with auto-teardown enabled should be used for releases and the main branch to guarantee a fresh state (See the deleted comment in this PR). I'll open a PR for that.