### PR TITLE
LTP: Fix for setpgid01

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -835,7 +835,7 @@
 #/ltp/testcases/kernel/syscalls/setitimer/setitimer03
 #/ltp/testcases/kernel/syscalls/setns/setns01
 /ltp/testcases/kernel/syscalls/setns/setns02
-/ltp/testcases/kernel/syscalls/setpgid/setpgid01
+#/ltp/testcases/kernel/syscalls/setpgid/setpgid01
 #/ltp/testcases/kernel/syscalls/setpgid/setpgid02
 /ltp/testcases/kernel/syscalls/setpgid/setpgid03
 /ltp/testcases/kernel/syscalls/setpgid/setpgid03_child

--- a/tests/ltp/patches/setpgid01.patch
+++ b/tests/ltp/patches/setpgid01.patch
@@ -1,0 +1,30 @@
+setpgid has a caveat that if pgid passed in is 0 then pgid is set to the
+process id of the calling process. Fix is to include that caveat.
+diff --git a/testcases/kernel/syscalls/setpgid/setpgid01.c b/testcases/kernel/syscalls/setpgid/setpgid01.c
+index 89c9a3779..c28f9e7f3 100644
+--- a/testcases/kernel/syscalls/setpgid/setpgid01.c
++++ b/testcases/kernel/syscalls/setpgid/setpgid01.c
+@@ -83,12 +83,19 @@ static void setpgid_test1(void)
+ 	pid = getpid();
+ 
+ 	TEST(setpgid(pid, pgid));
+-	if (TEST_RETURN == -1 || getpgrp() != pgid) {
+-		tst_resm(TFAIL | TTERRNO, "test setpgid(%d, %d) fail",
+-			 pid, pgid);
+-	} else {
++	if (pgid == 0 && TEST_RETURN == 0 && getpgrp() == pid)
++	{
+ 		tst_resm(TPASS, "test setpgid(%d, %d) success", pid, pgid);
+ 	}
++	else
++	{
++		if (TEST_RETURN == -1 || getpgrp() != pgid) {
++			tst_resm(TFAIL | TTERRNO, "test setpgid(%d, %d) fail",
++				 pid, pgid);
++		} else {
++			tst_resm(TPASS, "test setpgid(%d, %d) success", pid, pgid);
++		}
++	}
+ }
+ 
+ static int wait4child(pid_t child)


### PR DESCRIPTION
Issue: Test sets pgid for a process and retrieves it and checks. But it has a caveat that when pgid passed is 0 then it sets pgid to process id of calling process. Curret ltp code was not taking care of that.
Solution: Fix the test suite to check if pgid passed to setpgid is 0 then while retrieving pgid compare returned value with process id of calling process.