### PR TITLE
Add script to make installation self-contained

### DIFF
--- a/tests/common.mk
+++ b/tests/common.mk
@@ -14,15 +14,4 @@ else
 	export SGXLKL_DOCKER_TOOL=${SGXLKL_PREFIX}/bin/sgx-lkl-docker
 	export SGXLKL_GDB=${SGXLKL_PREFIX}/bin/sgx-lkl-gdb
 	export SGXLKL_JAVA_RUN=${SGXLKL_PREFIX}/bin/sgx-lkl-java
-
-	# Infer build mode if not given.
-	ifeq (${SGXLKL_BUILD_MODE},)
-		ifeq (${SGXLKL_PREFIX},/opt/sgx-lkl-debug)
-			export SGXLKL_BUILD_MODE=debug
-		else ifeq (${SGXLKL_PREFIX},/opt/sgx-lkl-nonrelease)
-			export SGXLKL_BUILD_MODE=nonrelease
-		else
-			$(error SGXLKL_BUILD_MODE not set and SGXLKL_PREFIX is not a standard path)
-		endif
-	endif
 endif

--- a/tests/containers/cc/Makefile
+++ b/tests/containers/cc/Makefile
@@ -14,7 +14,7 @@ CC_stamp=$(CC).stamp
 # Note: OE_LOG_LEVEL=INFO also enables Azure DCAP Client logging.
 CC_DOCKER_ARGS=\
 	--rm --privileged --network=host \
-	-v $(SGXLKL_PREFIX):$(SGXLKL_PREFIX) \
+	-v $(SGXLKL_PREFIX):/opt/sgx-lkl \
 	-e SGXLKL_VERBOSE=1 -e SGXLKL_KERNEL_VERBOSE=1 -e SGXLKL_TAP=sgxlkl_tap0 \
 	-e OE_LOG_LEVEL=INFO
 
@@ -28,7 +28,7 @@ $(DATA_IMAGE): $(DISK_IMAGE)
 	cp $(DISK_IMAGE) $(DATA_IMAGE)
 
 $(CC_stamp): $(DISK_IMAGE) $(DATA_IMAGE)
-	$(SGXLKL_DOCKER_TOOL) build-cc --name=$(CC) --mode=$(SGXLKL_BUILD_MODE) --host-cfg=host-config.json --app-cfg=app-config.json
+	$(SGXLKL_DOCKER_TOOL) build-cc --name=$(CC) --host-cfg=host-config.json --app-cfg=app-config.json
 	touch $(CC_stamp)
 
 run: run-hw run-sw

