### PR TITLE
LTP: Fix for send01 and settimeofday01

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -790,7 +790,7 @@
 #/ltp/testcases/kernel/syscalls/select/select02
 #/ltp/testcases/kernel/syscalls/select/select03
 #/ltp/testcases/kernel/syscalls/select/select04
-/ltp/testcases/kernel/syscalls/send/send01
+#/ltp/testcases/kernel/syscalls/send/send01
 #/ltp/testcases/kernel/syscalls/sendfile/sendfile02
 #/ltp/testcases/kernel/syscalls/sendfile/sendfile03
 /ltp/testcases/kernel/syscalls/sendfile/sendfile04
@@ -874,7 +874,7 @@
 /ltp/testcases/kernel/syscalls/setsockopt/setsockopt02
 #/ltp/testcases/kernel/syscalls/setsockopt/setsockopt03
 #/ltp/testcases/kernel/syscalls/setsockopt/setsockopt04
-/ltp/testcases/kernel/syscalls/settimeofday/settimeofday01
+#/ltp/testcases/kernel/syscalls/settimeofday/settimeofday01
 /ltp/testcases/kernel/syscalls/settimeofday/settimeofday02
 #/ltp/testcases/kernel/syscalls/setuid/setuid01
 #/ltp/testcases/kernel/syscalls/setuid/setuid03

--- a/tests/ltp/patches/send01.patch
+++ b/tests/ltp/patches/send01.patch
@@ -16,17 +16,19 @@ Also, a test related to shutdown a local endpoint is also
 disabled until issue 405.
 url:https://github.com/lsds/sgx-lkl/issues/405
 diff --git a/testcases/kernel/syscalls/send/send01.c b/testcases/kernel/syscalls/send/send01.c
-index 2e0ae2177..b0e10028e 100644
+index 2e0ae2177..9d7caa4a3 100644
 --- a/testcases/kernel/syscalls/send/send01.c
 +++ b/testcases/kernel/syscalls/send/send01.c
-@@ -43,6 +43,7 @@
+@@ -43,7 +43,8 @@
  
  #include "test.h"
  #include "safe_macros.h"
+-
 +#include "pthread.h"
- 
++#include "tst_safe_pthread.h"
  char *TCID = "send01";
  int testno;
+ 
 @@ -67,13 +68,13 @@ struct test_case_t {		/* test case structure */
  };
  
@@ -124,11 +126,14 @@ index 2e0ae2177..b0e10028e 100644
  	socklen_t slen = sizeof(*sin0);
  
  	sin0->sin_family = AF_INET;
-@@ -184,28 +190,22 @@ static pid_t start_server(struct sockaddr_in *sin0)
+@@ -184,28 +190,14 @@ static pid_t start_server(struct sockaddr_in *sin0)
  		return -1;
  	}
  	SAFE_GETSOCKNAME(cleanup, sfd, (struct sockaddr *)sin0, &slen);
--
++	 //start a child thread to create a directory
++	SAFE_PTHREAD_CREATE(&tid, NULL, do_child_thread, NULL);
++	return tid;
+ 
 -	switch ((pid = FORK_OR_VFORK())) {
 -	case 0:
 -#ifdef UCLINUX
@@ -144,18 +149,7 @@ index 2e0ae2177..b0e10028e 100644
 -	default:
 -		close(sfd);
 -		return pid;
-+	 //start a child thread to create a directory
-+	if(pthread_create(&tid, NULL, do_child_thread, NULL)== -1)
-+	{
-+		tst_brkm(TBROK | TERRNO, cleanup, "Thread create failed");
- 	}
-+	else
-+	{
-+		tst_resm(TINFO,"Thread created");
-+		(void)close(sfd);
-+	}
-+	return tid;
-+
+-	}
  
 -	exit(1);
  }
