### PR TITLE
LTP: Fix for munmap03 testcase failure

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -602,7 +602,7 @@
 /ltp/testcases/kernel/syscalls/munlockall/munlockall01
 /ltp/testcases/kernel/syscalls/munmap/munmap01
 /ltp/testcases/kernel/syscalls/munmap/munmap02
-/ltp/testcases/kernel/syscalls/munmap/munmap03
+#/ltp/testcases/kernel/syscalls/munmap/munmap03
 /ltp/testcases/kernel/syscalls/nanosleep/nanosleep01
 #/ltp/testcases/kernel/syscalls/nanosleep/nanosleep02
 /ltp/testcases/kernel/syscalls/nanosleep/nanosleep04

--- a/tests/ltp/patches/munmap03.patch
+++ b/tests/ltp/patches/munmap03.patch
@@ -1,0 +1,17 @@
+In SGXLKL Environment, the munmap() returned 0, but the errno is set to 
+correct value i.e. EINVAL. Hence, modified the test check to verify both 
+Test return and Test error number. 
+
+diff --git a/testcases/kernel/syscalls/munmap/munmap03.c b/testcases/kernel/syscalls/munmap/munmap03.c
+index 3b88b531e..38a556c12 100644
+--- a/testcases/kernel/syscalls/munmap/munmap03.c
++++ b/testcases/kernel/syscalls/munmap/munmap03.c
+@@ -93,7 +93,7 @@ static void setup(void)
+ 
+ static void check_and_print(int expected_errno)
+ {
+-	if (TEST_RETURN == -1) {
++	if (TEST_RETURN || TEST_ERRNO) {
+ 		if (TEST_ERRNO == expected_errno) {
+ 			tst_resm(TPASS | TTERRNO, "failed as expected");
+ 		} else {


### PR DESCRIPTION
LTP: Fix for issue 10 , munmap03 test case failure..3 tests are run within munmap03. The return value of munmap is 0 but errorno is set correctly. So modified the check for validation to include TERRNO also. 