### PR TITLE
LTP: Fix testcase recvfrom01 issue

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -717,7 +717,7 @@
 #/ltp/testcases/kernel/syscalls/reboot/reboot01
 #/ltp/testcases/kernel/syscalls/reboot/reboot02
 #/ltp/testcases/kernel/syscalls/recv/recv01
-/ltp/testcases/kernel/syscalls/recvfrom/recvfrom01
+#/ltp/testcases/kernel/syscalls/recvfrom/recvfrom01
 #/ltp/testcases/kernel/syscalls/recvmsg/recvmsg01
 #/ltp/testcases/kernel/syscalls/recvmsg/recvmsg02
 /ltp/testcases/kernel/syscalls/recvmsg/recvmsg03

--- a/tests/ltp/patches/fix_recvfrom_recvfrom01.patch
+++ b/tests/ltp/patches/fix_recvfrom_recvfrom01.patch
@@ -1,0 +1,119 @@
+In original test case the main process create a child process
+to wirte/read to/from sockets infinitely. In sgx-lkl supports single
+process environment. The test case is modified to use a child
+pthread instead of forking a child process.
+One of the sub test case designed to test generation of EFAULT
+by accessing invalid address values. Currently sgx behaviour is 
+to call enclave abort, if address is not within enclave address
+range. Because of this test program is causing enclave abort
+and exiting with non-zero exit code. 
+
+Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
+is raised to fix this behaviour. The sub test cases which test
+EFAULT error behaviour is commented/disabled until github
+issue169 is fixed.
+
+diff --git a/testcases/kernel/syscalls/recvfrom/recvfrom01.c b/testcases/kernel/syscalls/recvfrom/recvfrom01.c
+index 853d1cb9f..65e87fe01 100644
+--- a/testcases/kernel/syscalls/recvfrom/recvfrom01.c
++++ b/testcases/kernel/syscalls/recvfrom/recvfrom01.c
+@@ -44,6 +44,7 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#include <pthread.h>
+ 
+ #include <sys/types.h>
+ #include <sys/socket.h>
+@@ -54,6 +55,7 @@
+ 
+ #include "test.h"
+ #include "safe_macros.h"
++#include "tst_safe_pthread.h"
+ 
+ char *TCID = "recvfrom01";
+ int testno;
+@@ -64,7 +66,7 @@ struct sockaddr_in sin1, from;
+ static int sfd;			/* shared between do_child and start_server */
+ socklen_t fromlen;
+ 
+-void do_child(void);
++void* do_child(void* parm);
+ void setup(void);
+ void setup0(void);
+ void setup1(void);
+@@ -108,11 +110,12 @@ struct test_case_t {		/* test case structure */
+ 	PF_INET, SOCK_STREAM, 0, (void *)buf, sizeof(buf), 0,
+ 		    (struct sockaddr *)&from, &fromlen,
+ 		    -1, EINVAL, setup2, cleanup1, "invalid socket addr length"},
++// TODO: Enable back after issue 169 fixed
+ /* 5 */
+-	{
+-	PF_INET, SOCK_STREAM, 0, (void *)-1, sizeof(buf), 0,
+-		    (struct sockaddr *)&from, &fromlen,
+-		    -1, EFAULT, setup1, cleanup1, "invalid recv buffer"},
++//	{
++//	PF_INET, SOCK_STREAM, 0, (void *)-1, sizeof(buf), 0,
++//		    (struct sockaddr *)&from, &fromlen,
++//		    -1, EFAULT, setup1, cleanup1, "invalid recv buffer"},
+ /* 6 */
+ 	{
+ 	PF_INET, SOCK_STREAM, 0, (void *)buf, sizeof(buf), MSG_OOB,
+@@ -181,6 +184,7 @@ int main(int argc, char *argv[])
+ }
+ 
+ pid_t pid;
++pthread_t tid;
+ 
+ void setup(void)
+ {
+@@ -191,7 +195,8 @@ void setup(void)
+ 
+ void cleanup(void)
+ {
+-	(void)kill(pid, SIGKILL);
++	(void)close(sfd);
++	SAFE_PTHREAD_JOIN(tid, NULL);
+ 
+ }
+ 
+@@ -276,7 +281,7 @@ pid_t start_server(struct sockaddr_in *sin0)
+ 			tst_brkm(TBROK, cleanup, "server self_exec failed");
+ 		}
+ #else
+-		do_child();
++		SAFE_PTHREAD_CREATE(&tid, NULL, do_child, NULL);
+ #endif
+ 		break;
+ 	case -1:
+@@ -284,13 +289,12 @@ pid_t start_server(struct sockaddr_in *sin0)
+ 		/* fall through */
+ 	default:		/* parent */
+ 		(void)close(sfd);
+-		return pid;
+ 	}
+ 
+-	exit(1);
++	return pid;
+ }
+ 
+-void do_child(void)
++void* do_child(void* parm LTP_ATTRIBUTE_UNUSED)
+ {
+ 	struct sockaddr_in fsin;
+ 	fd_set afds, rfds;
+@@ -302,7 +306,7 @@ void do_child(void)
+ 	nfds = sfd + 1;
+ 
+ 	/* accept connections until killed */
+-	while (1) {
++	while (testno < TST_TOTAL) {
+ 		socklen_t fromlen;
+ 
+ 		memcpy(&rfds, &afds, sizeof(rfds));
+@@ -332,4 +336,5 @@ void do_child(void)
+ 				}
+ 			}
+ 	}
++	pthread_exit(0);
+ }


### PR DESCRIPTION
In original test case, the main process create a child process
to wirte/read to/from sockets infinitely. In sgx-lkl supports
single process environment. The test case is modified to use
a child pthread instead of forking a child process.
One of the sub test case designed to test generation of EFAULT
by accessing invalid address values. Currently sgx behaviour is
to call enclave abort, if address is not within enclave address
range. Because of this test program is causing enclave abort
and exiting with non-zero exit code.

Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
is raised to fix this behaviour. The sub test cases which test
EFAULT error behaviour is commented/disabled until github
issue169 is fixed.