### PR TITLE
LTP: fix testcase pipe09 issue

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -649,7 +649,7 @@
 /ltp/testcases/kernel/syscalls/pipe/pipe06
 /ltp/testcases/kernel/syscalls/pipe/pipe07
 /ltp/testcases/kernel/syscalls/pipe/pipe08
-/ltp/testcases/kernel/syscalls/pipe/pipe09
+#/ltp/testcases/kernel/syscalls/pipe/pipe09
 /ltp/testcases/kernel/syscalls/pipe/pipe10
 /ltp/testcases/kernel/syscalls/pipe/pipe11
 /ltp/testcases/kernel/syscalls/pipe2/pipe2_01

--- a/tests/ltp/patches/fix_pipe_pipe09.patch
+++ b/tests/ltp/patches/fix_pipe_pipe09.patch
@@ -1,0 +1,103 @@
+Original test case performs below operation.
+1. Open a  pipe
+2. Fork a child which writes to the pipe
+3. Fork another child which writes a different character to the pipe
+4. Have the parent read from the pipe
+5. It should get the characters from both children.
+Sgx-lkl environment supports single process environment.
+The test case is modified to work in single process
+without forking child processes.
+
+diff --git a/testcases/kernel/syscalls/pipe/pipe09.c b/testcases/kernel/syscalls/pipe/pipe09.c
+index a4b2f8231..ba716ce97 100644
+--- a/testcases/kernel/syscalls/pipe/pipe09.c
++++ b/testcases/kernel/syscalls/pipe/pipe09.c
+@@ -76,11 +76,10 @@ int main(int ac, char **av)
+ {
+ 	int lc;
+ 
+-	int i, red, wtstatus;
++	int i, red;
+ 	int pipefd[2];		/* fds for pipe read/write */
+ 	char rebuf[BUFSIZ];
+ 	int Acnt = 0, Bcnt = 0;	/* count 'A' and 'B' */
+-	int fork_1, fork_2;	/* ret values in parent */
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+ 
+@@ -98,58 +97,16 @@ int main(int ac, char **av)
+ 			continue;
+ 		}
+ 
+-		if ((fork_1 = FORK_OR_VFORK()) == -1) {
+-			tst_brkm(TBROK, cleanup, "fork() #1 failed");
+-		}
+-
+-		if (fork_1 == 0) {	/* 1st child */
+-			if (close(pipefd[0]) != 0) {
+-				tst_resm(TWARN, "pipefd[0] close failed, "
+-					 "errno = %d", errno);
+-				exit(1);
+-			}
+-
+-			for (i = 0; i < PIPEWRTCNT / 2; ++i) {
+-				if (write(pipefd[1], "A", 1) != 1) {
+-					tst_resm(TWARN, "write to pipe failed");
+-					exit(1);
+-				}
++		for (i = 0; i < PIPEWRTCNT / 2; ++i) {
++			if (write(pipefd[1], "A", 1) != 1) {
++				tst_brkm(TBROK|TERRNO, cleanup, "write to pipe failed");
+ 			}
+-			exit(0);
+-		}
+-
+-		/* parent */
+-
+-		SAFE_WAITPID(cleanup, fork_1, &wtstatus, 0);
+-		if (WIFEXITED(wtstatus) && WEXITSTATUS(wtstatus) != 0) {
+-			tst_brkm(TBROK, cleanup, "child exited abnormally");
+-		}
+-
+-		if ((fork_2 = FORK_OR_VFORK()) == -1) {
+-			tst_brkm(TBROK, cleanup, "fork() #2 failed");
+ 		}
+ 
+-		if (fork_2 == 0) {	/* 2nd child */
+-			if (close(pipefd[0]) != 0) {
+-				perror("pipefd[0] close failed");
+-				exit(1);
++		for (i = 0; i < PIPEWRTCNT / 2; ++i) {
++			if (write(pipefd[1], "B", 1) != 1) {
++				tst_brkm(TBROK|TERRNO, cleanup, "write to pipe failed");
+ 			}
+-
+-			for (i = 0; i < PIPEWRTCNT / 2; ++i) {
+-				if (write(pipefd[1], "B", 1) != 1) {
+-					perror("write to pipe failed");
+-					exit(1);
+-				}
+-			}
+-			exit(0);
+-		}
+-
+-		/* parent */
+-
+-		SAFE_WAITPID(cleanup, fork_2, &wtstatus, 0);
+-		if (WEXITSTATUS(wtstatus) != 0) {
+-			tst_brkm(TBROK, cleanup, "problem detected in child, "
+-				 "wait status %d, errno = %d", wtstatus, errno);
+ 		}
+ 
+ 		if (close(pipefd[1]) != 0) {
+@@ -187,6 +144,10 @@ int main(int ac, char **av)
+ 
+ 		/* clean up things in case we are looping */
+ 		Acnt = Bcnt = 0;
++
++		if (close(pipefd[0]) != 0)
++			tst_brkm(TBROK | TERRNO, cleanup,
++				 "pipefd[0] close failed, errno = %d", errno);
+ 	}
+ 	cleanup();
+ 


### PR DESCRIPTION
Original test case performs below operation.
1. Open a  pipe
2. Fork a child which writes to the pipe
3. Fork another child which writes a different character to the pipe
4. Have the parent read from the pipe
5. It should get the characters from both children.
Sgx-lkl environment supports single process environment.
The test case is modified to work in single process
without forking child processes .