### PR TITLE
Add instructions for running cc test locally

### DIFF
--- a/tests/containers/cc/Makefile
+++ b/tests/containers/cc/Makefile
@@ -36,22 +36,10 @@ run: run-hw run-sw
 
 ifeq (${SGXLKL_PREFIX},)
 run-hw:
-	@echo SGXLKL_PREFIX missing, skipping test.
-	@echo For local testing, run the following first:
-	@echo "> cd $$SGXLKL_ROOT"
-	@echo "> export SGXLKL_PREFIX=$$SGXLKL_ROOT/build/install"
-	@echo "> make install PREFIX=\$$SGXLKL_PREFIX"
-	@echo "> tools/make_self_contained.sh"
-	@echo "Then re-run the test with SGXLKL_PREFIX still set."
+	@echo SGXLKL_PREFIX missing, skipping test. See README.md.
 
 run-sw:
-	@echo SGXLKL_PREFIX missing, skipping test.
-	@echo For local testing, run the following first:
-	@echo "> cd $$SGXLKL_ROOT"
-	@echo "> export SGXLKL_PREFIX=$$SGXLKL_ROOT/build/install"
-	@echo "> make install PREFIX=\$$SGXLKL_PREFIX"
-	@echo "> tools/make_self_contained.sh"
-	@echo "Then re-run the test with SGXLKL_PREFIX still set."
+	@echo SGXLKL_PREFIX missing, skipping test. See README.md.
 else
 run-hw: $(CC_stamp)
 	docker run $(CC_DOCKER_ARGS) $(CC) --hw-debug

--- a/tests/containers/cc/Makefile
+++ b/tests/containers/cc/Makefile
@@ -11,12 +11,13 @@ CC=python-helloworld-cc
 CC_stamp=$(CC).stamp
 
 # This test verifies in-enclave networking.
-# Note: OE_LOG_LEVEL=INFO also enables Azure DCAP Client logging.
+# Due to the use of the Azure DCAP Client on the host,
+# it also implicitly verifies host-side networking (not using the TAP device).
 CC_DOCKER_ARGS=\
 	--rm --privileged --network=host \
 	-v $(SGXLKL_PREFIX):/opt/sgx-lkl \
 	-e SGXLKL_VERBOSE=1 -e SGXLKL_KERNEL_VERBOSE=1 -e SGXLKL_TAP=sgxlkl_tap0 \
-	-e OE_LOG_LEVEL=INFO
+	-e AZDCAP_DEBUG_LOG_LEVEL=INFO
 
 .DELETE_ON_ERROR:
 .PHONY: run run-hw run-sw clean
@@ -35,10 +36,22 @@ run: run-hw run-sw
 
 ifeq (${SGXLKL_PREFIX},)
 run-hw:
-	@echo SGXLKL_PREFIX missing, skipping test
+	@echo SGXLKL_PREFIX missing, skipping test.
+	@echo For local testing, run the following first:
+	@echo "> cd $$SGXLKL_ROOT"
+	@echo "> export SGXLKL_PREFIX=$$SGXLKL_ROOT/build/install"
+	@echo "> make install PREFIX=\$$SGXLKL_PREFIX"
+	@echo "> tools/make_self_contained.sh"
+	@echo "Then re-run the test with SGXLKL_PREFIX still set."
 
 run-sw:
-	@echo SGXLKL_PREFIX missing, skipping test
+	@echo SGXLKL_PREFIX missing, skipping test.
+	@echo For local testing, run the following first:
+	@echo "> cd $$SGXLKL_ROOT"
+	@echo "> export SGXLKL_PREFIX=$$SGXLKL_ROOT/build/install"
+	@echo "> make install PREFIX=\$$SGXLKL_PREFIX"
+	@echo "> tools/make_self_contained.sh"
+	@echo "Then re-run the test with SGXLKL_PREFIX still set."
 else
 run-hw: $(CC_stamp)
 	docker run $(CC_DOCKER_ARGS) $(CC) --hw-debug

--- a/tests/containers/cc/README.md
+++ b/tests/containers/cc/README.md
@@ -1,0 +1,11 @@
+This test does not run SGX-LKL on the host but inside a Docker container.
+For this, a self-contained SGX-LKL installation is mounted into the container.
+To run this test, make sure you installed SGX-LKL and made it self-contained:
+
+```sh
+export SGXLKL_PREFIX=/opt/sgx-lkl
+sudo make install PREFIX=$SGXLKL_PREFIX
+sudo -E tools/make_self_contained.sh
+```
+
+You can now run the test with `SGXLKL_PREFIX` still set.

--- a/tools/make_self_contained.sh
+++ b/tools/make_self_contained.sh
@@ -127,7 +127,7 @@ interp_install_path=$SGXLKL_TARGET_PREFIX/$external_lib_dir/$interp_filename
 patchelf --set-interpreter $interp_install_path $SGXLKL_PREFIX/bin/$exe_name
 
 # Add a well-known symlink to the loader so that it can be used if needed.
-ln -s $interp_filename $SGXLKL_PREFIX/$external_lib_dir/loader
+ln -sf $interp_filename $SGXLKL_PREFIX/$external_lib_dir/loader
 
 # Copy extra data files into Debian package tree.
 cp "${libsgx_enclave_image_paths[@]}" $SGXLKL_PREFIX/$external_lib_dir


### PR DESCRIPTION
Also fixes a minor issue when re-running `tools/make_self_contained.sh` after a re-install of SGX-LKL: