### PR TITLE
LTP: fix test case futex_futex_wait03 issue

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -272,7 +272,7 @@
 /ltp/testcases/kernel/syscalls/futex/futex_cmp_requeue02
 #/ltp/testcases/kernel/syscalls/futex/futex_wait01
 /ltp/testcases/kernel/syscalls/futex/futex_wait02
-/ltp/testcases/kernel/syscalls/futex/futex_wait03
+#/ltp/testcases/kernel/syscalls/futex/futex_wait03
 /ltp/testcases/kernel/syscalls/futex/futex_wait04
 #/ltp/testcases/kernel/syscalls/futex/futex_wait05
 #/ltp/testcases/kernel/syscalls/futex/futex_wait_bitset01

--- a/tests/ltp/patches/fix_futex_futex_wait03.patch
+++ b/tests/ltp/patches/fix_futex_futex_wait03.patch
@@ -1,0 +1,21 @@
+This test case invokes a function “tst_process_state_wait2()” in pthread.
+This function indefinitely wait for the process to change its state
+to “S” by monitoring the proc file (/proc/[pid]/state) entry. In sgx-lkl
+process state is not properly getting updated in proc filesystem. Hence,
+the call to “tst_process_state_wait2” is removed and added a sleep.
+
+diff --git a/testcases/kernel/syscalls/futex/futex_wait03.c b/testcases/kernel/syscalls/futex/futex_wait03.c
+index 9683e7650..3697c1033 100644
+--- a/testcases/kernel/syscalls/futex/futex_wait03.c
++++ b/testcases/kernel/syscalls/futex/futex_wait03.c
+@@ -37,7 +37,9 @@ static void *threaded(void *arg LTP_ATTRIBUTE_UNUSED)
+ {
+ 	long ret;
+ 
+-	tst_process_state_wait2(getpid(), 'S');
++	// wait for main thread to go for block state
++	sleep(3);
++	sched_yield();
+ 
+ 	ret = futex_wake(&futex, 1, FUTEX_PRIVATE_FLAG);
+ 


### PR DESCRIPTION
This test case invokes “tst_process_state_wait2” in thread.
Main issue is, this function indefinitely wait for process state
to be changed to “S” by monitoring the proc file
(/proc/[pid]/state). In sgx-lkl process state is not updating
properly in proc filesystem. Hence, the call to
“tst_process_state_wait2” is removed and added a sleep.