### PR TITLE
LTP: Fixed fdatasync03 testcase

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -225,7 +225,7 @@
 /ltp/testcases/kernel/syscalls/fcntl/fcntl36
 #/ltp/testcases/kernel/syscalls/fdatasync/fdatasync01
 #/ltp/testcases/kernel/syscalls/fdatasync/fdatasync02
-/ltp/testcases/kernel/syscalls/fdatasync/fdatasync03
+#/ltp/testcases/kernel/syscalls/fdatasync/fdatasync03
 #/ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr01
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr02
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr03

--- a/tests/ltp/patches/ltp_fdatasync_fdatasync03_fix.patch
+++ b/tests/ltp/patches/ltp_fdatasync_fdatasync03_fix.patch
@@ -1,10 +1,16 @@
 + Patch Description: Tests were failing with kernel panic in loop filesystem. 
 + So modified the tests to use root file system.
 diff --git a/testcases/kernel/syscalls/fdatasync/fdatasync03.c b/testcases/kernel/syscalls/fdatasync/fdatasync03.c
-index ee50e75c9..0134f08da 100644
+index ee50e75c9..1654b8180 100644
 --- a/testcases/kernel/syscalls/fdatasync/fdatasync03.c
 +++ b/testcases/kernel/syscalls/fdatasync/fdatasync03.c
-@@ -29,10 +29,13 @@ static void verify_fdatasync(void)
+@@ -24,15 +24,19 @@
+ #define FILE_SIZE_MB   32
+ #define FILE_SIZE      (FILE_SIZE_MB * TST_MB)
+ #define MODE           0644
++#define dev            "/dev/vda"
+
+ static void verify_fdatasync(void)
  {
         int fd;
         unsigned long written;
@@ -12,20 +18,20 @@ index ee50e75c9..0134f08da 100644
 +
 +       rmdir(MNTPOINT);
 +       SAFE_MKDIR(MNTPOINT, 0644);
-+       SAFE_MOUNT("/dev/vda", MNTPOINT, "ext4", 0, NULL);
++       SAFE_MOUNT(dev, MNTPOINT, "ext4", 0, NULL);
         fd = SAFE_OPEN(FNAME, O_RDWR|O_CREAT, MODE);
 
 -       tst_dev_bytes_written(tst_device->dev);
-+       tst_dev_bytes_written("/dev/vda");
++       tst_dev_bytes_written(dev);
 
         tst_fill_fd(fd, 0, TST_MB, FILE_SIZE_MB);
 
-@@ -41,9 +44,12 @@ static void verify_fdatasync(void)
+@@ -41,9 +45,12 @@ static void verify_fdatasync(void)
         if (TST_RET)
                 tst_brk(TFAIL | TTERRNO, "fdatasync(fd) failed");
 
 -       written = tst_dev_bytes_written(tst_device->dev);
-+       written = tst_dev_bytes_written("/dev/vda");
++       written = tst_dev_bytes_written(dev);
 
         SAFE_CLOSE(fd);
 +       remove(FNAME);
@@ -34,7 +40,7 @@ index ee50e75c9..0134f08da 100644
 
         if (written >= FILE_SIZE)
                 tst_res(TPASS, "Test file data synced to device");
-@@ -53,8 +59,5 @@ static void verify_fdatasync(void)
+@@ -53,8 +60,5 @@ static void verify_fdatasync(void)
 
  static struct tst_test test = {
         .needs_root = 1,

--- a/tests/ltp/patches/ltp_fdatasync_fdatasync03_fix.patch
+++ b/tests/ltp/patches/ltp_fdatasync_fdatasync03_fix.patch
@@ -1,0 +1,46 @@
++ Patch Description: Tests were failing with kernel panic in loop filesystem. 
++ So modified the tests to use root file system.
+diff --git a/testcases/kernel/syscalls/fdatasync/fdatasync03.c b/testcases/kernel/syscalls/fdatasync/fdatasync03.c
+index ee50e75c9..0134f08da 100644
+--- a/testcases/kernel/syscalls/fdatasync/fdatasync03.c
++++ b/testcases/kernel/syscalls/fdatasync/fdatasync03.c
+@@ -29,10 +29,13 @@ static void verify_fdatasync(void)
+ {
+        int fd;
+        unsigned long written;
+-
++
++       rmdir(MNTPOINT);
++       SAFE_MKDIR(MNTPOINT, 0644);
++       SAFE_MOUNT("/dev/vda", MNTPOINT, "ext4", 0, NULL);
+        fd = SAFE_OPEN(FNAME, O_RDWR|O_CREAT, MODE);
+
+-       tst_dev_bytes_written(tst_device->dev);
++       tst_dev_bytes_written("/dev/vda");
+
+        tst_fill_fd(fd, 0, TST_MB, FILE_SIZE_MB);
+
+@@ -41,9 +44,12 @@ static void verify_fdatasync(void)
+        if (TST_RET)
+                tst_brk(TFAIL | TTERRNO, "fdatasync(fd) failed");
+
+-       written = tst_dev_bytes_written(tst_device->dev);
++       written = tst_dev_bytes_written("/dev/vda");
+
+        SAFE_CLOSE(fd);
++       remove(FNAME);
++       SAFE_UMOUNT(MNTPOINT);
++       SAFE_RMDIR(MNTPOINT);
+
+        if (written >= FILE_SIZE)
+                tst_res(TPASS, "Test file data synced to device");
+@@ -53,8 +59,5 @@ static void verify_fdatasync(void)
+
+ static struct tst_test test = {
+        .needs_root = 1,
+-       .mount_device = 1,
+-       .all_filesystems = 1,
+-       .mntpoint = MNTPOINT,
+        .test_all = verify_fdatasync,
+ };
+


### PR DESCRIPTION
Patch Description: Tests were failing with kernel panic in loop filesystem. 
So modified the tests to use root file system.