### PR TITLE
Update README.md to initialise OE submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,12 @@ sudo apt-get install make gcc g++ bc python xutils-dev bison flex libgcrypt20-de
 
 2. Clone the SGX-LKL git repository:
 ```
-git clone --branch oe_port git@github.com:lsds/sgx-lkl.git
+git clone --branch oe_port --recursive --progress git@github.com:lsds/sgx-lkl.git
 cd sgx-lkl
 ```
 
 3. Install the Open Enclave build dependencies:
 ```
-git submodule update --recursive --progress --init openenclave
 cd openenclave
 sudo scripts/ansible/install-ansible.sh
 sudo ansible-playbook scripts/ansible/oe-contributors-setup.yml

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ cd sgx-lkl
 
 3. Install the Open Enclave build dependencies:
 ```
+git submodule update --recursive --progress --init openenclave
 cd openenclave
 sudo scripts/ansible/install-ansible.sh
 sudo ansible-playbook scripts/ansible/oe-contributors-setup.yml

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo apt-get install make gcc g++ bc python xutils-dev bison flex libgcrypt20-de
 
 2. Clone the SGX-LKL git repository:
 ```
-git clone --branch oe_port --recursive --progress git@github.com:lsds/sgx-lkl.git
+git clone --branch oe_port --recursive https://github.com/lsds/sgx-lkl.git
 cd sgx-lkl
 ```
 


### PR DESCRIPTION
In the current instructions, a step to explicitly initialise the OpenEnclave submodule was missing. This meant that it was not possible to invoke the Ansible scripts that install the OE build dependencies.