### PR TITLE
fix: wireguard client peer configuration without mandatory endpoint

### DIFF
--- a/src/ctl/sgxlkl_ctl.c
+++ b/src/ctl/sgxlkl_ctl.c
@@ -441,9 +441,9 @@ int main(int argc, char**argv) {
         if (!peer_key) {
             fprintf(stderr, "No peer key specified via --key.\n");
             usage(argv[0], EXIT_FAILURE);
-        } else if (!peer_endpoint) {
+        /*} else if (!peer_endpoint) {
             fprintf(stderr, "No peer endpoint specified via --endpoint.\n");
-            usage(argv[0], EXIT_FAILURE);
+            usage(argv[0], EXIT_FAILURE);*/
         } else if (!peer_allowedips) {
             fprintf(stderr, "No allowed IPs specified for peer via --allowedips.\n");
             usage(argv[0], EXIT_FAILURE);

--- a/src/wireguard/wireguard_util.c
+++ b/src/wireguard/wireguard_util.c
@@ -220,10 +220,10 @@ int wgu_add_peers(wg_device *dev, enclave_wg_peer_config_t *peers, size_t num_pe
             sgxlkl_warn("Unable to add wireguard peer due to missing allowed ips configuration.\n");
             continue;
         }
-        if (!peers[i].endpoint || !strlen(peers[i].endpoint)) {
+        /*if (!peers[i].endpoint || !strlen(peers[i].endpoint)) {
             sgxlkl_warn("Unable to add wireguard peer due to missing endpoint.\n");
             continue;
-        }
+        }*/
 
         memset(&new_peers[i], 0, sizeof(new_peers[i]));
         new_peers[i].flags = WGPEER_HAS_PUBLIC_KEY | WGPEER_REPLACE_ALLOWEDIPS;
@@ -238,7 +238,7 @@ int wgu_add_peers(wg_device *dev, enclave_wg_peer_config_t *peers, size_t num_pe
             goto err;
         }
 
-        if (!wgu_parse_endpoint(&new_peers[i].endpoint.addr, peer_cfg.endpoint)) {
+	if (peers[i].endpoint && strlen(peers[i].endpoint) && !wgu_parse_endpoint(&new_peers[i].endpoint.addr, peer_cfg.endpoint)) {
             ret = -EINVAL;
             goto err;
         }


### PR DESCRIPTION
Wireguard peers do not necessarily need an endpoint, as long as the other side (the enclave) provides an endpoint. I therefore removed the endpoint checks where necessary. This enables users to remotely attest and control enclaves behind NAT.