### PR TITLE
LTP: fix test case setgid02 issue

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -824,7 +824,7 @@
 #/ltp/testcases/kernel/syscalls/setfsuid/setfsuid03
 #/ltp/testcases/kernel/syscalls/setfsuid/setfsuid04
 #/ltp/testcases/kernel/syscalls/setgid/setgid01
-/ltp/testcases/kernel/syscalls/setgid/setgid02
+#/ltp/testcases/kernel/syscalls/setgid/setgid02
 #/ltp/testcases/kernel/syscalls/setgid/setgid03
 #/ltp/testcases/kernel/syscalls/setgroups/setgroups01
 #/ltp/testcases/kernel/syscalls/setgroups/setgroups02

--- a/tests/ltp/patches/fix_setgid_setgid02.patch
+++ b/tests/ltp/patches/fix_setgid_setgid02.patch
@@ -1,0 +1,60 @@
+Test failed to open /etc/passwd file with nobody user.
+As test is not intended to test opening /etc/passwd.
+Hence, moved the related code to setup function. 
+Git hub issue 224 “https://github.com/lsds/sgx-lkl/issues/224” is raised.
+
+diff --git a/testcases/kernel/syscalls/setgid/setgid02.c b/testcases/kernel/syscalls/setgid/setgid02.c
+index b3f4fd646..a00948faa 100644
+--- a/testcases/kernel/syscalls/setgid/setgid02.c
++++ b/testcases/kernel/syscalls/setgid/setgid02.c
+@@ -37,13 +37,14 @@ static char root[] = "root";
+ static char nobody_uid[] = "nobody";
+ static char nobody_gid[] = "nobody";
+ static struct passwd *ltpuser;
++static gid_t rootpw_gid;
+ 
+ static void setup(void);
+ static void cleanup(void);
+ 
+ int main(int ac, char **av)
+ {
+-	struct passwd *getpwnam(), *rootpwent;
++	struct passwd *getpwnam();
+ 	int lc;
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+@@ -53,14 +54,9 @@ int main(int ac, char **av)
+ 	for (lc = 0; TEST_LOOPING(lc); lc++) {
+ 		tst_count = 0;
+ 
+-		if ((rootpwent = getpwnam(root)) == NULL) {
+-			tst_brkm(TBROK, cleanup, "getpwnam failed for user id "
+-				 "%s", root);
+-		}
+-
+-		GID16_CHECK(rootpwent->pw_gid, setgid, cleanup);
++		GID16_CHECK(rootpw_gid, setgid, cleanup);
+ 
+-		TEST(SETGID(cleanup, rootpwent->pw_gid));
++		TEST(SETGID(cleanup, rootpw_gid));
+ 
+ 		if (TEST_RETURN != -1) {
+ 			tst_resm(TFAIL, "call succeeded unexpectedly");
+@@ -81,8 +77,17 @@ int main(int ac, char **av)
+ 
+ static void setup(void)
+ {
++	static struct passwd *rootusr;
++
+ 	tst_require_root();
+ 
++	if ((rootusr = getpwnam(root)) == NULL) {
++		tst_brkm(TBROK, cleanup, "getpwnam failed for user id "
++			 "%s", root);
++	}
++
++	rootpw_gid = rootusr->pw_gid;
++
+ 	/* Switch to nobody user for correct error code collection */
+ 	ltpuser = getpwnam(nobody_uid);
+ 	if (ltpuser == NULL)


### PR DESCRIPTION
Test is failed to open /etc/passwd file with nobody user.
As test is not intended to test opening /etc/passwd.
Hence, moved the related code to setup function.
Git hub issue 224 “https://github.com/lsds/sgx-lkl/issues/224”
is raised.