### PR TITLE
LTP: Fix for renameat201,renameat202

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -740,8 +740,8 @@
 #/ltp/testcases/kernel/syscalls/rename/rename13
 /ltp/testcases/kernel/syscalls/rename/rename14
 /ltp/testcases/kernel/syscalls/renameat/renameat01
-/ltp/testcases/kernel/syscalls/renameat2/renameat201
-/ltp/testcases/kernel/syscalls/renameat2/renameat202
+#/ltp/testcases/kernel/syscalls/renameat2/renameat201
+#/ltp/testcases/kernel/syscalls/renameat2/renameat202
 /ltp/testcases/kernel/syscalls/request_key/request_key01
 /ltp/testcases/kernel/syscalls/request_key/request_key02
 /ltp/testcases/kernel/syscalls/request_key/request_key03

--- a/tests/ltp/patches/renameat201.patch
+++ b/tests/ltp/patches/renameat201.patch
@@ -1,0 +1,75 @@
+Patch to use root file system for the test as file system used for test
+does not support RENAME_EXCHANGE flag
+diff --git a/testcases/kernel/syscalls/renameat2/renameat201.c b/testcases/kernel/syscalls/renameat2/renameat201.c
+index 9832b1cdb..6b54e11ff 100644
+--- a/testcases/kernel/syscalls/renameat2/renameat201.c
++++ b/testcases/kernel/syscalls/renameat2/renameat201.c
+@@ -39,8 +39,10 @@
+ #include "lapi/fcntl.h"
+ #include "renameat2.h"
+ 
+-#define TEST_DIR "test_dir/"
+-#define TEST_DIR2 "test_dir2/"
++#define MNTPOINT  "mntpoint"
++#define DIR_MODE  (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define TEST_DIR "mntpoint/test_dir/"
++#define TEST_DIR2 "mntpoint/test_dir2/"
+ 
+ #define TEST_FILE "test_file"
+ #define TEST_FILE2 "test_file2"
+@@ -51,7 +53,8 @@ char *TCID = "renameat201";
+ 
+ static int olddirfd;
+ static int newdirfd;
+-static long fs_type;
++const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ static struct test_case {
+ 	int *olddirfd;
+@@ -105,9 +108,11 @@ static void setup(void)
+ 			"This test can only run on kernels that are 3.15. and higher");
+ 	}
+ 
+-	tst_tmpdir();
+ 
+-	fs_type = tst_fs_type(cleanup, ".");
++
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, NULL);
+ 
+ 	SAFE_MKDIR(cleanup, TEST_DIR, 0700);
+ 	SAFE_MKDIR(cleanup, TEST_DIR2, 0700);
+@@ -127,8 +132,16 @@ static void cleanup(void)
+ 
+ 	if (newdirfd > 0 && close(newdirfd) < 0)
+ 		tst_resm(TWARN | TERRNO, "close newdirfd failed");
++	remove("test_dir/test_file1");
++	remove("test_dir/test_file3");
++	remove("test_dir2/test_file2");
++	remove("test_dir2/test_file3");
++
++	SAFE_RMDIR(NULL, TEST_DIR);
++	SAFE_RMDIR(NULL, TEST_DIR2);
++	SAFE_UMOUNT(NULL, MNTPOINT);
++	SAFE_RMDIR(NULL, MNTPOINT);
+ 
+-	tst_rmdir();
+ 
+ }
+ 
+@@ -137,13 +150,6 @@ static void renameat2_verify(const struct test_case *test)
+ 	TEST(renameat2(*(test->olddirfd), test->oldpath,
+ 			*(test->newdirfd), test->newpath, test->flags));
+ 
+-	if ((test->flags & RENAME_EXCHANGE) && EINVAL == TEST_ERRNO
+-		&& fs_type == TST_BTRFS_MAGIC) {
+-		tst_resm(TCONF,
+-			"RENAME_EXCHANGE flag is not implemeted on %s",
+-			tst_fs_type_name(fs_type));
+-		return;
+-	}
+ 
+ 	if (test->exp_errno && TEST_RETURN != -1) {
+ 		tst_resm(TFAIL, "renameat2() succeeded unexpectedly");

--- a/tests/ltp/patches/renameat202.patch
+++ b/tests/ltp/patches/renameat202.patch
@@ -1,0 +1,73 @@
+Patch to use root file system for the test as file system used for test
+does not support RENAME_EXCHANGE flag
+diff --git a/testcases/kernel/syscalls/renameat2/renameat202.c b/testcases/kernel/syscalls/renameat2/renameat202.c
+index 0c1457022..1ab4d97af 100644
+--- a/testcases/kernel/syscalls/renameat2/renameat202.c
++++ b/testcases/kernel/syscalls/renameat2/renameat202.c
+@@ -28,8 +28,10 @@
+ #include "lapi/fcntl.h"
+ #include "renameat2.h"
+ 
+-#define TEST_DIR "test_dir/"
+-#define TEST_DIR2 "test_dir2/"
++#define MNTPOINT  "mntpoint"
++#define DIR_MODE  (S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)
++#define TEST_DIR "mntpoint/test_dir/"
++#define TEST_DIR2 "mntpoint/test_dir2/"
+ 
+ #define TEST_FILE "test_file"
+ #define TEST_FILE2 "test_file2"
+@@ -42,7 +44,8 @@ static int fd = -1;
+ static int cnt;
+ 
+ static const char content[] = "content";
+-static long fs_type;
++const char *device = "/dev/vda";
++static const char *fs_type = "ext4";
+ 
+ 
+ int TST_TOTAL = 1;
+@@ -83,9 +86,9 @@ static void setup(void)
+ 			"This test can only run on kernels that are 3.15. and higher");
+ 	}
+ 
+-	tst_tmpdir();
+-
+-	fs_type = tst_fs_type(cleanup, ".");
++	rmdir(MNTPOINT);
++	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
++	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, NULL);
+ 
+ 	SAFE_MKDIR(cleanup, TEST_DIR, 0700);
+ 	SAFE_MKDIR(cleanup, TEST_DIR2, 0700);
+@@ -111,11 +114,14 @@ static void cleanup(void)
+ 	if (fd > 0 && close(fd) < 0)
+ 		tst_resm(TWARN | TERRNO, "close fd failed");
+ 
+-	tst_rmdir();
+-
++	remove("test_dir/test_file");
++	remove("test_dir2/test_file2");
++	SAFE_RMDIR(NULL, TEST_DIR);
++	SAFE_RMDIR(NULL, TEST_DIR2);
++	SAFE_UMOUNT(NULL, MNTPOINT);
++	SAFE_RMDIR(NULL, MNTPOINT);
+ }
+-
+-static void renameat2_verify(void)
++ void renameat2_verify(void)
+ {
+ 	char str[BUFSIZ] = { 0 };
+ 	struct stat st;
+@@ -123,11 +129,6 @@ static void renameat2_verify(void)
+ 	char *contentfile;
+ 	int readn, data_len;
+ 
+-	if (TEST_ERRNO == EINVAL && TST_BTRFS_MAGIC == fs_type) {
+-		tst_brkm(TCONF, cleanup,
+-			"RENAME_EXCHANGE flag is not implemeted on %s",
+-			tst_fs_type_name(fs_type));
+-	}
+ 
+ 	if (TEST_RETURN != 0) {
+ 		tst_resm(TFAIL | TTERRNO, "renameat2() failed unexpectedly");


### PR DESCRIPTION
Issue: Subtest related to RENAME_EXCHANGE flag in renameat2 system call were failing as file system was not supporting the flag. With this flag, an existing file at the new name will not be deleted; instead, it will be renamed to old name. 
Solution: Using root file system to test the API 