### PR TITLE
make_self_contained.sh: fail on pipe failures

### DIFF
--- a/tools/make_self_contained.sh
+++ b/tools/make_self_contained.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 # This script transforms an SGX-LKL installation such that all shared library dependencies
 # are bundled in the installation prefix and SGX-LKL can be run stand-alone


### PR DESCRIPTION
Previously, the script would happily succeed even if some of the libraries weren't found. This is because the output of `lddtree` was sent into a pipe which swallowed the error code.