@@ -165,7 +159,7 @@ index 2e0ae2177..b0e10028e 100644
  {
  	fd_set afds, rfds;
  	int nfds, cc, fd;
-@@ -217,7 +217,7 @@ static void do_child(void)
+@@ -217,7 +209,7 @@ static void do_child(void)
  	nfds = sfd + 1;
  
  	/* accept connections until killed */
@@ -174,7 +168,7 @@ index 2e0ae2177..b0e10028e 100644
  		socklen_t fromlen;
  
  		memcpy(&rfds, &afds, sizeof(rfds));
-@@ -245,6 +245,9 @@ static void do_child(void)
+@@ -245,6 +237,9 @@ static void do_child(void)
  			}
  		}
  	}
@@ -184,7 +178,7 @@ index 2e0ae2177..b0e10028e 100644
  }
  
  int main(int ac, char *av[])
-@@ -253,11 +256,6 @@ int main(int ac, char *av[])
+@@ -253,11 +248,6 @@ int main(int ac, char *av[])
  
  	tst_parse_opts(ac, av, NULL, NULL);
  
@@ -196,7 +190,7 @@ index 2e0ae2177..b0e10028e 100644
  	setup();
  
  	for (lc = 0; TEST_LOOPING(lc); ++lc) {
-@@ -293,20 +291,18 @@ int main(int ac, char *av[])
+@@ -293,21 +283,18 @@ int main(int ac, char *av[])
  	tst_exit();
  }
  
@@ -215,8 +209,9 @@ index 2e0ae2177..b0e10028e 100644
  static void cleanup(void)
  {
 -	kill(server_pid, SIGKILL);
+-
 +	kill_thread = 1;
 +	sched_yield();
- 
  }
  
+ static void setup0(void)

