### PR TITLE
LTP: Enable 14 misc LTP tests

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -56,11 +56,11 @@
 #/ltp/testcases/kernel/syscalls/clock_getres/clock_getres01
 #/ltp/testcases/kernel/syscalls/clock_gettime/clock_gettime01
 /ltp/testcases/kernel/syscalls/clock_gettime/clock_gettime02
-/ltp/testcases/kernel/syscalls/clock_gettime/leapsec01
+#/ltp/testcases/kernel/syscalls/clock_gettime/leapsec01
 #/ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep01
 #/ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep02
 /ltp/testcases/kernel/syscalls/clock_nanosleep2/clock_nanosleep2_01
-/ltp/testcases/kernel/syscalls/clock_settime/clock_settime01
+#/ltp/testcases/kernel/syscalls/clock_settime/clock_settime01
 /ltp/testcases/kernel/syscalls/clock_settime/clock_settime02
 /ltp/testcases/kernel/syscalls/clone/clone01
 /ltp/testcases/kernel/syscalls/clone/clone02
@@ -220,7 +220,7 @@
 /ltp/testcases/kernel/syscalls/fcntl/fcntl31
 /ltp/testcases/kernel/syscalls/fcntl/fcntl32
 /ltp/testcases/kernel/syscalls/fcntl/fcntl33
-/ltp/testcases/kernel/syscalls/fcntl/fcntl34
+#/ltp/testcases/kernel/syscalls/fcntl/fcntl34
 #/ltp/testcases/kernel/syscalls/fcntl/fcntl35
 /ltp/testcases/kernel/syscalls/fcntl/fcntl36
 #/ltp/testcases/kernel/syscalls/fdatasync/fdatasync01
@@ -492,7 +492,7 @@
 /ltp/testcases/kernel/syscalls/madvise/madvise07
 /ltp/testcases/kernel/syscalls/madvise/madvise08
 /ltp/testcases/kernel/syscalls/madvise/madvise09
-/ltp/testcases/kernel/syscalls/madvise/madvise10
+#/ltp/testcases/kernel/syscalls/madvise/madvise10
 /ltp/testcases/kernel/syscalls/mallopt/mallopt01
 /ltp/testcases/kernel/syscalls/mbind/mbind01
 /ltp/testcases/kernel/syscalls/mbind/mbind02
@@ -610,7 +610,7 @@
 #/ltp/testcases/kernel/syscalls/nice/nice01
 #/ltp/testcases/kernel/syscalls/nice/nice02
 #/ltp/testcases/kernel/syscalls/nice/nice03
-/ltp/testcases/kernel/syscalls/nice/nice04
+#/ltp/testcases/kernel/syscalls/nice/nice04
 /ltp/testcases/kernel/syscalls/open/open01
 /ltp/testcases/kernel/syscalls/open/open02
 /ltp/testcases/kernel/syscalls/open/open03
@@ -755,7 +755,7 @@
 /ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 /ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02
-/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
+#/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
 /ltp/testcases/kernel/syscalls/rt_sigsuspend/rt_sigsuspend01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk02
@@ -953,7 +953,7 @@
 /ltp/testcases/kernel/syscalls/syscall/syscall01
 /ltp/testcases/kernel/syscalls/sysconf/sysconf01
 /ltp/testcases/kernel/syscalls/sysctl/sysctl01
-/ltp/testcases/kernel/syscalls/sysctl/sysctl03
+#/ltp/testcases/kernel/syscalls/sysctl/sysctl03
 /ltp/testcases/kernel/syscalls/sysctl/sysctl04
 /ltp/testcases/kernel/syscalls/sysfs/sysfs01
 /ltp/testcases/kernel/syscalls/sysfs/sysfs02

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -25,7 +25,7 @@
 /ltp/testcases/kernel/syscalls/bpf/bpf_map01
 /ltp/testcases/kernel/syscalls/bpf/bpf_prog01
 /ltp/testcases/kernel/syscalls/bpf/bpf_prog02
-/ltp/testcases/kernel/syscalls/brk/brk01
+#/ltp/testcases/kernel/syscalls/brk/brk01
 /ltp/testcases/kernel/syscalls/cacheflush/cacheflush01
 /ltp/testcases/kernel/syscalls/capget/capget01
 /ltp/testcases/kernel/syscalls/capget/capget02
@@ -58,8 +58,8 @@
 /ltp/testcases/kernel/syscalls/clock_gettime/clock_gettime02
 /ltp/testcases/kernel/syscalls/clock_gettime/leapsec01
 /ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep01
