### PR TITLE
LTP: fixed linkat02 testcase

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -467,7 +467,7 @@
 /ltp/testcases/kernel/syscalls/link/link07
 /ltp/testcases/kernel/syscalls/link/link08
 /ltp/testcases/kernel/syscalls/linkat/linkat01
-/ltp/testcases/kernel/syscalls/linkat/linkat02
+#/ltp/testcases/kernel/syscalls/linkat/linkat02
 /ltp/testcases/kernel/syscalls/listen/listen01
 /ltp/testcases/kernel/syscalls/listxattr/listxattr01
 /ltp/testcases/kernel/syscalls/listxattr/listxattr02

--- a/tests/ltp/patches/ltp_linkat_linkat02_fix.patch
+++ b/tests/ltp/patches/ltp_linkat_linkat02_fix.patch
@@ -1,0 +1,50 @@
++ Patch Description: Tests were failing with kernel panic in loop filesystem. 
++ So modified the tests to use root file system.
+diff --git a/testcases/kernel/syscalls/linkat/linkat02.c b/testcases/kernel/syscalls/linkat/linkat02.c
+index 51785af02..080da3b25 100644
+--- a/testcases/kernel/syscalls/linkat/linkat02.c
++++ b/testcases/kernel/syscalls/linkat/linkat02.c
+@@ -49,10 +49,10 @@
+ #define BASENAME       "mntpoint/basename"
+
+ static char nametoolong[PATH_MAX+2];
+-static const char *device;
++static const char *device = "/dev/vda";
+ static int mount_flag;
+ static int max_hardlinks;
+-static const char *fs_type;
++static const char *fs_type = "ext4";
+
+ static void setup(void);
+ static void cleanup(void);
+@@ -148,12 +148,6 @@ static void setup(void)
+
+        tst_tmpdir();
+
+-       fs_type = tst_dev_fs_type();
+-       device = tst_acquire_device(cleanup);
+-
+-       if (!device)
+-               tst_brkm(TCONF, cleanup, "Failed to acquire device");
+-
+        TEST_PAUSE;
+
+        ltpuser = SAFE_GETPWNAM(cleanup, "nobody");
+@@ -170,7 +164,6 @@ static void setup(void)
+        SAFE_MKDIR(cleanup, "./tmp", DIR_MODE);
+        SAFE_TOUCH(cleanup, TEST_EACCES, 0666, NULL);
+
+-       tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+        SAFE_MKDIR(cleanup, "mntpoint", DIR_MODE);
+
+        SAFE_MOUNT(cleanup, device, "mntpoint", fs_type, 0, NULL);
+@@ -201,8 +194,5 @@ static void cleanup(void)
+        if (mount_flag && tst_umount("mntpoint") < 0)
+                tst_resm(TWARN | TERRNO, "umount device:%s failed", device);
+
+-       if (device)
+-               tst_release_device(device);
+-
+        tst_rmdir();
+ }
+


### PR DESCRIPTION
 Tests were failing with kernel panic in loop filesystem. So modified the tests to use root file system.