### PR TITLE
LTP: Fix for sendto01

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -802,7 +802,7 @@
 #/ltp/testcases/kernel/syscalls/sendmmsg/sendmmsg01
 /ltp/testcases/kernel/syscalls/sendmsg/sendmsg01
 /ltp/testcases/kernel/syscalls/sendmsg/sendmsg02
-/ltp/testcases/kernel/syscalls/sendto/sendto01
+#/ltp/testcases/kernel/syscalls/sendto/sendto01
 /ltp/testcases/kernel/syscalls/sendto/sendto02
 /ltp/testcases/kernel/syscalls/set_mempolicy/set_mempolicy01
 /ltp/testcases/kernel/syscalls/set_mempolicy/set_mempolicy02

--- a/tests/ltp/patches/sendto01.patch
+++ b/tests/ltp/patches/sendto01.patch
@@ -16,7 +16,7 @@ In addition a test related to shutdown a local endpoint is also
 disabled until issue 405.
 url:https://github.com/lsds/sgx-lkl/issues/405
 diff --git a/testcases/kernel/syscalls/sendto/sendto01.c b/testcases/kernel/syscalls/sendto/sendto01.c
-index 6fe0274ee..69cde8361 100644
+index 6fe0274ee..702baeae4 100644
 --- a/testcases/kernel/syscalls/sendto/sendto01.c
 +++ b/testcases/kernel/syscalls/sendto/sendto01.c
 @@ -42,6 +42,8 @@
@@ -118,7 +118,7 @@ index 6fe0274ee..69cde8361 100644
  	 .cleanup = cleanup1,
  	 .desc = "invalid to buffer length"}
  	,
-+// TODO: Enable back after issue 405 fixed
++// TODO: Enable back after issue 169 is fixed
  #ifndef UCLINUX
 -	/* Skip since uClinux does not implement memory protection */
 -	{.domain = PF_INET,
@@ -153,7 +153,7 @@ index 6fe0274ee..69cde8361 100644
  #endif
  	{.domain = PF_INET,
  	 .type = SOCK_DGRAM,
-@@ -195,20 +201,20 @@ struct test_case_t tdat[] = {
+@@ -195,20 +201,21 @@ struct test_case_t tdat[] = {
  	 .setup = setup1,
  	 .cleanup = cleanup1,
  	 .desc = "UDP message too big"}
@@ -171,6 +171,7 @@ index 6fe0274ee..69cde8361 100644
 -	 .setup = setup2,
 -	 .cleanup = cleanup1,
 -	 .desc = "local endpoint shutdown"}
++// TODO: Enable back after issue 405 is fixed
 +//	,
 +//	{.domain = PF_INET,
 +//	 .type = SOCK_STREAM,
@@ -188,7 +189,7 @@ index 6fe0274ee..69cde8361 100644
  	,
  	{.domain = PF_INET,
  	 .type = SOCK_DGRAM,
-@@ -231,9 +237,9 @@ int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+@@ -231,9 +238,9 @@ int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
  static char *argv0;
  #endif
  
@@ -200,7 +201,7 @@ index 6fe0274ee..69cde8361 100644
  	socklen_t slen = sizeof(*sin0);
  
  	sin0->sin_family = AF_INET;
-@@ -255,27 +261,21 @@ static pid_t start_server(struct sockaddr_in *sin0)
+@@ -255,27 +262,21 @@ static pid_t start_server(struct sockaddr_in *sin0)
  	}
  	SAFE_GETSOCKNAME(cleanup, sfd, (struct sockaddr *)sin0, &slen);
  
@@ -238,7 +239,7 @@ index 6fe0274ee..69cde8361 100644
  {
  	struct sockaddr_in fsin;
  	fd_set afds, rfds;
-@@ -287,7 +287,7 @@ static void do_child(void)
+@@ -287,7 +288,7 @@ static void do_child(void)
  	nfds = sfd + 1;
  
  	/* accept connections until killed */
@@ -247,7 +248,7 @@ index 6fe0274ee..69cde8361 100644
  		socklen_t fromlen;
  
  		memcpy(&rfds, &afds, sizeof(rfds));
-@@ -315,6 +315,8 @@ static void do_child(void)
+@@ -315,6 +316,8 @@ static void do_child(void)
  			}
  		}
  	}