-/ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep02
-/ltp/testcases/kernel/syscalls/clock_nanosleep2/clock_nanosleep2_01
+#/ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep02
+#/ltp/testcases/kernel/syscalls/clock_nanosleep2/clock_nanosleep2_01
 /ltp/testcases/kernel/syscalls/clock_settime/clock_settime01
 /ltp/testcases/kernel/syscalls/clock_settime/clock_settime02
 /ltp/testcases/kernel/syscalls/clone/clone01
@@ -188,7 +188,7 @@
 /ltp/testcases/kernel/syscalls/fchownat/fchownat01
 /ltp/testcases/kernel/syscalls/fchownat/fchownat02
 /ltp/testcases/kernel/syscalls/fcntl/fcntl01
-/ltp/testcases/kernel/syscalls/fcntl/fcntl02
+#/ltp/testcases/kernel/syscalls/fcntl/fcntl02
 /ltp/testcases/kernel/syscalls/fcntl/fcntl03
 /ltp/testcases/kernel/syscalls/fcntl/fcntl04
 /ltp/testcases/kernel/syscalls/fcntl/fcntl05
@@ -666,7 +666,7 @@
 /ltp/testcases/kernel/syscalls/prctl/prctl05
 /ltp/testcases/kernel/syscalls/prctl/prctl06
 /ltp/testcases/kernel/syscalls/prctl/prctl06_execve
-/ltp/testcases/kernel/syscalls/prctl/prctl07
+#/ltp/testcases/kernel/syscalls/prctl/prctl07
 #/ltp/testcases/kernel/syscalls/pread/pread01
 #/ltp/testcases/kernel/syscalls/pread/pread02
 #/ltp/testcases/kernel/syscalls/pread/pread03
@@ -952,9 +952,9 @@
 /ltp/testcases/kernel/syscalls/syncfs/syncfs01
 #/ltp/testcases/kernel/syscalls/syscall/syscall01
 #/ltp/testcases/kernel/syscalls/sysconf/sysconf01
-/ltp/testcases/kernel/syscalls/sysctl/sysctl01
+#/ltp/testcases/kernel/syscalls/sysctl/sysctl01
 /ltp/testcases/kernel/syscalls/sysctl/sysctl03
-/ltp/testcases/kernel/syscalls/sysctl/sysctl04
+#/ltp/testcases/kernel/syscalls/sysctl/sysctl04
 #/ltp/testcases/kernel/syscalls/sysfs/sysfs01
 #/ltp/testcases/kernel/syscalls/sysfs/sysfs02
 #/ltp/testcases/kernel/syscalls/sysfs/sysfs03

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -58,7 +58,7 @@
 /ltp/testcases/kernel/syscalls/clock_gettime/clock_gettime02
 /ltp/testcases/kernel/syscalls/clock_gettime/leapsec01
 /ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep01
-#/ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep02
+/ltp/testcases/kernel/syscalls/clock_nanosleep/clock_nanosleep02
 #/ltp/testcases/kernel/syscalls/clock_nanosleep2/clock_nanosleep2_01
 /ltp/testcases/kernel/syscalls/clock_settime/clock_settime01
 /ltp/testcases/kernel/syscalls/clock_settime/clock_settime02
@@ -188,7 +188,7 @@
 /ltp/testcases/kernel/syscalls/fchownat/fchownat01
 /ltp/testcases/kernel/syscalls/fchownat/fchownat02
 /ltp/testcases/kernel/syscalls/fcntl/fcntl01
-#/ltp/testcases/kernel/syscalls/fcntl/fcntl02
+/ltp/testcases/kernel/syscalls/fcntl/fcntl02
 /ltp/testcases/kernel/syscalls/fcntl/fcntl03
 /ltp/testcases/kernel/syscalls/fcntl/fcntl04
 /ltp/testcases/kernel/syscalls/fcntl/fcntl05
@@ -604,7 +604,7 @@
 /ltp/testcases/kernel/syscalls/munmap/munmap02
 /ltp/testcases/kernel/syscalls/munmap/munmap03
 /ltp/testcases/kernel/syscalls/nanosleep/nanosleep01
-/ltp/testcases/kernel/syscalls/nanosleep/nanosleep02
+#/ltp/testcases/kernel/syscalls/nanosleep/nanosleep02
 /ltp/testcases/kernel/syscalls/nanosleep/nanosleep04
 /ltp/testcases/kernel/syscalls/newuname/newuname01
 /ltp/testcases/kernel/syscalls/nice/nice01


### PR DESCRIPTION
Ran the 64 LTP disabled tests that were categorized and produc bug several times.
There are 14 passing tests, enabling them with this PR to increase test coverage.