### PR TITLE
Allow overriding of OE_SDK_ROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ default: all
 
 all: update-git-submodules $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)) $(BUILD_DIR)/$(SGXLKL_LIB_TARGET_SIGNED) fsgsbase-kernel-module
 
+ifeq ($(OE_SDK_ROOT),$(OE_SDK_ROOT_DEFAULT))
 # Build and install Open Enclave locally
 $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)):
 	# Don't build tests.
@@ -21,6 +22,7 @@ $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)):
 	mkdir -p $(OE_SUBMODULE)/build
 	cd $(OE_SUBMODULE)/build && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_INSTALL_PREFIX=$(OE_SDK_ROOT) -DENABLE_REFMAN=OFF -DCOMPILE_SYSTEM_EDL=ON ..
 	$(MAKE) -C $(OE_SUBMODULE)/build -j$(tools/ncore.sh) && $(MAKE) -C $(OE_SUBMODULE)/build install
+endif
 
 # Install the glibc headers as for building libsgxlkl.so --nostdincludes is required.
 glibc-header-install: | ${SGXLKL_LIBC_SRC_DIR}/.git ${HOST_LIBC_BLD_DIR}

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ default: all
 
 all: update-git-submodules $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)) $(BUILD_DIR)/$(SGXLKL_LIB_TARGET_SIGNED) fsgsbase-kernel-module
 
+# Check if the user didn't override the default in-tree OE install location with another OE host install
 ifeq ($(OE_SDK_ROOT),$(OE_SDK_ROOT_DEFAULT))
 # Build and install Open Enclave locally
 $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)):

--- a/config.mak
+++ b/config.mak
@@ -139,7 +139,8 @@ endif
 
 # OpenEnclave
 OE_SUBMODULE := $(SGXLKL_ROOT)/openenclave
-OE_SDK_ROOT := ${BUILD_DIR}/openenclave
+OE_SDK_ROOT_DEFAULT := $(BUILD_DIR)/openenclave
+OE_SDK_ROOT ?= $(OE_SDK_ROOT_DEFAULT)
 export OE_SDK_INCLUDES := $(OE_SDK_ROOT)/include
 export OE_SDK_LIBS := $(OE_SDK_ROOT)/lib
 OE_OESIGN_TOOL_PATH := $(OE_SDK_ROOT)/bin


### PR DESCRIPTION
This makes it easy to build with non-default OE_SDK_ROOT. 