@@ -256,7 +257,7 @@ index 6fe0274ee..69cde8361 100644
  }
  
  int main(int ac, char *av[])
-@@ -323,10 +325,6 @@ int main(int ac, char *av[])
+@@ -323,10 +326,6 @@ int main(int ac, char *av[])
  
  	tst_parse_opts(ac, av, NULL, NULL);
  
@@ -267,7 +268,7 @@ index 6fe0274ee..69cde8361 100644
  
  	setup();
  
-@@ -364,20 +362,18 @@ int main(int ac, char *av[])
+@@ -364,20 +363,18 @@ int main(int ac, char *av[])
  	tst_exit();
  }
  

--- a/tests/ltp/patches/sendto01.patch
+++ b/tests/ltp/patches/sendto01.patch
@@ -1,0 +1,293 @@
+In original test case the main process create a child process.
+sgx-lkl supports single process environment.
+The test case is modified to use a child
+pthread instead of forking a child process.
+One of the sub test case designed to test generation of EFAULT
+by accessing invalid address values. Currently sgx behaviour is 
+to call enclave abort, if address is not within enclave address
+range. Because of this test program is causing enclave abort
+and exiting with non-zero exit code. 
+
+Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
+is raised to fix this behaviour. The sub test cases which test
+EFAULT error behaviour is commented/disabled until github
+issue169 is fixed.
+In addition a test related to shutdown a local endpoint is also
+disabled until issue 405.
+url:https://github.com/lsds/sgx-lkl/issues/405
+diff --git a/testcases/kernel/syscalls/sendto/sendto01.c b/testcases/kernel/syscalls/sendto/sendto01.c
+index 6fe0274ee..69cde8361 100644
+--- a/testcases/kernel/syscalls/sendto/sendto01.c
++++ b/testcases/kernel/syscalls/sendto/sendto01.c
+@@ -42,6 +42,8 @@
+ 
+ #include "test.h"
+ #include "safe_macros.h"
++#include "pthread.h"
++#include "tst_safe_pthread.h"
+ 
+ char *TCID = "sendto01";
+ int testno;
+@@ -50,6 +52,8 @@ static char buf[1024], bigbuf[128 * 1024];
+ static int s;
+ static struct sockaddr_in sin1, sin2;
+ static int sfd;
++static pthread_t server_tid;
++static int kill_thread;
+ 
+ struct test_case_t {		/* test case structure */
+ 	int domain;		/* PF_INET, PF_UNIX, ... */
+@@ -75,7 +79,7 @@ static void setup3(void);
+ static void cleanup(void);
+ static void cleanup0(void);
+ static void cleanup1(void);
+-static void do_child(void);
++void* do_child_thread(void* arg);
+ 
+ struct test_case_t tdat[] = {
+ 	{.domain = PF_INET,
+@@ -106,37 +110,38 @@ struct test_case_t tdat[] = {
+ 	 .cleanup = cleanup0,
+ 	 .desc = "invalid socket"}
+ 	,
++// TODO: Enable back after issue 169 fixed
+ #ifndef UCLINUX
+-	/* Skip since uClinux does not implement memory protection */
+-	{.domain = PF_INET,
+-	 .type = SOCK_DGRAM,
+-	 .proto = 0,
+-	 .buf = (void *)-1,
+-	 .buflen = sizeof(buf),
+-	 .flags = 0,
+-	 .to = &sin1,
+-	 .tolen = sizeof(sin1),
+-	 .retval = -1,
+-	 .experrno = EFAULT,
+-	 .setup = setup1,
+-	 .cleanup = cleanup1,
+-	 .desc = "invalid send buffer"}
+-	,
++//	/* Skip since uClinux does not implement memory protection */
++//	{.domain = PF_INET,
++//	 .type = SOCK_DGRAM,
++//	 .proto = 0,
++//	 .buf = (void *)-1,
++//	 .buflen = sizeof(buf),
++//	 .flags = 0,
++//	 .to = &sin1,
++//	 .tolen = sizeof(sin1),
++//	 .retval = -1,
++//	 .experrno = EFAULT,
++//	 .setup = setup1,
++//	 .cleanup = cleanup1,
++//	 .desc = "invalid send buffer"}
++//	,
+ #endif
+-	{.domain = PF_INET,
+-	 .type = SOCK_STREAM,
+-	 .proto = 0,
+-	 .buf = buf,
+-	 .buflen = sizeof(buf),
+-	 .flags = 0,
+-	 .to = &sin2,
+-	 .tolen = sizeof(sin2),
+-	 .retval = 0,
+-	 .experrno = EFAULT,
+-	 .setup = setup1,
+-	 .cleanup = cleanup1,
+-	 .desc = "connected TCP"}
+-	,
++//	{.domain = PF_INET,
++//	 .type = SOCK_STREAM,
++//	 .proto = 0,
++//	 .buf = buf,
++//	 .buflen = sizeof(buf),
++//	 .flags = 0,
++//	 .to = &sin2,
++//	 .tolen = sizeof(sin2),
++//	 .retval = 0,
++//	 .experrno = EFAULT,
++//	 .setup = setup1,
++//	 .cleanup = cleanup1,
++//	 .desc = "connected TCP"}
++//	,
+ 	{.domain = PF_INET,
+ 	 .type = SOCK_STREAM,
+ 	 .proto = 0,
+@@ -165,22 +170,23 @@ struct test_case_t tdat[] = {
+ 	 .cleanup = cleanup1,
+ 	 .desc = "invalid to buffer length"}
+ 	,
++// TODO: Enable back after issue 405 fixed
+ #ifndef UCLINUX
+-	/* Skip since uClinux does not implement memory protection */
+-	{.domain = PF_INET,
+-	 .type = SOCK_DGRAM,
+-	 .proto = 0,
+-	 .buf = buf,
+-	 .buflen = sizeof(buf),
+-	 .flags = 0,
+-	 .to = (struct sockaddr_in *)-1,
+-	 .tolen = sizeof(sin1),
+-	 .retval = -1,
+-	 .experrno = EFAULT,
+-	 .setup = setup1,
+-	 .cleanup = cleanup1,
+-	 .desc = "invalid to buffer"}
+-	,
++//	/* Skip since uClinux does not implement memory protection */
++//	{.domain = PF_INET,
++//	 .type = SOCK_DGRAM,
++//	 .proto = 0,
++//	 .buf = buf,
++//	 .buflen = sizeof(buf),
++//	 .flags = 0,
++//	 .to = (struct sockaddr_in *)-1,
++//	 .tolen = sizeof(sin1),
++//	 .retval = -1,
++//	 .experrno = EFAULT,
++//	 .setup = setup1,
++//	 .cleanup = cleanup1,
++//	 .desc = "invalid to buffer"}
++//	,
+ #endif
+ 	{.domain = PF_INET,
+ 	 .type = SOCK_DGRAM,
+@@ -195,20 +201,20 @@ struct test_case_t tdat[] = {
+ 	 .setup = setup1,
+ 	 .cleanup = cleanup1,
+ 	 .desc = "UDP message too big"}
+-	,
+-	{.domain = PF_INET,
+-	 .type = SOCK_STREAM,
+-	 .proto = 0,
+-	 .buf = buf,
+-	 .buflen = sizeof(buf),
+-	 .flags = 0,
+-	 .to = &sin1,
+-	 .tolen = sizeof(sin1),
+-	 .retval = -1,
+-	 .experrno = EPIPE,
+-	 .setup = setup2,
+-	 .cleanup = cleanup1,
+-	 .desc = "local endpoint shutdown"}
++//	,
++//	{.domain = PF_INET,
++//	 .type = SOCK_STREAM,
++//	 .proto = 0,
++//	 .buf = buf,
++//	 .buflen = sizeof(buf),
++//	 .flags = 0,
++//	 .to = &sin1,
++//	 .tolen = sizeof(sin1),
++//	 .retval = -1,
++//	 .experrno = EPIPE,
++//	 .setup = setup2,
++//	 .cleanup = cleanup1,
++//	 .desc = "local endpoint shutdown"}
+ 	,
+ 	{.domain = PF_INET,
+ 	 .type = SOCK_DGRAM,
+@@ -231,9 +237,9 @@ int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+ static char *argv0;
+ #endif
+ 
+-static pid_t start_server(struct sockaddr_in *sin0)
++static pthread_t start_server(struct sockaddr_in *sin0)
+ {
+-	pid_t pid;
++	pthread_t tid;
+ 	socklen_t slen = sizeof(*sin0);
+ 
+ 	sin0->sin_family = AF_INET;
+@@ -255,27 +261,21 @@ static pid_t start_server(struct sockaddr_in *sin0)
+ 	}
+ 	SAFE_GETSOCKNAME(cleanup, sfd, (struct sockaddr *)sin0, &slen);
+ 
+-	switch ((pid = FORK_OR_VFORK())) {
+-	case 0:
+-#ifdef UCLINUX
+-		if (self_exec(argv0, "d", sfd) < 0)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "server self_exec failed");
+-#else
+-		do_child();
+-#endif
+-		break;
+-	case -1:
+-		tst_brkm(TBROK | TERRNO, cleanup, "server fork failed");
+-	default:
++	//start a child thread to create a directory
++	if(pthread_create(&tid, NULL, do_child_thread, NULL)== -1)
++	{
++		tst_brkm(TBROK | TERRNO, cleanup, "Thread create failed");
++	}
++	else
++	{
++		tst_resm(TINFO,"Thread created");
+ 		(void)close(sfd);
+-		return pid;
+ 	}
++	return tid;
+ 
+-	exit(1);
+ }
+ 
+-static void do_child(void)
++void* do_child_thread(void* arg)
+ {
+ 	struct sockaddr_in fsin;
+ 	fd_set afds, rfds;
+@@ -287,7 +287,7 @@ static void do_child(void)
+ 	nfds = sfd + 1;
+ 
+ 	/* accept connections until killed */
+-	while (1) {
++	while (!kill_thread) {
+ 		socklen_t fromlen;
+ 
+ 		memcpy(&rfds, &afds, sizeof(rfds));
+@@ -315,6 +315,8 @@ static void do_child(void)
+ 			}
+ 		}
+ 	}
++	tst_resm(TINFO,"Thread finished");
++	pthread_exit(NULL);
+ }
+ 
+ int main(int ac, char *av[])
+@@ -323,10 +325,6 @@ int main(int ac, char *av[])
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+ 
+-#ifdef UCLINUX
+-	argv0 = av[0];
+-	maybe_run_child(&do_child, "d", &sfd);
+-#endif
+ 
+ 	setup();
+ 
+@@ -364,20 +362,18 @@ int main(int ac, char *av[])
+ 	tst_exit();
+ }
+ 
+-static pid_t server_pid;
+ 
+ static void setup(void)
+ {
+-	TEST_PAUSE;
+-
+-	server_pid = start_server(&sin1);
++	server_tid = start_server(&sin1);
+ 
+ 	signal(SIGPIPE, SIG_IGN);
+ }
+ 
+ static void cleanup(void)
+ {
+-	kill(server_pid, SIGKILL);
++	kill_thread = 1;
++	sched_yield();
+ }
+ 
+ static void setup0(void)


### PR DESCRIPTION
Issue:Test was using child process which is not possible in sgx. Due to product issues some subtests were failing.
Solution: In original test case the main process create a child process.
sgx-lkl supports single process environment.
The test case is modified to use a child
pthread instead of forking a child process.
One of the sub test case designed to test generation of EFAULT
by accessing invalid address values. Currently sgx behaviour is 
to call enclave abort, if address is not within enclave address
range. Because of this test program is causing enclave abort
and exiting with non-zero exit code. In addition a test related to shutdown a local endpoint is also
disabled until issue 405 is resolved.