### PR TITLE
LTP: fix test case execve02 issue

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -129,7 +129,7 @@
 /ltp/testcases/kernel/syscalls/execv/execv01_child
 /ltp/testcases/kernel/syscalls/execve/execve01
 /ltp/testcases/kernel/syscalls/execve/execve01_child
-/ltp/testcases/kernel/syscalls/execve/execve02
+#/ltp/testcases/kernel/syscalls/execve/execve02
 /ltp/testcases/kernel/syscalls/execve/execve03
 /ltp/testcases/kernel/syscalls/execve/execve04
 /ltp/testcases/kernel/syscalls/execve/execve05

--- a/tests/ltp/patches/fix_execve_execve02.patch
+++ b/tests/ltp/patches/fix_execve_execve02.patch
@@ -1,0 +1,59 @@
+This test case is failed because, copying of resource
+file “execve_child” to the current directory is failed.
+Below modifications are performed to fix error.
+1. Complete path is mentioned in TEST_APP.
+2. Removed the resource file configuration.
+3. Modified to work as a single process.
+
+diff --git a/testcases/kernel/syscalls/execve/execve02.c b/testcases/kernel/syscalls/execve/execve02.c
+index d9fb5b919..87781df7a 100644
+--- a/testcases/kernel/syscalls/execve/execve02.c
++++ b/testcases/kernel/syscalls/execve/execve02.c
+@@ -28,12 +28,12 @@
+ 
+ #include "tst_test.h"
+ 
+-#define TEST_APP "execve_child"
++#define TEST_APP "/ltp/testcases/kernel/syscalls/execve/execve_child"
+ #define USER_NAME "nobody"
+ 
+ static uid_t nobody_uid;
+ 
+-static void do_child(void)
++static void verify_execve(void)
+ {
+ 	char *argv[2] = {TEST_APP, NULL};
+ 
+@@ -53,15 +53,6 @@ static void do_child(void)
+ 
+ 	tst_res(TPASS | TERRNO, "execve() failed expectedly");
+ 
+-	exit(0);
+-}
+-
+-static void verify_execve(void)
+-{
+-	pid_t pid = SAFE_FORK();
+-
+-	if (pid == 0)
+-		do_child();
+ }
+ 
+ static void setup(void)
+@@ -74,16 +65,10 @@ static void setup(void)
+ 	nobody_uid = pwd->pw_uid;
+ }
+ 
+-static const char *const resource_files[] = {
+-	TEST_APP,
+-	NULL,
+-};
+-
+ static struct tst_test test = {
+ 	.needs_root = 1,
+ 	.forks_child = 1,
+ 	.child_needs_reinit = 1,
+ 	.setup = setup,
+-	.resource_files = resource_files,
+ 	.test_all = verify_execve,
+ };


### PR DESCRIPTION
This test case is failed because, copying of resource
file “execve_child” to the current directory is failed.
Below modifications are performed to fix error.
1. Complete bin file path is mentioned in TEST_APP.
2. Removed the resource file configuration.
3. Modified to work as a single process.