--- a/tools/make_self_contained.sh
+++ b/tools/make_self_contained.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+set -e
+
+# This script transforms an SGX-LKL installation such that all shared library dependencies
+# are bundled in the installation prefix and SGX-LKL can be run stand-alone
+# without having other packages installed. The main purpose is to be able to
+# volume mount an SGX-LKL installation into a Docker container without requiring
+# the container to have any runtime dependencies installed.
+#
+# The folder structure of the self-contained installation is as follows:
+#
+# /opt/sgx-lkl
+#   bin/
+#     sgx-lkl-run-oe
+#     ...
+#   lib/
+#     libsgxlkl.so.signed
+#     external/
+#       loader (symlink to file below)
+#       ld-linux-x86-64.so.2
+#       libdcap_quoteprov.so
+#       libcurl.so.4
+#       libgcc_s.so.1
+#       ...
+#   tools/
+#
+# In general, this reflects a regular SGX-LKL installation tree plus the lib/external
+# folder containing all bundled libraries.
+#
+# Implementation notes:
+# 
+# Automatic dependency discovery relies on dynamically linked libraries, however, some
+# libraries like the Azure DCAP Client are dlopen'd at runtime.
+# Because of that, there is extra logic that deals with bundling them manually.
+
+if [ -z $SGXLKL_PREFIX ]; then
+    echo "ERROR: 'SGXLKL_PREFIX' is undefined. Please export SGXLKL_PREFIX=<SGX-LKL-OE> install prefix directory"
+    exit 1
+fi
+
+SGXLKL_PREFIX=$(realpath -s $SGXLKL_PREFIX)
+
+# Absolute prefix used for the location of the loader stored in the executable.
+# If this does not match at runtime, then the executable must be launched
+# with lib/external/loader bin/sgx-lkl-run-oe ...
+SGXLKL_TARGET_PREFIX=${SGXLKL_TARGET_PREFIX:-$SGXLKL_PREFIX}
+
+patchelf_version=0.10
+
+external_lib_dir=lib/external
+exe_name=sgx-lkl-run-oe
+exe_path=$SGXLKL_PREFIX/bin/$exe_name
+
+if [[ ! -f $exe_path ]]; then
+    echo "ERROR: $exe_path not found. Is this an installation?"
+    exit 1
+fi
+
+dlopened_libs=(
+    /usr/lib/libdcap_quoteprov.so # via Intel DCAP library
+    /lib/x86_64-linux-gnu/libnss_dns.so.2 # via libcurl (via Azure DCAP Client library)
+)
+
+# Extra files needed by libsgx libraries.
+libsgx_enclave_image_paths=(
+    /usr/lib/x86_64-linux-gnu/libsgx_pce.signed.so
+    /usr/lib/x86_64-linux-gnu/libsgx_qe3.signed.so
+    /usr/lib/x86_64-linux-gnu/libsgx_qve.signed.so
+)
+
+# We build patchelf ourselves as the Ubuntu package is too old and has bugs that affect us.
+patchelf_dir=/tmp/sgx-lkl-patchelf-$patchelf_version
+if [[ ! -d $patchelf_dir ]]; then
+    echo "Downloading and building patchelf $patchelf_version"
+    mkdir -p $patchelf_dir
+    pushd $patchelf_dir
+    git clone https://github.com/NixOS/patchelf.git
+    pushd patchelf
+    git checkout $patchelf_version
+    ./bootstrap.sh
+    ./configure --prefix=$patchelf_dir/dist
+    make
+    make install
+    popd
+    popd
+fi
+export PATH=$patchelf_dir/dist/bin:$PATH
+
+rpath=$(patchelf --print-rpath $exe_path)
+if [[ "$rpath" != "" ]]; then
+    echo "Installation is already self-contained."
+    exit 1
+fi
+
+mkdir -p $SGXLKL_PREFIX/$external_lib_dir
+
+# Copy shared library dependencies into Debian package tree.
+# Note that lddtree includes the input executables / libraries as well in its output.
+# This is why 'rm' below is removing the (only) executable again.
+echo "Shared library dependencies of $exe_path ${dlopened_libs[@]}:"
+lddtree -l "$exe_path" "${dlopened_libs[@]}" | sort | uniq
+lddtree -l "$exe_path" "${dlopened_libs[@]}" | sort | uniq | xargs -i cp {} $SGXLKL_PREFIX/$external_lib_dir
+rm $SGXLKL_PREFIX/$external_lib_dir/$exe_name
+
+# Patch RPATHs of main executable and shared libraries.
+patchelf --force-rpath --set-rpath "\$ORIGIN/../$external_lib_dir" $SGXLKL_PREFIX/bin/$exe_name
+for lib_path in $SGXLKL_PREFIX/lib/external/*; do
+    patchelf --force-rpath --set-rpath "\$ORIGIN" $lib_path
+done
+
+# Patch the main executable interpreter path.
+# Note that the interpreter has to be a valid absolute path as this is read
+# directly by the kernel which does not use the rpath etc for resolution.
+interp_path=$(patchelf --print-interpreter $SGXLKL_PREFIX/bin/$exe_name)
+interp_filename=$(basename $interp_path)
+cp $interp_path $SGXLKL_PREFIX/$external_lib_dir
+interp_install_path=$SGXLKL_TARGET_PREFIX/$external_lib_dir/$interp_filename
+patchelf --set-interpreter $interp_install_path $SGXLKL_PREFIX/bin/$exe_name
+
+# Add a well-known symlink to the loader so that it can be used if needed.
+ln -s $interp_filename $SGXLKL_PREFIX/$external_lib_dir/loader
+
+# Copy extra data files into Debian package tree.
+cp "${libsgx_enclave_image_paths[@]}" $SGXLKL_PREFIX/$external_lib_dir
+
+# Sanity check 1: ldd will fail if patchelf broke something badly,
+# though note that this does not check whether libraries can be resolved.
+echo "Running ldd test"
+ldd $SGXLKL_PREFIX/bin/$exe_name
+
+# Sanity check 2: Run --help in empty Docker container to check if libs can be resolved.
+# Note: This does not check whether the Azure DCAP Client library loads.
+tar cv --files-from /dev/null | sudo docker import - empty
+echo "Running Docker test 1"
+sudo docker run --rm -v $SGXLKL_PREFIX:$SGXLKL_TARGET_PREFIX empty $SGXLKL_TARGET_PREFIX/bin/$exe_name --help
+echo "Running Docker test 2"
+sudo docker run --rm -v $SGXLKL_PREFIX:/foo empty /foo/lib/external/loader /foo/bin/$exe_name --help
+
+echo "Successfully made installation self-contained."

--- a/tools/sgx-lkl-docker
+++ b/tools/sgx-lkl-docker
@@ -8,7 +8,6 @@ sgxlkl_root="${cmd_root}/.."
 
 sub_cmd=
 cc_name=
-cc_mode=debug
 cc_app_cfg=
 cc_host_cfg=
 
@@ -37,19 +36,10 @@ function usage() {
 function build-cc() {
     echo "SGX-LKL root: $sgxlkl_root"
 
-    echo "Creating confidential container '${cc_name}' for $cc_mode mode"
+    echo "Creating confidential container '${cc_name}'"
 
     context_dir=$(mktemp -d sgxlkl_docker_context_XXXX)
     echo "Using temporary directory ${context_dir}"
-
-    if [[ $cc_mode == release ]]; then
-        suffix=
-        mode_arg="--hw-release"
-    else
-        suffix="-$cc_mode"
-        mode_arg="--hw-debug"
-    fi
-    install_prefix="/opt/sgx-lkl$suffix"
 
     cat >>${context_dir}/Dockerfile << EOF
 FROM ubuntu:18.04
@@ -67,8 +57,8 @@ ENV TMPDIR=/tmp
 # See https://github.com/microsoft/Azure-DCAP-Client.
 ENV AZDCAP_CACHE=${TMPDIR}
 
-ENTRYPOINT ["${install_prefix}/bin/sgx-lkl-run-oe", "--host-config=/host-cfg.json", "--app-config=/app-cfg.json"]
-CMD ["${mode_arg}"]
+ENTRYPOINT ["/opt/sgx-lkl/lib/external/loader", "/opt/sgx-lkl/bin/sgx-lkl-run-oe", "--host-config=/host-cfg.json", "--app-config=/app-cfg.json"]
+CMD ["--hw-release"]
 EOF
 
     cp ${cc_app_cfg} ${context_dir}/app-cfg.json
@@ -103,9 +93,6 @@ function main() {
                 ;;
             build-cc)
                 sub_cmd=$1
-                ;;
-            --mode=?*)
-                cc_mode=${1#*=}
                 ;;
             --name=?*)
                 cc_name=${1#*=}

--- a/tools/sgx-lkl-docker
+++ b/tools/sgx-lkl-docker
@@ -57,7 +57,10 @@ ENV TMPDIR=/tmp
 # See https://github.com/microsoft/Azure-DCAP-Client.
 ENV AZDCAP_CACHE=${TMPDIR}
 
-ENTRYPOINT ["/opt/sgx-lkl/lib/external/loader", "/opt/sgx-lkl/bin/sgx-lkl-run-oe", "--host-config=/host-cfg.json", "--app-config=/app-cfg.json"]
+ENTRYPOINT ["/opt/sgx-lkl/lib/external/loader", "/opt/sgx-lkl/bin/sgx-lkl-run-oe",\
+    "--enclave-image=/opt/sgx-lkl/lib/libsgxlkl.so.signed",\
+    "--host-config=/host-cfg.json",\
+    "--app-config=/app-cfg.json"]
 CMD ["--hw-release"]
 EOF
 


### PR DESCRIPTION
Fixes https://github.com/lsds/sgx-lkl/issues/422.

This PR moves the part that makes an SGX-LKL installation stand-alone out of the Debian packaging script into a separate script. This allows developers that build SGX-LKL from source to run Docker containers by mounting SGX-LKL into the container at `/opt/sgx-lkl`.

As part of this PR I also removed the build mode option when building the Docker wrapper images with `sgx-lkl-docker build-cc`. The build mode was previously used to construct the right installation prefix path for the ENTRYPOINT. By using a single expected SGX-LKL prefix and launching SGX-LKL with the bundled loader library it doesn't matter anymore what the hard-coded path to the loader is within `sgx-lkl-run-oe`. This change means that the Docker image can be used more flexibly without having to mess with overriding the ENTRYPOINT when launching the container. It is enough to bind-mount a different installation into the container at the same path (`/opt/sgx-lkl`).