### PR TITLE
CI: Don't fail publish test results task on test failures

### DIFF
--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -155,7 +155,6 @@ stages:
                 testResultsFiles: "report/*-junit.xml"
                 testRunTitle: "${{ test_suite }} (${{ build_mode }}, ${{ run_mode }}, ${{ ethreads }} ethreads)"
                 mergeTestResults: true
-                failTaskOnFailedTests: true
 
             - task: PublishBuildArtifacts@1
               displayName: "Archive Logs"


### PR DESCRIPTION
The Run Tests task already fails in this case (as the test runner script exits with 1) and this just creates more noise, in particular it adds one more entry per failed test suite to the failure list on GitHub:

![grafik](https://user-images.githubusercontent.com/530988/85844540-ccf9f000-b79a-11ea-8053-1d7dcfae32c3.png)
