### PR TITLE
LTP: Fix for syslogtst

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -965,7 +965,7 @@
 /ltp/testcases/kernel/syscalls/sysinfo/sysinfo02
 #/ltp/testcases/kernel/syscalls/syslog/syslog11
 #/ltp/testcases/kernel/syscalls/syslog/syslog12
-/ltp/testcases/kernel/syscalls/syslog/syslogtst
+#/ltp/testcases/kernel/syscalls/syslog/syslogtst
 #/ltp/testcases/kernel/syscalls/tee/tee01
 #/ltp/testcases/kernel/syscalls/tee/tee02
 /ltp/testcases/kernel/syscalls/tgkill/tgkill01

--- a/tests/ltp/patches/syslogtst.patch
+++ b/tests/ltp/patches/syslogtst.patch
@@ -1,0 +1,16 @@
+Patch to add a TPASS message after test pass.
+diff --git a/testcases/kernel/syscalls/syslog/syslogtst.c b/testcases/kernel/syscalls/syslog/syslogtst.c
+index 6950419ce..e0bb4c559 100644
+--- a/testcases/kernel/syscalls/syslog/syslogtst.c
++++ b/testcases/kernel/syscalls/syslog/syslogtst.c
+@@ -297,7 +297,10 @@ int main(int argc, char *argv[])
+ 	if (exit_flag == 1)
+ 		exit(1);
+ 	else
++	{
++		tst_resm(TPASS, "syslogt passed all test cases");	
+ 		exit(0);
++	}
+ 
+ }
+ 


### PR DESCRIPTION
Issue: Test was passing but was not having a TPASS statement.
Fix: Add a TPASS message before exiting successfully.