--- a/tests/ltp/patches/send01.patch
+++ b/tests/ltp/patches/send01.patch
@@ -1,0 +1,222 @@
+In the original test case, the main process creates a child process.
+sgx-lkl supports a single process environment.
+The test case is modified to use a child
+pthread instead of forking a child process.
+One of the subtest cases designed to test the generation of EFAULT
+by accessing invalid address values. Currently, sgx behavior is
+to call enclave abort, if the address is not within the enclave address
+range. Because of this test program is causing enclave abort
+and exiting with non-zero exit code.
+
+Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
+is raised to fix this behavior. The subtest cases which test
+EFAULT error behavior is commented/disabled until GitHub
+issue169 is fixed.
+Also, a test related to shutdown a local endpoint is also
+disabled until issue 405.
+url:https://github.com/lsds/sgx-lkl/issues/405
+diff --git a/testcases/kernel/syscalls/send/send01.c b/testcases/kernel/syscalls/send/send01.c
+index 2e0ae2177..b0e10028e 100644
+--- a/testcases/kernel/syscalls/send/send01.c
++++ b/testcases/kernel/syscalls/send/send01.c
+@@ -43,6 +43,7 @@
+ 
+ #include "test.h"
+ #include "safe_macros.h"
++#include "pthread.h"
+ 
+ char *TCID = "send01";
+ int testno;
+@@ -67,13 +68,13 @@ struct test_case_t {		/* test case structure */
+ };
+ 
+ static void cleanup(void);
+-static void do_child(void);
+ static void setup(void);
+ static void setup0(void);
+ static void setup1(void);
+ static void setup2(void);
+ static void cleanup0(void);
+ static void cleanup1(void);
++void* do_child_thread(void* arg);
+ 
+ static struct test_case_t tdat[] = {
+ 	{.domain = PF_INET,
+@@ -100,20 +101,21 @@ static struct test_case_t tdat[] = {
+ 	 .cleanup = cleanup0,
+ 	 .desc = "invalid socket"}
+ 	,
++//TODO Enable below lines after issue 169 is fixed
+ #ifndef UCLINUX
+-	/* Skip since uClinux does not implement memory protection */
+-	{.domain = PF_INET,
+-	 .type = SOCK_STREAM,
+-	 .proto = 0,
+-	 .buf = (void *)-1,
+-	 .buflen = sizeof(buf),
+-	 .flags = 0,
+-	 .retval = -1,
+-	 .experrno = EFAULT,
+-	 .setup = setup1,
+-	 .cleanup = cleanup1,
+-	 .desc = "invalid send buffer"}
+-	,
++//	/* Skip since uClinux does not implement memory protection */
++//	{.domain = PF_INET,
++//	 .type = SOCK_STREAM,
++//	 .proto = 0,
++//	 .buf = (void *)-1,
++//	 .buflen = sizeof(buf),
++//	 .flags = 0,
++//	 .retval = -1,
++//	 .experrno = EFAULT,
++//	 .setup = setup1,
++//	 .cleanup = cleanup1,
++//	 .desc = "invalid send buffer"}
++//	,
+ #endif
+ 	{.domain = PF_INET,
+ 	 .type = SOCK_DGRAM,
+@@ -127,18 +129,19 @@ static struct test_case_t tdat[] = {
+ 	 .cleanup = cleanup1,
+ 	 .desc = "UDP message too big"}
+ 	,
+-	{.domain = PF_INET,
+-	 .type = SOCK_STREAM,
+-	 .proto = 0,
+-	 .buf = buf,
+-	 .buflen = sizeof(buf),
+-	 .flags = 0,
+-	 .retval = -1,
+-	 .experrno = EPIPE,
+-	 .setup = setup2,
+-	 .cleanup = cleanup1,
+-	 .desc = "local endpoint shutdown"}
+-	,
++//TODO:Enable below lines after issue 405 is fixed
++//	{.domain = PF_INET,
++//	 .type = SOCK_STREAM,
++//	 .proto = 0,
++//	 .buf = buf,
++//	 .buflen = sizeof(buf),
++//	 .flags = 0,
++//	 .retval = -1,
++//	 .experrno = EPIPE,
++//	 .setup = setup2,
++//	 .cleanup = cleanup1,
++//	 .desc = "local endpoint shutdown"}
++//	,
+ #ifndef UCLINUX
+ 	/* Skip since uClinux does not implement memory protection */
+ 	{.domain = PF_INET,
+@@ -161,9 +164,12 @@ int TST_TOTAL = sizeof(tdat) / sizeof(tdat[0]);
+ static char *argv0;
+ #endif
+ 
+-static pid_t start_server(struct sockaddr_in *sin0)
++static pthread_t server_tid;
++static int kill_thread;
++
++static pthread_t start_server(struct sockaddr_in *sin0)
+ {
+-	pid_t pid;
++	pthread_t tid;
+ 	socklen_t slen = sizeof(*sin0);
+ 
+ 	sin0->sin_family = AF_INET;
+@@ -184,28 +190,22 @@ static pid_t start_server(struct sockaddr_in *sin0)
+ 		return -1;
+ 	}
+ 	SAFE_GETSOCKNAME(cleanup, sfd, (struct sockaddr *)sin0, &slen);
+-
+-	switch ((pid = FORK_OR_VFORK())) {
+-	case 0:
+-#ifdef UCLINUX
+-		if (self_exec(argv0, "d", sfd) < 0)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "server self_exec failed");
+-#else
+-		do_child();
+-#endif
+-		break;
+-	case -1:
+-		tst_brkm(TBROK | TERRNO, cleanup, "server fork failed");
+-	default:
+-		close(sfd);
+-		return pid;
++	 //start a child thread to create a directory
++	if(pthread_create(&tid, NULL, do_child_thread, NULL)== -1)
++	{
++		tst_brkm(TBROK | TERRNO, cleanup, "Thread create failed");
+ 	}
++	else
++	{
++		tst_resm(TINFO,"Thread created");
++		(void)close(sfd);
++	}
++	return tid;
++
+ 
+-	exit(1);
+ }
+ 
+-static void do_child(void)
++void* do_child_thread(void* arg)
+ {
+ 	fd_set afds, rfds;
+ 	int nfds, cc, fd;
+@@ -217,7 +217,7 @@ static void do_child(void)
+ 	nfds = sfd + 1;
+ 
+ 	/* accept connections until killed */
+-	while (1) {
++	while (!kill_thread) {
+ 		socklen_t fromlen;
+ 
+ 		memcpy(&rfds, &afds, sizeof(rfds));
+@@ -245,6 +245,9 @@ static void do_child(void)
+ 			}
+ 		}
+ 	}
++	tst_resm(TINFO,"Thread finished");
++	pthread_exit(NULL);
++
+ }
+ 
+ int main(int ac, char *av[])
+@@ -253,11 +256,6 @@ int main(int ac, char *av[])
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+ 
+-#ifdef UCLINUX
+-	argv0 = av[0];
+-	maybe_run_child(&do_child, "d", &sfd);
+-#endif
+-
+ 	setup();
+ 
+ 	for (lc = 0; TEST_LOOPING(lc); ++lc) {
+@@ -293,20 +291,18 @@ int main(int ac, char *av[])
+ 	tst_exit();
+ }
+ 
+-static pid_t server_pid;
+ 
+ static void setup(void)
+ {
+-	TEST_PAUSE;
+-
+-	server_pid = start_server(&sin1);
++	server_tid = start_server(&sin1);
+ 
+ 	signal(SIGPIPE, SIG_IGN);
+ }
+ 
+ static void cleanup(void)
+ {
+-	kill(server_pid, SIGKILL);
++	kill_thread = 1;
++	sched_yield();
+ 
+ }
+ 

--- a/tests/ltp/patches/settimeofday01.patch
+++ b/tests/ltp/patches/settimeofday01.patch
@@ -1,0 +1,41 @@
+One of the subtest cases designed to test the generation of EFAULT
+by accessing invalid address values. Currently, sgx behavior is
+to call enclave abort, if the address is not within the enclave address
+range. Because of this test program is causing enclave abort
+and exiting with non-zero exit code.
+
+Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
+is raised to fix this behavior. The subtest cases which test
+EFAULT error behavior is commented/disabled until GitHub
+issue169 is fixed.
+diff --git a/testcases/kernel/syscalls/settimeofday/settimeofday01.c b/testcases/kernel/syscalls/settimeofday/settimeofday01.c
+index 7388c3231..2cb5448a7 100644
+--- a/testcases/kernel/syscalls/settimeofday/settimeofday01.c
++++ b/testcases/kernel/syscalls/settimeofday/settimeofday01.c
+@@ -123,16 +123,16 @@ int main(int argc, char **argv)
+ 			tst_resm(TFAIL, "Test condition %d failed",
+ 				 condition_number++);
+ 		}
+-
+-		/* Invalid Args : Error Condition where tp = NULL */
+-		TEST(settimeofday((struct timeval *)-1, NULL));
+-		if (TEST_RETURN == -1) {
+-			tst_resm(TPASS, "Test condition %d successful",
+-				 condition_number++);
+-		} else {
+-			tst_resm(TFAIL, "Test condition %d failed",
+-				 condition_number);
+-		}
++//TODO:Enable after issue 169 is fixed
++//		/* Invalid Args : Error Condition where tp = NULL */
++//		TEST(settimeofday((struct timeval *)-1, NULL));
++//		if (TEST_RETURN == -1) {
++//			tst_resm(TPASS, "Test condition %d successful",
++//				 condition_number++);
++//		} else {
++//			tst_resm(TFAIL, "Test condition %d failed",
++//				 condition_number);
++//		}
+ 
+ 	}
+ 	cleanup();


### PR DESCRIPTION
send01
---------
Issue: In the original test case, the main process creates a child process.
sgx-lkl supports a single process environment.

One of the subtest cases designed to test the generation of EFAULT
by accessing invalid address values. Currently, sgx behavior is
to call enclave abort, if the address is not within the enclave address
range. Because of this test program is causing enclave abort
and exiting with non-zero exit code.
Solution:
The test case is modified to use a child
pthread instead of forking a child process.Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
is raised to fix this behavior. The subtest cases which test
EFAULT error behavior is commented/disabled until GitHub
issue169 is fixed.
Also, a test related to shutdown a local endpoint is also
disabled until issue 405.
url:https://github.com/lsds/sgx-lkl/issues/405

settimeofday01:
----------------
Issue: One of the subtest cases designed to test the generation of EFAULT
by accessing invalid address values. Currently, sgx behavior is
to call enclave abort, if the address is not within the enclave address
range. Because of this test program is causing enclave abort
and exiting with non-zero exit code.


Solution:Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
is raised to fix this behavior. The subtest cases which test
EFAULT error behavior is commented/disabled until GitHub
issue169 is fixed.