### PR TITLE
CI: Run tests with unbuffered output streams to avoid losing output

### DIFF
--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -37,8 +37,9 @@ function RunOneTest()
     # Start the test timer. This only creates $test_name-StartTime file with time stamp in it
     JunitTestStarted "$test_name"
 
-    # Start the test. Redirect stdout to stdout_file and error logs to stderr_file
-    bash $test_runner_script run $run_mode >"$stdout_file" 2>"$stderr_file"
+    # Start the test. Redirect stdout to stdout_file and error logs to stderr_file.
+    # Test is run with unbuffered output streams to avoid losing errors in case of crashes.
+    stdbuf -o0 -e0 $test_runner_script run $run_mode >"$stdout_file" 2>"$stderr_file"
     test_exit_code=$?
 }
 


### PR DESCRIPTION
The issue in https://github.com/lsds/sgx-lkl/pull/505 could have been diagnosed instantly if the error message output by OE would not have been swallowed before crashing. Running the tests with unbuffered output streams avoids this.

Note that OE is sending errors to stdout unfortunately, otherwise it would not have been an issue since stderr is unbuffered by default.