### PR TITLE
Change URL in networking test + free net file descriptor

### DIFF
--- a/src/host_interface/virtio_netdev.c
+++ b/src/host_interface/virtio_netdev.c
@@ -227,15 +227,14 @@ static void virtio_net_fd_net_poll_hup(uint8_t netdev_id)
     close(nd_fd->pipe[1]);
 }
 
-// FIXME not called from anywhere
 /*
  * Function to close the net device
  */
-//static void virtio_net_fd_net_free(uint8_t netdev_id)
-//{
-//    struct netdev_fd* nd_fd = get_netdev_fd_instance(netdev_id);
-//    close(nd_fd->fd);
-//}
+static void virtio_net_fd_net_free(uint8_t netdev_id)
+{
+    struct netdev_fd* nd_fd = get_netdev_fd_instance(netdev_id);
+    close(nd_fd->fd);
+}
 
 /*
  * Function to perform tx operation
@@ -653,5 +652,6 @@ void net_dev_remove(uint8_t netdev_id)
 {
     struct virtio_net_dev* net_dev = get_virtio_netdev_instance(netdev_id);
     virtio_net_fd_net_poll_hup(netdev_id);
+    virtio_net_fd_net_free(netdev_id);
     pthread_join(net_dev->poll_tid, NULL);
 }

--- a/tests/basic/network/Makefile
+++ b/tests/basic/network/Makefile
@@ -1,7 +1,11 @@
 include ../../common.mk
 
 CC_APP=/usr/bin/curl
-CC_APP_CMDLINE=${CC_APP} -v https://www.microsoft.com/
+
+# The following used to access https://www.microsoft.com, but this fails
+# with Github issue https://github.com/lsds/sgx-lkl/issues/499. Other URLs
+# appear to work fine.
+CC_APP_CMDLINE=${CC_APP} --trace-ascii - https://www.wikipedia.org/
 
 CC_IMAGE_SIZE=128M
 


### PR DESCRIPTION
This works around https://github.com/lsds/sgx-lkl/issues/499, so we can at least reactivate the networking test for the CI.

It also frees the allocated net file descriptor at shutdown.
