### PR TITLE
Turn some tests back on

### DIFF
--- a/.azure-pipelines/scripts/disabled_tests.txt
+++ b/.azure-pipelines/scripts/disabled_tests.txt
@@ -7,7 +7,3 @@ tests/containers/unencrypted/env/Makefile
 tests/virtio/ping_test/Makefile
 tests/virtio/python_read/Makefile
 tests/languages/java/network/Makefile
-tests/languages/java/hello_world/Makefile
-tests/languages/java/read_file/Makefile
-tests/languages/python/Makefile
-tests/containers/cc/Makefile


### PR DESCRIPTION
These were previously turned off because they were flakey. I believe that
the sources of that flakiness has now been fixed.