### PR TITLE
Fix hanging issue during root file system unmount

### DIFF
--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1162,8 +1162,9 @@ static void display_mount_table()
     }
 
     SGXLKL_VERBOSE("========= /proc/mounts ===========\n");
-    while ((ret = lkl_sys_read(fd, buf, 1024)) > 0)
+    while ((ret = lkl_sys_read(fd, buf, 1023)) > 0)
     {
+        buf[ret] = '\0';
         SGXLKL_VERBOSE_RAW("%s", buf);
     }
     SGXLKL_VERBOSE("==================================\n");


### PR DESCRIPTION
This change uses the `MNT_DETACH` flag when unmounting the root file system to avoid sporadic hangs.

It also dumps the kernel mount table before and after the unmount operation in the DEBUG build with verbose logging, e.g.:
```
[[  SGX-LKL ]] lkl_mount_disks(): Set working directory: /
[[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /usr/bin/python3
Confidential Computing using Intel SGX in Python with NumPy...
[[   0    1    2 ...   97   98   99]
 [ 100  101  102 ...  197  198  199]
 [ 200  201  202 ...  297  298  299]
 ...
 [9700 9701 9702 ... 9797 9798 9799]
 [9800 9801 9802 ... 9897 9898 9899]
 [9900 9901 9902 ... 9997 9998 9999]]
TEST_PASSED
[[  SGX-LKL ]] lkl_terminate(): terminating LKL (exit_status=0)
[[  SGX-LKL ]] lkl_termination_thread(): termination thread unblocked
[[  SGX-LKL ]] lkl_termination_thread(): calling lkl_sys_chdir(/)
[[  SGX-LKL ]] display_mount_table(): ========= /proc/mounts ===========
/dev/vda / ext4 rw,relatime 0 0
devtmpfs /dev devtmpfs rw,relatime 0 0
tmpfs /dev/shm tmpfs rw,relatime 0 0
tmpfs /tmp tmpfs rw,relatime,mode=777 0 0
tmpfs /mnt tmpfs rw,relatime,mode=777 0 0
none /sys sysfs rw,relatime 0 0
tmpfs /run tmpfs rw,relatime,mode=700 0 0
proc /proc proc rw,relatime 0 0
[[  SGX-LKL ]] display_mount_table(): ==================================
[[  SGX-LKL ]] lkl_termination_thread(): calling lkl_umount_timeout("/", MNT_DETACH, 2000)
[[  SGX-LKL ]] display_mount_table(): /proc/mounts cannot be accessed
[[  SGX-LKL ]] lkl_termination_thread(): calling lkl_virtio_netdev_remove()
[[  SGX-LKL ]] lkl_termination_thread(): calling lkl_sys_halt()
[    1.948119] reboot: Restarting system
[[  SGX-LKL ]] lkl_termination_thread(): lthread_detach2() done
[   SGX-LKL  ] ethread (28: 0) init (0: 0 exit=0) ethread (34: 0) ethread (1: 0) ethread (18: 0) ethread (16: 0) ethread (27: 0) ethread (4: 0) ethread (39: 0) ethread (47: 0) ethread (55: 0) ethread (44: 0) ethread (32: 0) ethread (49: 0) ethread (36: 0) ethread (29: 0) ethread (58: 0) ethread (38: 0) ethread (40: 0) ethread (23: 0) ethread (51: 0) ethread (2: 0) ethread (43: 0) ethread (7: 0) ethread
(12: 0) ethread (14: 0) ethread (35: 0) ethread (10: 0) ethread (9: 0) ethread (13: 0) ethread (31: 0) ethread (5: 0) ethread (8: 0) ethread (17: 0) ethread (25: 0) ethread (37: 0) ethread (41: 0) ethread (19: 0) ethread (33: 0) ethread (61: 0) ethread (15: 0) ethread (3: 0) ethread (52: 0) ethread (20: 0) ethread (22: 0) ethread (21: 0) ethread (45: 0) ethread (53: 0) ethread (56: 0) ethread (57: 0) ethread (63: 0) ethread (24: 0) ethread (6: 0) ethread (11: 0) ethread (50: 0) ethread (46: 0) ethread (30: 0) ethread (48: 0) ethread (62: 0) ethread (60: 0) ethread (54: 0) ethread (26: 0) ethread (59: 0) ethread (42: 0)
[   SGX-LKL  ] oe_terminate_enclave... done
[   SGX-LKL  ] SGX-LKL-OE exit: exit_status=0
```