### PR TITLE
Fix incorrect address-of

### DIFF
--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -168,7 +168,7 @@ static int startmain(void* args)
         );
         if (OE_OK != result)
             sgxlkl_fail("Failed to retrieve report via oe_get_report_v2: %d.\n", result);
-        oe_free_report(&remote_report);
+        oe_free_report(remote_report);
     }
 
     /* Disk config has been set through app config


### PR DESCRIPTION
Since the whole DCAP test is throwing confusing warnings/errors for others I'm thinking about removing it. There's a new test in the EEID config that will exercise all of this properly.