### PR TITLE
LTP: fix testcase pipe04 issue

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -644,7 +644,7 @@
 #/ltp/testcases/kernel/syscalls/pipe/pipe01
 /ltp/testcases/kernel/syscalls/pipe/pipe02
 #/ltp/testcases/kernel/syscalls/pipe/pipe03
-/ltp/testcases/kernel/syscalls/pipe/pipe04
+#/ltp/testcases/kernel/syscalls/pipe/pipe04
 /ltp/testcases/kernel/syscalls/pipe/pipe05
 #/ltp/testcases/kernel/syscalls/pipe/pipe06
 #/ltp/testcases/kernel/syscalls/pipe/pipe07

--- a/tests/ltp/patches/fix_pipe_pipe04.patch
+++ b/tests/ltp/patches/fix_pipe_pipe04.patch
@@ -1,0 +1,184 @@
+In original test case, parent process create a pipe
+and fork 2 child processes. These two child processes
+continuously write into pipe and parent process read
+from this pipe for 100 times and kills both the child
+process.
+sgx-lkl supports a single process environment. Hence,
+child processes are changed to child thread and a
+global variable is used to exit from thread.
+
+diff --git a/testcases/kernel/syscalls/pipe/pipe04.c b/testcases/kernel/syscalls/pipe/pipe04.c
+index a3c56e337..5fb72ddfe 100644
+--- a/testcases/kernel/syscalls/pipe/pipe04.c
++++ b/testcases/kernel/syscalls/pipe/pipe04.c
+@@ -46,20 +46,24 @@
+ #include <unistd.h>
+ #include <errno.h>
+ #include <signal.h>
++#include <pthread.h>
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include "test.h"
+ #include "safe_macros.h"
++#include "tst_safe_pthread.h"
+ 
+ char *TCID = "pipe04";
+ int TST_TOTAL = 1;
+ 
+ int fildes[2];			/* fds for pipe read and write */
++int c1func_exit = 0;
++int c2func_exit = 0;
+ 
+ void setup(void);
+ void cleanup(void);
+-void c1func(void);
+-void c2func(void);
++void* c1func(void* parm);
++void* c2func(void* parm);
+ void alarmfunc(int);
+ 
+ ssize_t do_read(int fd, void *buf, size_t count)
+@@ -76,18 +80,13 @@ ssize_t do_read(int fd, void *buf, size_t count)
+ int main(int ac, char **av)
+ {
+ 	int lc;
+-	pid_t c1pid, c2pid;
+-	int wtstatus;
++	pthread_t tid1, tid2;
+ 	int bytesread;
+ 	int acnt = 0, bcnt = 0;
+ 
+ 	char rbuf[BUFSIZ];
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+-#ifdef UCLINUX
+-	maybe_run_child(&c1func, "ndd", 1, &fildes[0], &fildes[1]);
+-	maybe_run_child(&c2func, "ndd", 2, &fildes[0], &fildes[1]);
+-#endif
+ 
+ 	setup();
+ 
+@@ -98,35 +97,9 @@ int main(int ac, char **av)
+ 
+ 		SAFE_PIPE(cleanup, fildes);
+ 
+-		if ((c1pid = FORK_OR_VFORK()) == -1)
+-			tst_brkm(TBROK, cleanup, "fork() failed - "
+-				 "errno %d", errno);
+-		if (c1pid == 0)
+-#ifdef UCLINUX
+-			if (self_exec(av[0], "ndd", 1, fildes[0], fildes[1]) <
+-			    0) {
+-				tst_brkm(TBROK, cleanup, "self_exec failed");
+-			}
+-#else
+-			c1func();
+-#endif
+-		if ((c2pid = FORK_OR_VFORK()) == -1)
+-			tst_brkm(TBROK, cleanup, "fork() failed - "
+-				 "errno %d", errno);
+-		if (c2pid == 0)
+-#ifdef UCLINUX
+-			if (self_exec(av[0], "ndd", 2, fildes[0], fildes[1]) <
+-			    0) {
+-				tst_brkm(TBROK, cleanup, "self_exec failed");
+-			}
+-#else
+-			c2func();
+-#endif
++		SAFE_PTHREAD_CREATE(&tid1, NULL, c1func, NULL);
++		SAFE_PTHREAD_CREATE(&tid2, NULL, c2func, NULL);
+ 
+-		/* PARENT */
+-		if (close(fildes[1]) == -1)
+-			tst_resm(TWARN, "Could not close fildes[1] - errno %d",
+-				 errno);
+ 		/*
+ 		 * Read a bit from the children first
+ 		 */
+@@ -151,15 +124,9 @@ int main(int ac, char **av)
+ 			}
+ 		}
+ 
+-		/*
+-		 * Try to kill the children
+-		 */
+-		if (kill(c1pid, SIGKILL) == -1)
+-			tst_resm(TFAIL, "failed to kill child 1, errno=%d",
+-				 errno);
+-		if (kill(c2pid, SIGKILL) == -1)
+-			tst_resm(TFAIL, "failed to kill child 1, errno=%d",
+-				 errno);
++		// Exit from the thread
++		c1func_exit = 1;
++		c2func_exit = 1;
+ 
+ 		/*
+ 		 * Set action for the alarm
+@@ -171,25 +138,18 @@ int main(int ac, char **av)
+ 		 * processes don't die
+ 		 */
+ 		alarm(60);
+-		if (waitpid(c1pid, &wtstatus, 0) != -1) {
+-			if (wtstatus != SIGKILL)
+-				tst_resm(TFAIL | TERRNO,
+-					 "unexpected wait status " "%d",
+-					 wtstatus);
+-			else
+-				tst_resm(TPASS, "Child 1 killed while "
+-					 "writing to a pipe");
+-		}
+-		if (waitpid(c2pid, &wtstatus, 0) != -1) {
+-			if (!WIFSIGNALED(wtstatus) ||
+-			    WTERMSIG(wtstatus) != SIGKILL)
+-				tst_resm(TFAIL | TERRNO,
+-					 "unexpected wait status " "%d",
+-					 wtstatus);
+-			else
+-				tst_resm(TPASS, "Child 2 killed while "
+-					 "writing to a pipe");
+-		}
++		
++		// Wait for all threads to join
++		SAFE_PTHREAD_JOIN(tid1, NULL);
++		SAFE_PTHREAD_JOIN(tid2, NULL);
++		
++		// close pipe descriptors
++		if (close(fildes[0]) == -1)
++			tst_resm(TFAIL, "Could not close fildes[0] - errno %d",
++				 errno);
++		if (close(fildes[1]) == -1)
++			tst_resm(TFAIL, "Could not close fildes[1] - errno %d",
++				 errno);
+ 		if (alarm(0) <= 0)
+ 			tst_resm(TWARN, "call to alarm(0) failed");
+ 	}
+@@ -217,22 +177,20 @@ void cleanup(void)
+ {
+ }
+ 
+-void c1func(void)
++void* c1func(void* parm LTP_ATTRIBUTE_UNUSED)
+ {
+-	if (close(fildes[0]) == -1)
+-		tst_resm(TWARN, "Could not close fildes[0] - errno %d", errno);
+-	while (1)
++	while (c1func_exit != 1)
+ 		if (write(fildes[1], "bbbbbbbbbbbbbbbbbbbbbbbbb", 25) == -1)
+ 			tst_resm(TBROK | TERRNO, "[child 1] pipe write failed");
++	pthread_exit(0);
+ }
+ 
+-void c2func(void)
++void* c2func(void* parm LTP_ATTRIBUTE_UNUSED)
+ {
+-	if (close(fildes[0]) == -1)
+-		tst_resm(TWARN, "Could not close fildes[0] - errno %d", errno);
+-	while (1)
++	while (c2func_exit != 1)
+ 		if (write(fildes[1], "AAAAAAAAAAAAAAAAAAAAAAAAA", 25) == -1)
+ 			tst_resm(TBROK | TERRNO, "[child 2] pipe write failed");
++	pthread_exit(0);
+ }
+ 
+ void alarmfunc(int sig LTP_ATTRIBUTE_UNUSED)


### PR DESCRIPTION
In original test case, parent process create a pipe
and fork 2 child processes. These two child processes
continuously write into pipe and parent process read
from this pipe for 100 times and kills both the child
process.
sgx-lkl supports a single process environment. Hence,
child processes are changed to child thread.