### PR TITLE
Disable incorrect sendto, sendmsg and fsync LTP tests

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -261,10 +261,10 @@
 #/ltp/testcases/kernel/syscalls/fstatat/fstatat01
 #/ltp/testcases/kernel/syscalls/fstatfs/fstatfs01
 #/ltp/testcases/kernel/syscalls/fstatfs/fstatfs02
-#/ltp/testcases/kernel/syscalls/fsync/fsync01
-#/ltp/testcases/kernel/syscalls/fsync/fsync02
-#/ltp/testcases/kernel/syscalls/fsync/fsync03
-#/ltp/testcases/kernel/syscalls/fsync/fsync04
+/ltp/testcases/kernel/syscalls/fsync/fsync01
+/ltp/testcases/kernel/syscalls/fsync/fsync02
+/ltp/testcases/kernel/syscalls/fsync/fsync03
+/ltp/testcases/kernel/syscalls/fsync/fsync04
 #/ltp/testcases/kernel/syscalls/ftruncate/ftruncate01
 #/ltp/testcases/kernel/syscalls/ftruncate/ftruncate03
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate04

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -264,7 +264,7 @@
 /ltp/testcases/kernel/syscalls/fsync/fsync01
 /ltp/testcases/kernel/syscalls/fsync/fsync02
 /ltp/testcases/kernel/syscalls/fsync/fsync03
-#/ltp/testcases/kernel/syscalls/fsync/fsync04
+/ltp/testcases/kernel/syscalls/fsync/fsync04
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate01
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate03
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate04
@@ -800,9 +800,9 @@
 #/ltp/testcases/kernel/syscalls/sendfile/sendfile08
 #/ltp/testcases/kernel/syscalls/sendfile/sendfile09
 #/ltp/testcases/kernel/syscalls/sendmmsg/sendmmsg01
-#/ltp/testcases/kernel/syscalls/sendmsg/sendmsg01
+/ltp/testcases/kernel/syscalls/sendmsg/sendmsg01
 /ltp/testcases/kernel/syscalls/sendmsg/sendmsg02
-#/ltp/testcases/kernel/syscalls/sendto/sendto01
+/ltp/testcases/kernel/syscalls/sendto/sendto01
 /ltp/testcases/kernel/syscalls/sendto/sendto02
 /ltp/testcases/kernel/syscalls/set_mempolicy/set_mempolicy01
 /ltp/testcases/kernel/syscalls/set_mempolicy/set_mempolicy02

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -264,7 +264,7 @@
 /ltp/testcases/kernel/syscalls/fsync/fsync01
 /ltp/testcases/kernel/syscalls/fsync/fsync02
 /ltp/testcases/kernel/syscalls/fsync/fsync03
-/ltp/testcases/kernel/syscalls/fsync/fsync04
+#/ltp/testcases/kernel/syscalls/fsync/fsync04
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate01
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate03
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate04


### PR DESCRIPTION
This PR disables LTP tests (sendto, sendmsg and fsync) that are patched incorrectly and therefore fail arbitrarily and/or don't increase test coverage. More specifically:

- the `fsync` test relies on block devices being created inside the enclave, which is not possible currently;
- the `sendto`/`sendmsg` tests need to create a client/server setup inside the enclave. This requires multiple processes, which is also not supported.

The current patches for these tests do not overcome the above problems correctly.