### PR TITLE
LTP: Fix for ptrace03

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -682,7 +682,7 @@
 #/ltp/testcases/kernel/syscalls/pselect/pselect03
 /ltp/testcases/kernel/syscalls/ptrace/ptrace01
 /ltp/testcases/kernel/syscalls/ptrace/ptrace02
-/ltp/testcases/kernel/syscalls/ptrace/ptrace03
+#/ltp/testcases/kernel/syscalls/ptrace/ptrace03
 /ltp/testcases/kernel/syscalls/ptrace/ptrace04
 /ltp/testcases/kernel/syscalls/ptrace/ptrace05
 /ltp/testcases/kernel/syscalls/ptrace/ptrace07

--- a/tests/ltp/patches/ptrace03.patch
+++ b/tests/ltp/patches/ptrace03.patch
@@ -1,8 +1,7 @@
 Removed the wait calls as it is in single process context.
 PTRACE_TRACEME needs child process. Hence removing it from tests for sgxlkl
-
 diff --git a/testcases/kernel/syscalls/ptrace/ptrace03.c b/testcases/kernel/syscalls/ptrace/ptrace03.c
-index f326b834d..0313153db 100644
+index f326b834d..cf61a5d1e 100644
 --- a/testcases/kernel/syscalls/ptrace/ptrace03.c
 +++ b/testcases/kernel/syscalls/ptrace/ptrace03.c
 @@ -99,7 +99,6 @@ char *TCID = "ptrace03";
@@ -13,7 +12,7 @@ index f326b834d..0313153db 100644
  
  struct test_case_t {
  	int request;
-@@ -108,87 +107,46 @@ struct test_case_t {
+@@ -108,86 +107,42 @@ struct test_case_t {
  } test_cases[] = {
  	{
  	PTRACE_ATTACH, &init_pid, EPERM}, {
@@ -112,8 +111,6 @@ index f326b834d..0313153db 100644
 +			continue;
 +		}
 +
-+
-+
 +		TEST(ptrace(test_cases[i].request,
 +				    *(test_cases[i].pid), NULL, NULL));
 +		if ((TEST_RETURN == -1) && (TEST_ERRNO ==
@@ -125,7 +122,5 @@ index f326b834d..0313153db 100644
 +					 "ptrace() returned %ld",
 +					 TEST_RETURN);
  		}
-+
  	}
  
- 	/* cleanup and exit */

--- a/tests/ltp/patches/ptrace03.patch
+++ b/tests/ltp/patches/ptrace03.patch
@@ -1,0 +1,131 @@
+Removed the wait calls as it is in single process context.
+PTRACE_TRACEME needs child process. Hence removing it from tests for sgxlkl
+
+diff --git a/testcases/kernel/syscalls/ptrace/ptrace03.c b/testcases/kernel/syscalls/ptrace/ptrace03.c
+index f326b834d..0313153db 100644
+--- a/testcases/kernel/syscalls/ptrace/ptrace03.c
++++ b/testcases/kernel/syscalls/ptrace/ptrace03.c
+@@ -99,7 +99,6 @@ char *TCID = "ptrace03";
+ 
+ static pid_t init_pid = 1;
+ static pid_t unused_pid;
+-static pid_t zero_pid;
+ 
+ struct test_case_t {
+ 	int request;
+@@ -108,87 +107,46 @@ struct test_case_t {
+ } test_cases[] = {
+ 	{
+ 	PTRACE_ATTACH, &init_pid, EPERM}, {
+-	PTRACE_ATTACH, &unused_pid, ESRCH}, {
+-	PTRACE_TRACEME, &zero_pid, EPERM},};
++	PTRACE_ATTACH, &unused_pid, ESRCH}, 
++	};
+ 
+ int TST_TOTAL = sizeof(test_cases) / sizeof(test_cases[0]);
+ 
+ int main(int ac, char **av)
+ {
+ 
+-	int lc, i;
+-	pid_t child_pid;
+-	int status;
++	int i;
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+ 
+ 	setup();
+ 
+-	for (lc = 0; TEST_LOOPING(lc); lc++) {
+-
+-		tst_count = 0;
+-
+-		for (i = 0; i < TST_TOTAL; ++i) {
+-
+-			/* since Linux 2.6.26, it's allowed to trace init,
+-			   so just skip this test case */
+-			if (i == 0 && tst_kvercmp(2, 6, 25) > 0) {
+-				tst_resm(TCONF,
+-					 "this kernel allows to trace init");
+-				continue;
+-			}
+-
+-			/* fork() */
+-			switch (child_pid = FORK_OR_VFORK()) {
+-
+-			case -1:
+-				/* fork() failed */
+-				tst_resm(TFAIL, "fork() failed");
+-				continue;
+-
+-			case 0:
+-				/* Child */
+-
+-				/* setup for third test case */
+-				if (i == 2) {
+-					if ((ptrace(PTRACE_TRACEME, 0,
+-						    NULL, NULL)) == -1) {
+-						tst_resm(TWARN, "ptrace()"
+-							 " falied with errno, %d : %s",
+-							 errno,
+-							 strerror(errno));
+-						exit(0);
+-					}
+-				}
+-
+-				TEST(ptrace(test_cases[i].request,
+-					    *(test_cases[i].pid), NULL, NULL));
+-				if ((TEST_RETURN == -1) && (TEST_ERRNO ==
+-							    test_cases
+-							    [i].exp_errno)) {
+-					exit(TEST_ERRNO);
+-				} else {
+-					tst_resm(TWARN | TTERRNO,
+-						 "ptrace() returned %ld",
+-						 TEST_RETURN);
+-					exit(TEST_ERRNO);
+-				}
+-
+-			default:
+-				/* Parent */
+-				if ((waitpid(child_pid, &status, 0)) < 0) {
+-					tst_resm(TFAIL, "waitpid() failed");
+-					continue;
+-				}
+-				if ((WIFEXITED(status)) &&
+-				    (WEXITSTATUS(status) ==
+-				     test_cases[i].exp_errno)) {
+-					tst_resm(TPASS, "Test Passed");
+-				} else {
+-					tst_resm(TFAIL, "Test Failed");
+-				}
+-			}
++	tst_count = 0;
++	for (i = 0; i < TST_TOTAL; ++i) {
++
++		tst_resm(TINFO,"Running test %d",i);
++		/* since Linux 2.6.26, it's allowed to trace init,
++		   so just skip this test case */
++		if (i == 0 && tst_kvercmp(2, 6, 25) > 0) {
++			tst_resm(TINFO,
++				 "skipping this test as this kernel allows to trace init");
++			continue;
++		}
++
++
++
++		TEST(ptrace(test_cases[i].request,
++				    *(test_cases[i].pid), NULL, NULL));
++		if ((TEST_RETURN == -1) && (TEST_ERRNO ==
++					    test_cases
++					    [i].exp_errno)) {
++			tst_resm(TPASS,"Test passed %d",i);
++		} else {
++				tst_resm(TWARN | TTERRNO,
++					 "ptrace() returned %ld",
++					 TEST_RETURN);
+ 		}
++
+ 	}
+ 
+ 	/* cleanup and exit */


### PR DESCRIPTION
Issue: Test was failing as it requires child process for ptrace calls. 
Solution: Removed the wait that was causing test to hang and also disabled one test for PTRACE_TRACEME that requires child process.