### PR TITLE
LTP: fix test case vhangup02 issue

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -1024,7 +1024,7 @@
 /ltp/testcases/kernel/syscalls/vfork/vfork01
 /ltp/testcases/kernel/syscalls/vfork/vfork02
 #/ltp/testcases/kernel/syscalls/vhangup/vhangup01
-/ltp/testcases/kernel/syscalls/vhangup/vhangup02
+#/ltp/testcases/kernel/syscalls/vhangup/vhangup02
 /ltp/testcases/kernel/syscalls/vmsplice/vmsplice01
 #/ltp/testcases/kernel/syscalls/vmsplice/vmsplice02
 #/ltp/testcases/kernel/syscalls/wait/wait01

--- a/tests/ltp/patches/fix_vhangup_vhangup02.patch
+++ b/tests/ltp/patches/fix_vhangup_vhangup02.patch
@@ -1,0 +1,46 @@
+The “setsid” API returning the error because current
+process is the group leader. Sgx-lkl supports single
+process environment and current process is the group
+leader. Hence, code related to fork is removed and 
+Error from “setsid” is ignored.
+
+diff --git a/testcases/kernel/syscalls/vhangup/vhangup02.c b/testcases/kernel/syscalls/vhangup/vhangup02.c
+index 660785079..6562752dd 100644
+--- a/testcases/kernel/syscalls/vhangup/vhangup02.c
++++ b/testcases/kernel/syscalls/vhangup/vhangup02.c
+@@ -17,25 +17,20 @@
+ 
+ static void run(void)
+ {
+-	pid_t pid, pid1;
++	pid_t pid;
+ 
+-	pid = SAFE_FORK();
+-	if (pid > 0) {
+-		waitpid(pid, NULL, 0);
+-	} else {
+-		pid1 = setsid();
+-		if (pid1 < 0)
+-			tst_brk(TBROK | TTERRNO, "setsid failed");
+-		TEST(tst_syscall(__NR_vhangup));
+-		if (TST_RET == -1)
+-			tst_res(TFAIL | TTERRNO, "vhangup() failed");
+-		else
+-			tst_res(TPASS, "vhangup() succeeded");
+-	}
++	pid = setsid();
++	if (pid < 0)
++		tst_res(TWARN | TTERRNO,
++			"current process is already a group leader");
++	TEST(tst_syscall(__NR_vhangup));
++	if (TST_RET == -1)
++		tst_res(TFAIL | TTERRNO, "vhangup() failed");
++	else
++		tst_res(TPASS, "vhangup() succeeded");
+ }
+ 
+ static struct tst_test test = {
+ 	.test_all = run,
+-	.forks_child = 1,
+ 	.needs_root = 1,
+ };


### PR DESCRIPTION
The “setsid” API returning the error because current
process is the group leader. Sgx-lkl supports single
process environment and current process is the group
leader. Hence, code related to fork is removed and
Error from “setsid” is ignored.