### PR TITLE
CI: Fix pkill logic

### DIFF
--- a/.azure-pipelines/scripts/test_utils.sh
+++ b/.azure-pipelines/scripts/test_utils.sh
@@ -31,13 +31,14 @@ function CheckNotRunning()
         ps -aux | grep $process
         echo "Trying to kill hanging $process process"
         sudo pkill -9 $process
-        pkill_exit=$?
-        if [[ $pkill_exit -ne 0 ]]; then
-            echo "Failed to kill hanging $process process. Exit code: $pkill_exit"
-            exit $pkill_exit
-        else
-	    echo "Killed the hanging $process process successfully"
-	    ps -aux | grep sgx-lkl-run-oe
+        # pkill does not block.
+        sleep 5
+        if pgrep -x $process >/dev/null; then
+            echo "Failed to kill hanging $process process."
+            ps -aux | grep $process
+            exit 1
         fi
+        echo "Killed the hanging $process process successfully"
+        ps -aux | grep $process
     fi
 }


### PR DESCRIPTION
There were two bugs:
1. A process might be running during `pgrep` but may have exited when calling `pkill`, which in turn would then fail with exit code 1 (no process found).
2. pkill does not block until the process exited. The exit code does not signal whether killing was successful.

This PR fixes both issues by ignoring the exit code of `pkill` and instead waiting for 5 seconds and then checking running processes again with `pgrep`.