### PR TITLE
Disable two tests until fixed to unblock pipeline runs

### DIFF
--- a/.azure-pipelines/scripts/disabled_tests.txt
+++ b/.azure-pipelines/scripts/disabled_tests.txt
@@ -10,3 +10,5 @@ tests/virtio/python_read/Makefile
 tests/languages/java/network/Makefile
 tests/languages/java/hello_world/Makefile
 tests/languages/java/read_file/Makefile
+tests/languages/python/Makefile
+tests/containers/cc/Makefile


### PR DESCRIPTION
containers/cc tes is failing https://github.com/lsds/sgx-lkl/issues/413
languages/python test is failing https://github.com/lsds/sgx-lkl/issues/414
And these two failures happens a lot and cause high rate pipeline failures.
Disabling these two tests for now.

cc @letmaik  @jxyang @SeanTAllen 