### PR TITLE
LTP: Fix for getdents01

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -289,7 +289,7 @@
 /ltp/testcases/kernel/syscalls/getcwd/getcwd02
 /ltp/testcases/kernel/syscalls/getcwd/getcwd03
 #/ltp/testcases/kernel/syscalls/getcwd/getcwd04
-/ltp/testcases/kernel/syscalls/getdents/getdents01
+#/ltp/testcases/kernel/syscalls/getdents/getdents01
 /ltp/testcases/kernel/syscalls/getdents/getdents02
 /ltp/testcases/kernel/syscalls/getdomainname/getdomainname01
 /ltp/testcases/kernel/syscalls/getdtablesize/getdtablesize01

--- a/tests/ltp/patches/getdents01.patch
+++ b/tests/ltp/patches/getdents01.patch
@@ -1,0 +1,14 @@
+Patch to set the longsyscall flag needed for using 64bit api. 
+This is set by command line option -l. Fixing for pipeline.
+diff --git a/testcases/kernel/syscalls/getdents/getdents01.c b/testcases/kernel/syscalls/getdents/getdents01.c
+index 3962d960b..078ef45e6 100644
+--- a/testcases/kernel/syscalls/getdents/getdents01.c
++++ b/testcases/kernel/syscalls/getdents/getdents01.c
+@@ -99,6 +99,7 @@ int main(int ac, char **av)
+ 	dirp = buf;
+ 
+ 	setup();
++	longsyscall = 1;
+ 
+ 	for (lc = 0; TEST_LOOPING(lc); lc++) {
+ 		const char *d_name;


### PR DESCRIPTION
Issue : The test was not using 64 bit API as it needs -l option. So it was using 32 bit API and string was not matching.
Solution: Set the flag to use 64 bit API