### PR TITLE
LTP: enabling chdir02 test

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -32,9 +32,9 @@
 #/ltp/testcases/kernel/syscalls/capset/capset01
 /ltp/testcases/kernel/syscalls/capset/capset02
 #/ltp/testcases/kernel/syscalls/chdir/chdir01
-/ltp/testcases/kernel/syscalls/chdir/chdir02
+#/ltp/testcases/kernel/syscalls/chdir/chdir02
 #/ltp/testcases/kernel/syscalls/chdir/chdir03
-/ltp/testcases/kernel/syscalls/chdir/chdir04
+#/ltp/testcases/kernel/syscalls/chdir/chdir04
 #/ltp/testcases/kernel/syscalls/chmod/chmod01
 #/ltp/testcases/kernel/syscalls/chmod/chmod02
 /ltp/testcases/kernel/syscalls/chmod/chmod03

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -34,7 +34,7 @@
 /ltp/testcases/kernel/syscalls/chdir/chdir01
 /ltp/testcases/kernel/syscalls/chdir/chdir02
 /ltp/testcases/kernel/syscalls/chdir/chdir03
-#/ltp/testcases/kernel/syscalls/chdir/chdir04
+/ltp/testcases/kernel/syscalls/chdir/chdir04
 /ltp/testcases/kernel/syscalls/chmod/chmod01
 /ltp/testcases/kernel/syscalls/chmod/chmod02
 #/ltp/testcases/kernel/syscalls/chmod/chmod03


### PR DESCRIPTION
chdir02 test is passing locally all the time. so enabled the test.

Note: moved chdir04 test from ltp-batch2 to ltp-batch1 as all other chdir tests are enabled in batch1. 