### PR TITLE
CI: Add missing sudo to pkill

### DIFF
--- a/.azure-pipelines/scripts/test_utils.sh
+++ b/.azure-pipelines/scripts/test_utils.sh
@@ -30,7 +30,7 @@ function CheckNotRunning()
         echo "SGX-LKL still running:"
         ps -aux | grep $process
         echo "Trying to kill hanging $process process"
-        pkill -9 $process
+        sudo pkill -9 $process
         pkill_exit=$?
         if [[ $pkill_exit -ne 0 ]]; then
             echo "Failed to kill hanging $process process. Exit code: $pkill_exit"


### PR DESCRIPTION
When running inside Docker then sgx-lkl is run as root which means it can't be killed without sudo.

https://dev.azure.com/sgx-lkl/sgx-lkl/_build/results?buildId=617&view=logs&j=f018f836-aedf-54a0-b1be-775dc31cccc9&t=a69a47f6-59eb-5595-6ccb-ce4af4a17f1c

```
SGX-LKL still running:
AzDevOps  1246  0.0  0.6 2234736 103580 ?      DN   16:35   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img fsgsbase_unset-test
AzDevOps  1817  0.0  0.6 2229616 103864 ?      DN   16:35   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img stat
AzDevOps  2366  0.0  0.6 2229616 103848 ?      DN   16:36   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img pthread_join-test
AzDevOps  2910  0.0  0.6 2229616 103852 ?      DN   16:37   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img illegal_instructions-test
AzDevOps  3471  0.0  0.6 2229616 103676 ?      DN   16:38   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img clone
AzDevOps  4016  0.0  0.6 2234744 103768 ?      DN   16:39   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img /bin/touch /foo.txt
AzDevOps  4555  0.0  0.6 2229616 103744 ?      DN   16:40   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-abort.img abort
AzDevOps  5103  0.0  0.6 2229616 103704 ?      DN   16:42   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img signal
AzDevOps  5654  0.0  0.6 2229616 103712 ?      DN   16:43   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img global_vars_test -a -b -c hello
AzDevOps  6195  0.0  0.6 2229616 103736 ?      DN   16:44   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img helloworld
AzDevOps  6740  0.0  0.6 2229616 103520 ?      DN   16:45   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img sleep-test
AzDevOps  7368  0.0  0.6 2281840 103560 ?      DN   16:46   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img /bin/touch /foo.txt
AzDevOps  7574  0.0  0.6 2736496 103608 ?      DN   16:47   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-miniroot-fs.img bin/cat /etc/os-release
AzDevOps  8303  0.0  0.6 107213176 103664 ?    DN   16:52   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --app-config=app-config.json --hw-debug rootfs.img
AzDevOps  9852  0.0  0.6 2634100 103856 ?      DN   16:57   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-java.img /usr/bin/java -Xms2000k -XX:InitialCodeCacheSize=2000k -XX:ReservedCodeCacheSize=4000K -XX:CompressedClassSpaceSize=4000K -XX:+UseCompressedClassPointers -XX:+PerfDisableSharedMem -XX:+UseMembar -Dsun.zip.disableMemoryMapping=true -cp /app MainApp
AzDevOps 10722  0.0  0.6 3482788 103712 ?      DN   17:03   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-nodejs.img /usr/local/bin/node /app/index.js
AzDevOps 11514  0.0  0.6 2480496 103588 ?      DN   17:07   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-dotnet.img /usr/bin/dotnet /app/HelloWorld.dll
AzDevOps 12376  0.0  0.6 3273072 103876 ?      DN   17:13   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-python.img /usr/bin/python3 app/python-helloworld.py
root     12597  175  0.4 2822476 71268 ?       Ssl  15:00 412:36 /opt/sgx-lkl-nonrelease/bin/sgx-lkl-run-oe --host-config=/host-cfg.json --app-config=/app-cfg.json --hw-debug
AzDevOps 16189  0.0  0.5 3751816 94952 ?       DN   17:53   0:02 /opt/sgx-lkl-nonrelease/bin/sgx-lkl-run-oe --hw-debug sgxlkl-miniroot-fs.img /ltp/testcases/kernel/syscalls/accept/accept01
AzDevOps 17148  0.0  0.5 3263664 94696 ?       DN   15:17   0:02 /opt/sgx-lkl-nonrelease/bin/sgx-lkl-run-oe --hw-debug sgxlkl-python.img /usr/bin/python3 app/python-helloworld.py
AzDevOps 21325  0.0  0.0  14856  1052 ?        SN   18:55   0:00 grep sgx-lkl-run-oe
AzDevOps 26580  0.0  0.5 6409392 94360 ?       DN   15:46   0:02 /opt/sgx-lkl-nonrelease/bin/sgx-lkl-run-oe --hw-debug sgxlkl-openvino.img /home/user/dldt/bin/intel64/Debug/hello_nv12_input_classification /app/public_models/squeezenet1.1.xml /app/public_models/car.yuv 640x480 CPU
AzDevOps 29838  0.0  0.6 2240880 103616 ?      DN   16:17   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-print_lkl_version-test.img /bin/uname -a
AzDevOps 29946  0.0  0.5 3751816 95196 ?       DN   17:22   0:02 /opt/sgx-lkl-nonrelease/bin/sgx-lkl-run-oe --hw-debug sgxlkl-miniroot-fs.img /ltp/testcases/kernel/syscalls/brk/brk01
AzDevOps 30576  0.0  0.6 2240880 103720 ?      DN   16:22   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --app-config=sgxlkl-exit_status_full-appconfig.json --hw-debug sgxlkl-alpine-bash.img
AzDevOps 31402  0.0  0.6 2229616 103692 ?      DN   16:27   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgxlkl-exit-test.img exit-test
AzDevOps 32230  0.0  0.6 2229616 103592 ?      DN   16:32   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img clock
AzDevOps 32767  0.0  0.6 2229616 103780 ?      DN   16:33   0:02 /opt/sgx-lkl-debug/bin/sgx-lkl-run-oe --hw-debug sgx-lkl-rootfs.img nonroot_halt_test
Trying to kill hanging sgx-lkl-run-oe process
pkill: killing pid 12597 failed: Operation not permitted
Killed the hanging sgx-lkl-run-oe process successfully
```