### PR TITLE
Add pre-commit hook & fix shell script lint errors

### DIFF
--- a/.azure-pipelines/scripts/build.sh
+++ b/.azure-pipelines/scripts/build.sh
@@ -1,27 +1,32 @@
 #!/bin/bash
 
-if [ -z $SGXLKL_ROOT ]; then
+if [ -z "$SGXLKL_ROOT" ]; then
     echo "ERROR: 'SGXLKL_ROOT' is undefined. Please export SGXLKL_ROOT=<SGX-LKL-OE> source code repository"
     exit 1
 fi
-if [ -z $SGXLKL_PREFIX ]; then
+if [ -z "$SGXLKL_PREFIX" ]; then
     echo "ERROR: 'SGXLKL_PREFIX' is undefined. Please export SGXLKL_PREFIX=<install-prefix>"
     exit 1
 fi
-
-. $SGXLKL_ROOT/.azure-pipelines/scripts/junit_utils.sh
-
-# Initialize the variables.
-if [[ "$build_mode" == "debug" ]]; then
-    make_args="DEBUG=true"
-elif [[ "$build_mode" == "nonrelease" ]]; then
-    make_args=""
-else
-    echo "unknown build_mode: $build_mode"
+if [ -z "$SGXLKL_BUILD_MODE" ]; then
+    echo "ERROR: 'SGXLKL_BUILD_MODE' is undefined. Please export SGXLKL_BUILD_MODE=<mode>"
     exit 1
 fi
-make_install_args="$make_args PREFIX=$SGXLKL_PREFIX"
-test_name="Compile and build ($build_mode)"
+
+# shellcheck source=/dev/null
+. "$SGXLKL_ROOT/.azure-pipelines/scripts/junit_utils.sh"
+
+# Initialize the variables.
+if [[ "$SGXLKL_BUILD_MODE" == "debug" ]]; then
+    make_args=( "DEBUG=true" )
+elif [[ "$SGXLKL_BUILD_MODE" == "nonrelease" ]]; then
+    make_args=( )
+else
+    echo "unknown SGXLKL_BUILD_MODE: $SGXLKL_BUILD_MODE"
+    exit 1
+fi
+make_install_args=( "${make_args[@]}" "PREFIX=$SGXLKL_PREFIX" )
+test_name="Compile and build ($SGXLKL_BUILD_MODE)"
 test_class="Build"
 test_suite="sgx-lkl-oe"
 error_message_file_path="report/$test_name.error"
@@ -34,11 +39,11 @@ JunitTestStarted "$test_name"
 make distclean
 
 # Install the Open Enclave build dependencies for Azure
-sudo bash $SGXLKL_ROOT/openenclave/scripts/ansible/install-ansible.sh
-sudo ansible-playbook $SGXLKL_ROOT/openenclave/scripts/ansible/oe-contributors-acc-setup-no-driver.yml
+sudo bash "$SGXLKL_ROOT/openenclave/scripts/ansible/install-ansible.sh"
+sudo ansible-playbook "$SGXLKL_ROOT/openenclave/scripts/ansible/oe-contributors-acc-setup-no-driver.yml"
 
 # Let's build
-make $make_args && make install $make_install_args
+make "${make_args[@]}" && make install "${make_install_args[@]}"
 make_exit=$?
 
 # Process the result
@@ -46,7 +51,7 @@ if [[ "$make_exit" == "0" ]] && [[ -f build/sgx-lkl-run-oe ]] && [[ -f build/lib
     JunitTestFinished "$test_name" "passed" "$test_class" "$test_suite"
 else
     echo "'$test_name' exited with $make_exit" > "$error_message_file_path"
-    make $make_args > "$stack_trace_file_path"  2>&1
+    make "${make_args[@]}" > "$stack_trace_file_path"  2>&1
     JunitTestFinished "$test_name" "failed" "$test_class" "$test_suite"
 fi
 

--- a/.azure-pipelines/scripts/build.sh
+++ b/.azure-pipelines/scripts/build.sh
@@ -13,7 +13,7 @@ if [ -z "$SGXLKL_BUILD_MODE" ]; then
     exit 1
 fi
 
-# shellcheck source=/dev/null
+# shellcheck source=.azure-pipelines/scripts/junit_utils.sh
 . "$SGXLKL_ROOT/.azure-pipelines/scripts/junit_utils.sh"
 
 # Initialize the variables.

--- a/.azure-pipelines/scripts/create_deb_apt_repository.sh
+++ b/.azure-pipelines/scripts/create_deb_apt_repository.sh
@@ -2,22 +2,22 @@
 
 set -e
 
-if [ -z $SGXLKL_ROOT ]; then
+if [ -z "$SGXLKL_ROOT" ]; then
     echo "ERROR: 'SGXLKL_ROOT' is undefined. Please export SGXLKL_ROOT=<SGX-LKL-OE> source code repository"
     exit 1
 fi
 
 function req() {
-    [[ -x "$(command -v $1)" ]] || (echo "The following application/package is required and could not be found: $1."; exit 1)
+    [[ -x "$(command -v "$1")" ]] || (echo "The following application/package is required and could not be found: $1."; exit 1)
 }
 
 req apt-ftparchive
 
-rm -rf $SGXLKL_APT_REPO_DIR
-mkdir -p $SGXLKL_APT_REPO_DIR
-cd $SGXLKL_APT_REPO_DIR
+rm -rf "$SGXLKL_APT_REPO_DIR"
+mkdir -p "$SGXLKL_APT_REPO_DIR"
+cd "$SGXLKL_APT_REPO_DIR"
 
-cp $SGXLKL_DEB_DIR/* .
+cp "$SGXLKL_DEB_DIR"/* .
 
 apt-ftparchive packages . > Packages
 apt-ftparchive release . > Release

--- a/.azure-pipelines/scripts/create_fsgsbase_dkms_deb_pkg.sh
+++ b/.azure-pipelines/scripts/create_fsgsbase_dkms_deb_pkg.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#shellcheck disable=SC2086,SC2154
+
 set -e
 
 # This script creates a Debian package that contains a DKMS-enabled kernel module

--- a/.azure-pipelines/scripts/create_standalone_deb_pkg.sh
+++ b/.azure-pipelines/scripts/create_standalone_deb_pkg.sh
@@ -36,22 +36,23 @@ set -e
 # libraries like the Azure DCAP Client are dlopen'd at runtime.
 # Because of that, there is extra logic that deals with bundling them manually.
 
-if [ -z $SGXLKL_ROOT ]; then
+if [ -z "$SGXLKL_ROOT" ]; then
     echo "ERROR: 'SGXLKL_ROOT' is undefined. Please export SGXLKL_ROOT=<SGX-LKL-OE> source code repository"
     exit 1
 fi
 
-if [ -z $SGXLKL_PREFIX ]; then
+if [ -z "$SGXLKL_PREFIX" ]; then
     echo "ERROR: 'SGXLKL_PREFIX' is undefined. Please export SGXLKL_PREFIX=<SGX-LKL-OE> install prefix directory"
     exit 1
 fi
 
-if [ -z $SGXLKL_BUILD_MODE ]; then
+if [ -z "$SGXLKL_BUILD_MODE" ]; then
     echo "ERROR: 'SGXLKL_BUILD_MODE' is undefined. Please export SGXLKL_BUILD_MODE=<debug|nonrelease>"
     exit 1
 fi
 
-. $SGXLKL_ROOT/.azure-pipelines/scripts/set_version.sh
+#shellcheck source=.azure-pipelines/scripts/set_version.sh
+. "$SGXLKL_ROOT/.azure-pipelines/scripts/set_version.sh"
 
 if [[ $SGXLKL_BUILD_MODE == release ]]; then
     suffix=
@@ -63,8 +64,6 @@ deb_pkg_name=sgx-lkl$suffix
 deb_pkg_license=/usr/share/common-licenses/GPL-2
 install_prefix=/opt/sgx-lkl$suffix
 external_lib_dir=lib/external
-exe_name=sgx-lkl-run-oe
-exe_path=$SGXLKL_PREFIX/bin/$exe_name
 
 deb_pkg_version=${SGXLKL_VERSION}
 deb_pkg_full_name=${deb_pkg_name}_${deb_pkg_version}
@@ -74,24 +73,24 @@ pkg_dir=$tmp_dir/pkg
 deb_root_dir=$tmp_dir/$deb_pkg_full_name
 deb_install_prefix=$deb_root_dir$install_prefix
 
-rm -rf $tmp_dir
-mkdir -p $tmp_dir
+rm -rf "$tmp_dir"
+mkdir -p "$tmp_dir"
 
-mkdir -p $deb_install_prefix
+mkdir -p "$deb_install_prefix"
 
 # Copy installation prefix into Debian package tree.
-cp -r $SGXLKL_PREFIX/. $deb_install_prefix
+cp -r "$SGXLKL_PREFIX/." "$deb_install_prefix"
 
 # Remove FSGSBASE kernel module as this should be installed via the DKMS Debian package.
-rm -rf $deb_install_prefix/tools/kmod-set-fsgsbase
+rm -rf "$deb_install_prefix/tools/kmod-set-fsgsbase"
 
 # Bundle all dependencies.
 SGXLKL_PREFIX=$deb_install_prefix SGXLKL_TARGET_PREFIX=$install_prefix \
-    $SGXLKL_ROOT/tools/make_self_contained.sh
+    "$SGXLKL_ROOT/tools/make_self_contained.sh"
 
 # Build the .deb package.
-mkdir $deb_root_dir/DEBIAN
-cat << EOF > $deb_root_dir/DEBIAN/control
+mkdir "$deb_root_dir/DEBIAN"
+cat << EOF > "$deb_root_dir/DEBIAN/control"
 Package: ${deb_pkg_name}
 Version: ${deb_pkg_version}
 Priority: optional
@@ -108,7 +107,7 @@ for lib_path in $deb_install_prefix/$external_lib_dir/*; do
         continue
     fi
     lib_name=${lib_path##*/}
-    pkg=$(dpkg -S \*/$lib_name | grep -v -e sgx-lkl -e i386 | head -1 | cut -f1 -d":")
+    pkg=$(dpkg -S "*/$lib_name" | grep -v -e sgx-lkl -e i386 | head -1 | cut -f1 -d":")
     if [[ -z $pkg ]]; then
         echo "No package found that contains $lib_name! Exiting..."
         exit 1
@@ -121,17 +120,17 @@ copyright="$(cat $deb_pkg_license)"
 copyright="$copyright$NL$NL==================${NL}THIRD-PARTY NOTICES"
 for pkg in "${uniq_pkgs[@]}"; do
     copyright_path=/usr/share/doc/$pkg/copyright
-    if [ ! -f $copyright_path ]; then
+    if [ ! -f "$copyright_path" ]; then
         echo "No copyright file found for $pkg! Exiting..."
         exit 1
     fi
-    copyright="$copyright$NL$NL##################$NL$(cat $copyright_path)"
+    copyright="$copyright$NL$NL##################$NL$(cat "$copyright_path")"
 done
-echo "$copyright" > $deb_root_dir/DEBIAN/copyright
+echo "$copyright" > "$deb_root_dir/DEBIAN/copyright"
 
-cd $tmp_dir
-dpkg-deb --build $deb_pkg_full_name
-mkdir -p $pkg_dir
-mv $deb_pkg_full_name.deb $pkg_dir
+cd "$tmp_dir"
+dpkg-deb --build "$deb_pkg_full_name"
+mkdir -p "$pkg_dir"
+mv "$deb_pkg_full_name.deb" "$pkg_dir"
 
 echo "Done! Install with: sudo apt install $pkg_dir/$deb_pkg_full_name.deb"

--- a/.azure-pipelines/scripts/create_vmss.sh
+++ b/.azure-pipelines/scripts/create_vmss.sh
@@ -31,8 +31,7 @@
 
 set -e
 
-expected_args=4
-if [[ $# != $expected_args ]]; then
+if [[ $# != 4 ]]; then
     echo "Usage: $0 <subscription> <region> <vmss-name> sgx|nosgx"
     echo "Example: $0 7150ce20-6afe... eastus ci-scaleset-sgx sgx"
     exit 1

--- a/.azure-pipelines/scripts/dump_system_info.sh
+++ b/.azure-pipelines/scripts/dump_system_info.sh
@@ -18,6 +18,7 @@ echo "SGX kernel module:"
 modinfo intel_sgx || echo "none"
 echo
 echo "Running SGX-LKL instances:"
+#shellcheck disable=SC2009
 ps -aux | grep sgx-lkl-run-oe | grep -v grep || echo "none"
 echo
 echo "Environment variables:"

--- a/.azure-pipelines/scripts/install_deb_pkg.sh
+++ b/.azure-pipelines/scripts/install_deb_pkg.sh
@@ -9,10 +9,10 @@ else
 fi
 
 deb_pkg_name=sgx-lkl$suffix
-deb_pkg=($SGXLKL_DEB_DIR/${deb_pkg_name}_*.deb)
-deb_pkg=${deb_pkg[0]}
+deb_pkg_arr=($SGXLKL_DEB_DIR/${deb_pkg_name}_*.deb)
+deb_pkg=${deb_pkg_arr[0]}
 echo "Using $deb_pkg"
 
 sudo rm -rf /opt/sgx-lkl*
 # Not using apt install here to simplify subsequent removal.
-sudo dpkg-deb -x $deb_pkg /
+sudo dpkg-deb -x "$deb_pkg" /

--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -7,7 +7,7 @@ sudo apt-get install -y \
     curl wget rsync pv \
     make gcc g++ bc python xutils-dev flex bison autogen libgcrypt20-dev libjson-c-dev \
     autopoint pkgconf autoconf libtool libcurl4-openssl-dev libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler libssl-dev \
-    ninja-build ansible linux-headers-$(uname -r) \
+    ninja-build ansible "linux-headers-$(uname -r)" \
     python3 python3-pip unzip dkms debhelper apt-utils pax-utils openjdk-8-jdk-headless \
     expect
 
@@ -16,5 +16,5 @@ sudo python3 -m pip install "jsonschema>=3"
 if [[ ! -x "$(command -v docker)" ]]; then
     sudo apt-get install -y docker.io
     # Allow to run Docker without sudo
-    sudo chmod u+s $(which docker)
+    sudo chmod u+s "$(which docker)"
 fi

--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -7,14 +7,15 @@ sudo apt-get install -y \
     curl wget rsync pv \
     make gcc g++ bc python xutils-dev flex bison autogen libgcrypt20-dev libjson-c-dev \
     autopoint pkgconf autoconf libtool libcurl4-openssl-dev libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler libssl-dev \
-    ninja-build ansible linux-headers-$(uname -r) \
+    ninja-build ansible "linux-headers-$(uname -r)" \
     python3 python3-pip unzip dkms debhelper apt-utils pax-utils openjdk-8-jdk-headless \
-    expect
+    expect \
+    shellcheck clang-format
 
 sudo python3 -m pip install "jsonschema>=3"
 
 if [[ ! -x "$(command -v docker)" ]]; then
     sudo apt-get install -y docker.io
     # Allow to run Docker without sudo
-    sudo chmod u+s $(which docker)
+    sudo chmod u+s "$(which docker)"
 fi

--- a/.azure-pipelines/scripts/junit_utils.sh
+++ b/.azure-pipelines/scripts/junit_utils.sh
@@ -29,14 +29,16 @@ function CreateSuiteTestRunDurationJunit()
     suite_end_time=$(date +%s)
     junit_file_path="report/TEST-test-suite-test-run-overall-result-${test_group_name}-junit.xml"
 
-    duration=$(($suite_end_time-$suite_start_time))
+    duration=$((suite_end_time-suite_start_time))
 
-    echo "<testsuites>" > "$junit_file_path"
-    echo "  <testsuite name=\"$test_suite\" duration=\"$duration\">" >> "$junit_file_path"
-    echo "    <testcase name=\"test-suite-test-run-overall-result-${test_group_name}\" classname=\"Summary\" time=\"$duration\">" >> "$junit_file_path"
-    echo "    </testcase>" >> "$junit_file_path"
-    echo "  </testsuite>" >> "$junit_file_path"
-    echo '</testsuites>' >> "$junit_file_path"
+    {
+        echo "<testsuites>"
+        echo "  <testsuite name=\"$test_suite\" duration=\"$duration\">"
+        echo "    <testcase name=\"test-suite-test-run-overall-result-${test_group_name}\" classname=\"Summary\" time=\"$duration\">"
+        echo "    </testcase>"
+        echo "  </testsuite>"
+        echo '</testsuites>' 
+    } > "$junit_file_path"
 }
 
 # If log file exists, read it, clean xml non-compliant characters
@@ -52,9 +54,9 @@ function AddLogFileToJunit()
     if [[ -f "$log_file" ]]; then
         FILE2=$(<"$junit_file")
         # Remove non-printable characters from log file
-        FILE1=`sed 's/[^[:print:]]//g' "$log_file"`
+        FILE1=$(sed 's/[^[:print:]]//g' "$log_file")
         if [[ $place_holder != "TEST_MESSAGE" ]]; then
-            FILE1="<![CDATA["$FILE1"]]>"
+            FILE1="<![CDATA[$FILE1]]>"
         fi
         echo "${FILE2//$place_holder/$FILE1}" > "$junit_file"
     fi
@@ -142,9 +144,12 @@ function JunitTestFinished()
         AddLogFileToJunit "$stdout_file_path" "$junit_file_path" "STD_OUT_MESSAGE"
     fi
 
-    echo "    </testcase>" >> "$junit_file_path"
-    echo "  </testsuite>" >> "$junit_file_path"
-    echo '</testsuites>' >> "$junit_file_path"
+    {
+        echo "    </testcase>"
+        echo "  </testsuite>"
+        echo "</testsuites>"
+    } >> "$junit_file_path"
+
     rm -f "$test_start_time_file_path"
     rm -f "$test_end_time_file_path"
     rm -f "$error_message_file_path"

--- a/.azure-pipelines/scripts/run_setup.sh
+++ b/.azure-pipelines/scripts/run_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # Set up host networking and FSGSBASE userspace support
-make -C $SGXLKL_ROOT/tools/kmod-set-fsgsbase
-$SGXLKL_ROOT/tools/sgx-lkl-setup
+make -C "$SGXLKL_ROOT/tools/kmod-set-fsgsbase"
+"$SGXLKL_ROOT/tools/sgx-lkl-setup"

--- a/.azure-pipelines/scripts/set_version.sh
+++ b/.azure-pipelines/scripts/set_version.sh
@@ -1,9 +1,11 @@
-if [ -z $SGXLKL_ROOT ]; then
+#!/bin/bash
+
+if [ -z "$SGXLKL_ROOT" ]; then
     echo "ERROR: 'SGXLKL_ROOT' is undefined. Please export SGXLKL_ROOT=<SGX-LKL-OE> source code repository"
     exit 1
 fi
 
-SGXLKL_VERSION=$(cat $SGXLKL_ROOT/VERSION)
+SGXLKL_VERSION=$(cat "$SGXLKL_ROOT/VERSION")
 if [[ $SGXLKL_VERSION == *-dev ]]; then
     if [[ -n $BUILD_BUILDNUMBER ]]; then
         # If we're running in Azure Pipelines, use build number (YYYYMMDD.n).

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -8,18 +8,31 @@
 #   2. stdout of run_test.sh contains one or more failure identifiers from $SGXLKL_ROOT/.azure-pipelines/other/failure_identifiers.txt (case sensitive).
 # Based on the test result, junit files will be created (consumable by Azure/Jenkins CI pipelines).
 
-. $SGXLKL_ROOT/.azure-pipelines/scripts/test_utils.sh
-. $SGXLKL_ROOT/.azure-pipelines/scripts/junit_utils.sh
+#shellcheck disable=SC2002
+
+if [ -z "$SGXLKL_ROOT" ]; then
+    echo "ERROR: 'SGXLKL_ROOT' is undefined. Please export SGXLKL_ROOT=<SGX-LKL-OE> source code repository"
+    exit 1
+fi
+if [ -z "$SGXLKL_BUILD_MODE" ]; then
+    echo "ERROR: 'SGXLKL_BUILD_MODE' is undefined. Please export SGXLKL_BUILD_MODE=<mode>"
+    exit 1
+fi
+
+#shellcheck source=.azure-pipelines/scripts/test_utils.sh
+. "$SGXLKL_ROOT/.azure-pipelines/scripts/test_utils.sh"
+#shellcheck source=.azure-pipelines/scripts/junit_utils.sh
+. "$SGXLKL_ROOT/.azure-pipelines/scripts/junit_utils.sh"
 
 # Runs make clean for the curren test folder
 function CleanTest()
 {
-    test_directory=$(dirname $file)
-    ChangeDirectory $test_directory
+    test_directory=$(dirname "$file")
+    ChangeDirectory "$test_directory"
 
     # Run make clean
-    bash $test_runner_script "clean"
-    ChangeDirectory $SGXLKL_ROOT
+    bash "$test_runner_script" "clean"
+    ChangeDirectory "$SGXLKL_ROOT"
 }
 
 function RunOneTest()
@@ -29,8 +42,9 @@ function RunOneTest()
     run_mode=$1
 
     echo "[Test #$counter/$total_tests] Found $file in directory $test_directory"
-    ChangeDirectory $test_directory
-    . $test_runner_script init "$run_mode"
+    ChangeDirectory "$test_directory"
+    #shellcheck source=.azure-pipelines/scripts/run_test.sh
+    . "$test_runner_script" init "$run_mode"
     echo "Test '$test_name' status - Running ($run_mode) ..."
     stdout_file="report/$test_name.stdout.txt"
     # Start the test timer. This only creates $test_name-StartTime file with time stamp in it
@@ -38,7 +52,7 @@ function RunOneTest()
 
     # Start the test. Redirect stdout and stderr logs to stdout_file.
     # Test is run with unbuffered output streams to avoid losing errors in case of crashes.
-    stdbuf -o0 -e0 $test_runner_script run $run_mode >"$stdout_file" 2>&1
+    stdbuf -o0 -e0 "$test_runner_script" run "$run_mode" >"$stdout_file" 2>&1
     test_exit_code=$?
 }
 
@@ -53,29 +67,31 @@ function ProcessOneTestResult()
     do
         failure="${failure_identifiers[$i]}"
         echo "Checking for '$failure' in '$stdout_file' ..."
-        current_output_failures=$(cat "$stdout_file" | grep "$failure" | grep -v "echo" | wc -l)
-        total_failures=$(($total_failures + $current_output_failures))
-        if [[ $current_output_failures > 0 ]]; then
+        current_output_failures=$(cat "$stdout_file" | grep "$failure" | grep -v -c "echo")
+        total_failures=$((total_failures + current_output_failures))
+        if [[ $current_output_failures -gt 0 ]]; then
             failure_string_in_output="Failure : '$failure' observed in '$stdout_file'"
-            echo $failure_string_in_output
+            echo "$failure_string_in_output"
             current_test_failures+="$failure_string_in_output\n"
-            failures_in_output=$(($failures_in_output + $current_output_failures))
+            failures_in_output=$((failures_in_output + current_output_failures))
         fi
     done
 
     # Copy last 50 lines of stdout into stacktrace for junit xml
     # Note: Azure DevOps supports only 4K characters in stack trace
-    echo "Note: Printing last 50 lines." >> "$stack_trace_file_path"
-    echo "----------output-start-------------" >> "$stack_trace_file_path"
-    cat "$stdout_file" | tail -50 >> "$stack_trace_file_path"
-    echo "----------output-end-------------" >> "$stack_trace_file_path"
+    {
+      echo "Note: Printing last 50 lines."
+      echo "----------output-start-------------"
+      cat "$stdout_file" | tail -50
+      echo "----------output-end-------------" 
+    } >> "$stack_trace_file_path"
 
     if [[ $test_exit_code -eq 0 && $failures_in_output -eq 0 ]]; then
         current_test_result="passed"
-        total_passed=$(($total_passed + 1))
+        total_passed=$((total_passed + 1))
     else
         current_test_result="failed"
-        total_failed=$(($total_failed + 1))
+        total_failed=$((total_failed + 1))
         for ((i = 0; i < ${#current_test_failures[@]}; i++))
         do
             echo -e "${current_test_failures[$i]}" >> "$stack_trace_file_path"
@@ -97,10 +113,10 @@ function ProcessOneTestResult()
     echo "Test '$test_name' status - Completed."
     echo "Current Status: passed = $total_passed, failed = $total_failed, disabled = $total_disabled, remaining = $total_remaining."
     
-    cp -ar report/* $SGXLKL_ROOT/report
+    cp -ar report/* "$SGXLKL_ROOT/report"
     echo "Cleaning up $SGXLKL_ROOT/$test_directory/report"
     rm -rf "$SGXLKL_ROOT/$test_directory/report"
-    ChangeDirectory $SGXLKL_ROOT
+    ChangeDirectory "$SGXLKL_ROOT"
     echo ""
     echo "-------------------------------------------------------------"
     echo ""
@@ -110,28 +126,27 @@ function ProcessOneTestResult()
 # Also set test_directory using $file
 function GetReadyToRunNextTest()
 {
-    counter=$(($counter + 1))
-    total_remaining=$(($total_tests - $counter))
-    test_directory=$(dirname $file)
+    counter=$((counter + 1))
+    total_remaining=$((total_tests - counter))
+    test_directory=$(dirname "$file")
 }
 
 function SkipTestIfDisabled()
 {
     skip_test=false
-    is_test_disabled=$(grep $file "$disabled_tests_file" | wc -l)
+    is_test_disabled=$(grep -c "$file" "$disabled_tests_file")
     # if this test is disabled set counters and skip to next test
     if [[ $is_test_disabled -ge 1 ]]; then
         echo "Test $file is disabled. Skipping test..."
         echo "To enable the test remove $file from $disabled_tests_file"
 
-        total_disabled=$(($total_disabled + 1))
-        counter=$(($counter + 1))
-        total_remaining=$(($total_tests - $counter))
+        total_disabled=$((total_disabled + 1))
+        counter=$((counter + 1))
+        total_remaining=$((total_tests - counter))
         skip_test=true
     fi
 }
 
-pwd=$(pwd)
 test_folder_name="tests"
 test_folder_identifier="Makefile"
 test_runner_script="$SGXLKL_ROOT/.azure-pipelines/scripts/run_test.sh"
@@ -169,7 +184,7 @@ suite_test_start_time=$(date +%s)
 failure_identifiers=()
 while IFS= read -r line; do failure_identifiers+=("$line"); done < "$failure_identifiers_file"
 
-for file in ${file_list[@]};
+for file in "${file_list[@]}";
 do
     SkipTestIfDisabled
     if [[ $skip_test == true ]]; then 
@@ -177,7 +192,7 @@ do
     fi
 
     GetReadyToRunNextTest
-    RunOneTest $run_mode
+    RunOneTest "$run_mode"
     ProcessOneTestResult
 
     # run "make clean" for current test folder
@@ -192,10 +207,12 @@ echo "total    = $total_tests"
 echo "=================================================="
 
 # Using suite test start time, create test duration junit xml which will be used for test duration in pipeline
-[[ "$test_group_name" == "core" ]] && CreateSuiteTestRunDurationJunit $suite_test_start_time "$test_suite" "${test_group_name}-${build_mode}-${run_mode}"
+if [[ "$test_group_name" == "core" ]]; then
+    CreateSuiteTestRunDurationJunit "$suite_test_start_time" "$test_suite" "${test_group_name}-${SGXLKL_BUILD_MODE}-${run_mode}"
+fi
 
 # Subtract disabled tests before comparing toltal_passed
 # Disabled tests not considered failure
-total_tests=$(($total_tests - $total_disabled))
+total_tests=$((total_tests - total_disabled))
 [[ $total_passed -eq $total_tests && $total_failed -eq 0  && $total_tests -gt 0 ]] && exit 0
 exit 1

--- a/.azure-pipelines/scripts/test_utils.sh
+++ b/.azure-pipelines/scripts/test_utils.sh
@@ -12,6 +12,7 @@ function InitializeTestCase()
     echo "Initialized test_name=$test_name"
     echo "Initialized test_class=$test_class"
     echo "Initialized test_suite=$test_suite"
+    echo "Initialized test_mode=$test_mode"
     echo "Initialized error_message_file_path=$error_message_file_path"
     echo "Initialized stack_trace_file_path=$stack_trace_file_path"  
 }
@@ -20,6 +21,7 @@ function ChangeDirectory()
 {
     test_directory="$1"
     echo "Changing directory to $test_directory"
+    #shellcheck disable=SC2164
     cd "$test_directory"
 }
 
@@ -28,6 +30,7 @@ function CheckNotRunning()
     process="sgx-lkl-run-oe"
     if pgrep -x $process >/dev/null; then
         echo "SGX-LKL still running:"
+        # shellcheck disable=SC2009
         ps -aux | grep $process
         echo "Trying to kill hanging $process process"
         sudo pkill -9 $process
@@ -35,10 +38,12 @@ function CheckNotRunning()
         sleep 5
         if pgrep -x $process >/dev/null; then
             echo "Failed to kill hanging $process process."
+            # shellcheck disable=SC2009
             ps -aux | grep $process
             exit 1
         fi
         echo "Killed the hanging $process process successfully"
+        # shellcheck disable=SC2009
         ps -aux | grep $process
     fi
 }

--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -78,10 +78,13 @@ stages:
         - bash: .azure-pipelines/scripts/dump_system_info.sh
           displayName: Dump system info
 
+        - bash: scripts/check-ci
+          displayName: Run linters and check formatting
+
         - bash: .azure-pipelines/scripts/build.sh
           displayName: Compile and Build
           env:
-            build_mode: "${{ build_mode }}"
+            SGXLKL_BUILD_MODE: "${{ build_mode }}"
             SGXLKL_PREFIX: $(SGXLKL_ROOT)/install
 
         - bash: .azure-pipelines/scripts/create_standalone_deb_pkg.sh
@@ -141,7 +144,6 @@ stages:
             - bash: .azure-pipelines/scripts/test_runner.sh ${{ test_suite }}
               displayName: Run Tests
               env:
-                build_mode: "${{ build_mode }}"
                 SGXLKL_BUILD_MODE: "${{ build_mode }}"
                 run_mode: "run-${{ run_mode }}"
                 SGXLKL_PREFIX: ${{ parameters.install_prefix_mapping[build_mode] }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ src/enclave/sgxlkl_t.c
 *.docker_entrypoint
 .gdb_history
 
-.vscode/
+.vscode/*
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "timonwong.shellcheck"
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OESIGN_CONFIG_PATH = $(SGXLKL_ROOT)/config
 .DEFAULT_GOAL:=all
 default: all
 
-all: update-git-submodules $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)) $(BUILD_DIR)/$(SGXLKL_LIB_TARGET_SIGNED) fsgsbase-kernel-module
+all: update-git-submodules install-git-pre-commit-hook $(addprefix $(OE_SDK_ROOT)/lib/openenclave/, $(OE_LIBS)) $(BUILD_DIR)/$(SGXLKL_LIB_TARGET_SIGNED) fsgsbase-kernel-module
 
 # Check if the user didn't override the default in-tree OE install location with another OE host install
 ifeq ($(OE_SDK_ROOT),$(OE_SDK_ROOT_DEFAULT))
@@ -144,6 +144,10 @@ update-git-submodules:
 	[ "$(FORCE_SUBMODULES_UPDATE)" = "false" ] || git submodule update --progress
 	# Initialise the missing Open Enclave submodules
 	cd $(OE_SUBMODULE) && git submodule update --recursive --progress --init
+
+# Git pre-commit hook installation
+install-git-pre-commit-hook: scripts/pre-commit
+	cp scripts/pre-commit .git/hooks
 
 fsgsbase-kernel-module:
 	make -C ${TOOLS}/kmod-set-fsgsbase

--- a/samples/basic/attack/read_memory.sh
+++ b/samples/basic/attack/read_memory.sh
@@ -4,27 +4,27 @@ set -e
 
 program=$1
 search_string=$2
-save_pid=$(pidof $program || echo "")
+save_pid=$(pidof "$program" || echo "")
 if [[ "$save_pid" == "" ]]; then
     echo "Process '$program' not found"
     exit 1
 fi
 
-echo Saving memory image of process ${save_pid}...
+echo "Saving memory image of process ${save_pid}..."
 
-sudo gcore -o mem.dump ${save_pid} >/dev/null 2>&1
+sudo gcore -o mem.dump "${save_pid}" >/dev/null 2>&1
 mem_files=(mem.dump.*)
 
 mem_file=${mem_files[0]}
 
-sudo chown $(id -u -n):$(id -g -n) $mem_file
+sudo chown "$(id -u -n):$(id -g -n)" "$mem_file"
 
-echo Searching memory for string \"${search_string}\" in \"${mem_file}\"...
+echo "Searching memory for string \"${search_string}\" in \"${mem_file}\"..."
 
-if (strings ${mem_file} | grep -i ${search_string}); then
+if (strings "${mem_file}" | grep -i "${search_string}"); then
         echo Match found.
 else
         echo No match found.
 fi
 
-rm $mem_file
+rm "$mem_file"

--- a/scripts/check-ci
+++ b/scripts/check-ci
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# This script is very similar to the pre-commit hook, except it
+# unconditionally checks all files, which we have time for in CI.
+
+exit_() {
+    echo ""
+    echo "$1"
+    echo ""
+    exit 1
+}
+
+## Check whether source code has been formatted:
+if ! ./scripts/format-code --quiet --whatif; then
+    echo "code not formatted correctly, IGNORING FOR NOW!"
+    #exit_ "CI failed: please run ./scripts/format-code"
+fi
+
+# Check whether all scripts pass ShellCheck:
+if ! ./scripts/check-linters; then
+    exit_ "CI failed: please run ./scripts/check-linters"
+fi

--- a/scripts/check-linters
+++ b/scripts/check-linters
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+# This script currently runs just the ShellCheck linter on shell
+# scripts. If run from a subdirectory, it will restrict itself to just
+# that directory.
+
+if ! hash shellcheck 2>/dev/null; then
+    echo "ShellCheck not found, please install!"
+    echo "See https://www.shellcheck.net/ for more info."
+    exit 1
+fi
+
+if [[ $# -ne 0 ]]; then
+    filelist="$*"
+else
+    filelist=$(git ls-files)
+fi
+
+for i in $filelist; do
+    if ! file -b "$i" | grep -q "shell script"; then
+        continue;
+    fi
+
+    if ! shellcheck -x "$i"; then
+        failed=1;
+    fi
+done
+
+if [[ $failed -eq 1 ]]; then
+    exit 1
+fi
+
+exit 0

--- a/scripts/format-code
+++ b/scripts/format-code
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+##==============================================================================
+##
+## Echo if verbose flag (ignores quiet flag)
+##
+##==============================================================================
+log_verbose()
+{
+    if [[ ${verbose} -eq 1 ]]; then
+        echo "$1"
+    fi
+}
+
+##==============================================================================
+##
+## Echo if whatif flag is specified but not quiet flag
+##
+##==============================================================================
+log_whatif()
+{
+    if [[ ${whatif} -eq 1 && ${quiet} -ne 1 ]]; then
+        echo "$1"
+    fi
+}
+
+##==============================================================================
+##
+## Process command-line options:
+##
+##==============================================================================
+
+for opt in "$@"
+do
+  case $opt in
+    -h | --help)
+        usage=1
+        ;;
+
+    -v | --verbose)
+        verbose=1
+        ;;
+
+    -q | --quiet)
+        quiet=1
+        ;;
+
+    -w | --whatif)
+        whatif=1
+        ;;
+
+    -s | --staged)
+        # Split into array
+        mapfile -t userFiles <<< "$(git diff --cached --name-only --diff-filter=ACMR)"
+        ;;
+
+    --exclude-dirs=*)
+        userExcludeDirs="${opt#*=}"
+        ;;
+
+    --include-exts=*)
+        userIncludeExts="${opt#*=}"
+        ;;
+
+    --files=*)
+        read -ra userFiles <<< "${opt#*=}"
+        ;;
+    *)
+        echo "$0: unknown option:  $opt"
+        exit 1
+        ;;
+  esac
+done
+
+##==============================================================================
+##
+## Display help
+##
+##==============================================================================
+
+if [[ ${usage} -eq 1 ]]; then
+    cat<<EOF
+
+OVERVIEW:
+
+Formats all C/C++ source files based on the .clang-format rules
+
+    $ format-code [-h] [-q] [-s] [-v] [-w] [--exclude-dirs="..."] [--include-exts="..."] [--files="..."]
+
+OPTIONS:
+    -h, --help              Print this help message.
+    -q, --quiet             Display only clang-format output and errors.
+    -s, --staged            Only format files which are staged to be committed.
+    -v, --verbose           Display verbose output.
+    -w, --whatif            Run the script without actually modifying the files
+                            and display the diff of expected changes, if any.
+    --exclude-dirs          Subdirectories to exclude. If unspecified, then
+                            ./host-musl ./lkl ./openenclave and ./sgx-lkl-musl
+                            are excluded.
+                            All subdirectories are relative to the current path.
+    --include-exts          File extensions to include for formatting. If
+                            unspecified, then *.h, *.c and *.cpp are included.
+    --files                 Only run the script against the specified files from
+                            the current directory.
+
+EXAMPLES:
+
+To determine what lines of each file in the default configuration would be
+modified by format-code, you can run from the root folder:
+
+    $ ./scripts/format-code -w
+
+To update only all .c and .cpp files in tests/ except for tests/echo/host, you
+can run from the tests folder:
+
+    tests$ ../scripts/format-code --exclude-dirs="echo/host" \
+      --include-exts="c cpp"
+
+To run only against a specified set of comma separated files in the current directory:
+
+    $ ./scripts/format-code -w --files="file1 file2"
+
+EOF
+    exit 0
+fi
+
+##==============================================================================
+##
+## Check for acceptable version of clang-format
+##
+##==============================================================================
+check_version()
+{
+    # shellcheck disable=SC2206
+    v1=(${1//./ })
+    # shellcheck disable=SC2206
+    v2=(${2//./ })
+    if [[ ${#v1[@]} -ne ${#v2[@]} ]]; then
+        echo "Cannot parse clang-format version number: $2"
+        exit 1
+    fi
+    for ((i=0; i<${#v1[@]}; i++));
+    do
+        # Because clang-format is not invariant across versions, this
+        # is an explicit equivalence check.
+        if [[ ${v1[$i]} -ne ${v2[$i]} ]]; then
+            echo "Warning: format-code prefers clang-format version $1, installed version is $2"
+        fi
+    done
+}
+
+##==============================================================================
+##
+## Check for installed clang-format tool
+##
+##==============================================================================
+check_clang-format()
+{
+    # First check explicitly for the clang-format-7 executable.
+    cf=$(command -v clang-format-7 2> /dev/null)
+
+    if [[ -x ${cf} ]]; then
+        cf="clang-format-7"
+        return
+    else
+        cf=$(command -v clang-format 2> /dev/null)
+        if [[ ! -x ${cf} ]]; then
+            echo "clang-format is not installed"
+            exit 1
+        fi
+        cf="clang-format"
+    fi
+
+    local required_cfver='7.0.1'
+    # shellcheck disable=SC2155
+    local cfver=$(${cf} --version | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    check_version "${required_cfver}" "${cfver}"
+}
+
+check_clang-format
+
+##==============================================================================
+##
+## Determine parameters for finding files to format
+##
+##==============================================================================
+
+findargs='find .'
+
+get_find_args()
+{
+    local defaultExcludeDirs='./.git ./host-musl ./lkl ./openenclave ./sgx-lkl-musl ./build ./build_musl ./third_party'
+    local defaultIncludeExts='h c cpp'
+
+    if [[ -z ${userExcludeDirs} ]]; then
+        read -r -a excludeDirs <<< "${defaultExcludeDirs}"
+    else
+        log_verbose "Using user directory exclusions: ${userExcludeDirs}"
+        read -r -a excludeDirs <<< "${userExcludeDirs}"
+    fi
+
+    for exc in "${excludeDirs[@]}"
+    do
+        findargs="${findargs} ! \( -path '${exc}' -prune \)"
+    done
+
+    if [[ -z ${userIncludeExts} ]]; then
+        # not local as this is used in get_file_list() too
+        read -r -a includeExts <<< "${defaultIncludeExts}"
+    else
+        log_verbose "Using user extension inclusions: ${userIncludeExts}"
+        read -r -a includeExts <<< "${userIncludeExts}"
+    fi
+
+    findargs="${findargs} \("
+    for ((i=0; i<${#includeExts[@]}; i++));
+    do
+        findargs="${findargs} -iname '*.${includeExts[$i]}'"
+        if [[ $((i + 1)) -lt ${#includeExts[@]} ]]; then
+            findargs="${findargs} -o"
+        fi
+    done
+    findargs="${findargs} \)"
+}
+
+get_find_args
+
+log_verbose "Query for files for format:"
+log_verbose "${findargs}"
+log_verbose ""
+
+##==============================================================================
+##
+## Call clang-format for each file to be formatted
+##
+##==============================================================================
+
+filecount=0
+changecount=0
+
+cfargs="${cf} -style=file"
+if [[ ${whatif} -ne 1 ]]; then
+    cfargs="${cfargs} -i"
+fi
+
+get_file_list()
+{
+    if [[ -z "${userFiles[*]}" ]]; then
+        mapfile -t file_list < <(eval "$findargs")
+        if [[ ${#file_list[@]} -eq 0 ]]; then
+            echo "No files were found to format!"
+            exit 1
+        fi
+    else
+        log_verbose "Using user files: ${userFiles[*]}"
+        file_list=()
+        for file in "${userFiles[@]}"; do
+            for ext in "${includeExts[@]}"; do
+                if [[ ${file##*\.} == "$ext" ]]; then
+                    file_list+=( "$file" )
+                    log_verbose "Checking user file: ${file}"
+                    break
+                fi
+            done
+        done
+    fi
+}
+
+get_file_list
+
+for file in "${file_list[@]}"
+do
+    ((filecount+=1))
+    cf="${cfargs} $file"
+
+    log_whatif "Formatting $file ..."
+
+    if [[ ${whatif} -eq 1 ]]; then
+        ${cf} | diff -u "$file" -
+    else
+        if [[ ${verbose} -eq 1 ]]; then
+            ${cf}
+        else
+            ${cf} > /dev/null
+        fi
+    fi
+
+    #shellcheck disable=SC2181
+    if [[ $? -ne 0 ]]; then
+        if [[ ${whatif} -eq 1 ]]; then
+            ((changecount+=1))
+        else
+            echo "clang-format failed on file: $file."
+        fi
+    fi
+done
+
+log_whatif "${filecount} files processed, ${changecount} changed."
+
+# If files are being edited, this count is zero so we exit with success.
+exit "$changecount"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright (c) Open Enclave SDK contributors.
+# Licensed under the MIT License.
+
+set -o errexit
+
+exit_() {
+    echo ""
+    echo "$1"
+    echo ""
+    echo "This hook can be skipped if needed with 'git commit --no-verify'"
+    echo "See '.git/hooks/pre-commit', installed from 'scripts/pre-commit'"
+    exit 1
+}
+
+if [[ $(git config --get user.name | wc -w) -lt 2 ]]; then
+    # This heuristic avoids bad user names such as "root" or "Ubuntu"
+    # or a computer login name. A full name should (usually) have at
+    # least two words. We can change this if needed later.
+    exit_ "Commit failed: please fix your Git user name (see docs/Contributing.md)"
+fi
+
+# TODO enable after formatting is enabled
+#if ! git diff-index --check --cached HEAD --; then
+#    exit_ "Commit failed: please fix the conflict markers or whitespace errors"
+#fi
+
+mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    # When 'git commit --amend' is used, the files list is empty. The
+    # scripts below interpret an empty file set as a directive to
+    # check all the files, which is slow (but used in CI). So in this
+    # Git hook, we just skip the following checks instead.
+    exit 0
+fi
+
+scripts=$(git rev-parse --show-toplevel)/scripts
+
+# TODO enable after files have been formatted
+# shellcheck disable=SC2154
+#if ! "$scripts/format-code" --quiet --whatif --files="${files[*]}"; then
+#    exit_ "Commit failed: please run './scripts/format-code --staged' to fix the formatting"
+#fi
+
+if ! "$scripts/check-linters" "${files[@]}"; then
+    exit_ "Commit failed: please run './scripts/check-linters' and fix the warnings"
+fi

--- a/src/include/shared/tree.h
+++ b/src/include/shared/tree.h
@@ -23,6 +23,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// clang-format off
+
 #ifndef	_SYS_TREE_H_
 #define	_SYS_TREE_H_
 

--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -2,6 +2,8 @@
 /* This file is based on posix-host.c from LKL, modified to provide a host
  * interface for enclave environments. */
 
+// clang-format off
+
 #include <errno.h>
 #include <futex.h>
 #include <lkl_host.h>

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -27,8 +27,6 @@
  *
  */
 
-// clang-format off
-
 #define WANT_REAL_ARCH_SYSCALLS
 
 #include <inttypes.h>

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -27,6 +27,8 @@
  *
  */
 
+// clang-format off
+
 #define WANT_REAL_ARCH_SYSCALLS
 
 #include <inttypes.h>

--- a/tests/ltp/buildenv.sh
+++ b/tests/ltp/buildenv.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+#shellcheck disable=SC2002,SC2164
+
 mode=$1
 test_directory=$2
 
 LTP_GIT_TAG="20190930"
 
 
-if [ -z $test_directory ]; then
+if [ -z "$test_directory" ]; then
     echo "Please provide ltp tests directory. Example: ltp.sh 'testcases/kernel/syscalls'"
     exit 1
 fi
@@ -36,8 +38,8 @@ if [[ "$mode" == "build" ]]; then
     pwd=$(pwd)
     c_binaries_list_file_tmp="/$pwd/.c_binaries_list.tmp"
     c_binaries_list_file="/$pwd/.c_binaries_list"
-    rm -rf $c_binaries_list_file
-    touch $c_binaries_list_file
+    rm -rf "$c_binaries_list_file"
+    touch "$c_binaries_list_file"
 
     git checkout $LTP_GIT_TAG
  
@@ -53,35 +55,34 @@ if [[ "$mode" == "build" ]]; then
     
     pass_file="$pwd/passed_test.txt"
     fail_file="$pwd/failed_test.txt"
-    echo "" > $pass_file
-    echo "" > $fail_file
+    echo "" > "$pass_file"
+    echo "" > "$fail_file"
 
     IFS=$'\n'
-    file_list=( $(find $test_directory -name Makefile) )
+    file_list=( $(find "$test_directory" -name Makefile) )
 
-    makefile_counter=$(find $test_directory -name Makefile | wc -l)
+    makefile_counter=$(find "$test_directory" -name Makefile | wc -l)
     counter=0
     c_binaries_counter=0
     c_binaries_failures=0
 
     echo "Compling and generating binaries in $test_directory recursively"
-    for file in ${file_list[@]};
+    for file in "${file_list[@]}";
     do
-        current_test_directory=$(dirname $file)
-        counter=$(($counter + 1))
+        current_test_directory=$(dirname "$file")
+        counter=$((counter + 1))
         printf '%-17s' "[Test #$counter/$makefile_counter]"
-        cd $current_test_directory
+        cd "$current_test_directory"
         c_file_list=( $(find . -name "*.c") )
         printf '%-70s' "Building $current_test_directory "
-        make 1> build.log 2>&1
-        if [[ $? == 0 ]]; then
+        if make 1> build.log 2>&1 ; then
                 printf '%-10s\n' "Success"
-                for c_file in ${c_file_list[@]};
+                for c_file in "${c_file_list[@]}";
                 do
                         filename="${c_file%.*}"
-                        if [ -f $filename ];then
-                            c_binaries_counter=$(($c_binaries_counter + 1))
-                            echo "$current_test_directory/$filename" >> $c_binaries_list_file_tmp
+                        if [ -f "$filename" ];then
+                            c_binaries_counter=$((c_binaries_counter + 1))
+                            echo "$current_test_directory/$filename" >> "$c_binaries_list_file_tmp"
                         else
                             echo -e "\t \t WARNING !! $filename is not generated"
                         fi
@@ -91,14 +92,14 @@ if [[ "$mode" == "build" ]]; then
                 echo "_________________________________________"
                 cat build.log
                 echo -e "_________________________________________\n"
-                c_binaries_failures=$(($c_binaries_failures + 1))
+                c_binaries_failures=$((c_binaries_failures + 1))
         fi
         [ -f build.log ] && rm -f build.log
-        cd $pwd
+        cd "$pwd"
     done
-    sed 's/\.\///' -i $c_binaries_list_file_tmp
-    cat $c_binaries_list_file_tmp | sort | uniq  > $c_binaries_list_file
-    rm -f $c_binaries_list_file_tmp
+    sed 's/\.\///' -i "$c_binaries_list_file_tmp"
+    cat "$c_binaries_list_file_tmp" | sort | uniq  > "$c_binaries_list_file"
+    rm -f "$c_binaries_list_file_tmp"
     echo "--------------------------------------------------------------"
     echo "Generated $c_binaries_counter binaries in $test_directory"
     echo $c_binaries_counter > .c_binaries_counter
@@ -110,36 +111,35 @@ if [[ "$mode" == "run" ]];then
     cd /ltp
     pwd=$(pwd)
     c_binaries_list_file="$pwd/.c_binaries_list"    
-    file_list=( $(find $test_directory -name Makefile) )
-    makefile_counter=$(find $test_directory -name Makefile | wc -l)
+    file_list=( $(find "$test_directory" -name Makefile) )
+    makefile_counter=$(find "$test_directory" -name Makefile | wc -l)
     
     counter=0    
     pass_file="$pwd/passed_test.txt"
     fail_file="$pwd/failed_test.txt"
-    echo "" > $pass_file
-    echo "" > $fail_file
+    echo "" > "$pass_file"
+    echo "" > "$fail_file"
     c_binaries_counter=$(cat .c_binaries_counter)
     echo "Running the tests using generated binaries in $test_directory recursively"
     counter=0
-    for file in ${file_list[@]};
+    for file in "${file_list[@]}";
     do
-        current_test_directory=$(dirname $file)
-        cd $current_test_directory
+        current_test_directory=$(dirname "$file")
+        cd "$current_test_directory"
         c_file_list=( $(find . -name "*.c") )
-        for c_file in ${c_file_list[@]};
+        for c_file in "${c_file_list[@]}";
         do
             filename="${c_file%.*}"
-            if [ ! -z $filename ]; then
-                counter=$(($counter + 1))
+            if [ ! -z "$filename" ]; then
+                counter=$((counter + 1))
                 echo "[Test #$counter/$c_binaries_counter] Running $filename in directory $current_test_directory ..."
-                $filename
-                if [[ "$?" == "0" ]]; then
-                        echo "$current_test_directory/$filename" >> $pass_file
+                if $filename; then
+                        echo "$current_test_directory/$filename" >> "$pass_file"
                 else
-                        echo "$current_test_directory/$filename" >> $fail_file
+                        echo "$current_test_directory/$filename" >> "$fail_file"
                 fi
             fi
         done
-        cd $pwd
+        cd "$pwd"
     done
 fi

--- a/tests/ltp/ltp_test_failure_analyzer
+++ b/tests/ltp/ltp_test_failure_analyzer
@@ -3,9 +3,9 @@
 CSV_TEST_REPORT="sgxlkl_oe_ltp_failure.csv"
 REPORT_DIR=report
 [ x"$1" != "x" ] && REPORT_DIR="$1"
-[ ! -d $REPORT_DIR ] && exit 1
+[ ! -d "$REPORT_DIR" ] && exit 1
 
-files=$(find $REPORT_DIR -name "*.txt")
+files=$(find "$REPORT_DIR" -name "*.txt")
 
 counter=0
 specific_failure_identifiers=("Out of memory" "fork() failed" "system call is not implemented" \
@@ -21,21 +21,21 @@ check_specific_failures()
     filename=$1
     err_category="$2"
     for ((j = 0; j < ${#specific_failure_identifiers[@]}; j++));do
-        grep -qw "${specific_failure_identifiers[$j]}" $filename
+        grep -qw "${specific_failure_identifiers[$j]}" "$filename"
         ret=$?
         if [ $ret -eq 0 ];then
             str="$str ${specific_failure_identifiers[$j]} /"
-            error_desc=$(grep -w "${specific_failure_identifiers[$j]}" $filename | head -1)
+            error_desc=$(grep -w "${specific_failure_identifiers[$j]}" "$filename" | head -1)
         else
             if [ x"$error_desc" == x ];then
-                error_desc=$(grep -w "$err_category" $filename | head -1)
+                error_desc=$(grep -w "$err_category" "$filename" | head -1)
             fi
         fi
     done
     str=${str%/*}
-    test_case=$(echo ${filename%.*.*} | sed 's/-/\//g; s/_/\//g')
+    test_case=$(echo "${filename%.*.*}" | sed 's/-/\//g; s/_/\//g')
     test_logname=$filename
-    counter=$(($counter + 1))
+    counter=$((counter++))
     [ x"$str" != x ] && printf '\t %-80s %-30s\n' "$filename" "[$str]" || printf '\t %-70s\n' "$filename"
     echo "$counter, $test_case, $test_logname, $err_category, [ $str ], \"$error_desc\"" >> $CSV_TEST_REPORT
 }
@@ -45,10 +45,10 @@ search_failure()
 {
     err_type="$1"
     for file in $files;do
-        grep -qw "$err_type" $file
+        grep -qw "$err_type" "$file"
         ret=$?
         if [ $ret -eq 0 ];then
-            check_specific_failures $file "$err_type"
+            check_specific_failures "$file" "$err_type"
         fi
     done
 }
@@ -56,7 +56,7 @@ search_failure()
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "SI. No, Test Case , Log FileName, LTP Failure Category, Failure Reason, Error Description" > $CSV_TEST_REPORT
 failure_identifiers=()
-while IFS= read -r line; do failure_identifiers+=("$line"); done < $DIR/failure_identifiers.txt
+while IFS= read -r line; do failure_identifiers+=("$line"); done < "$DIR/failure_identifiers.txt"
 
 for ((i = 0; i < ${#failure_identifiers[@]}; i++));do
     failure="${failure_identifiers[$i]}"

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-if [ -z $SGXLKL_ROOT ]; then
+if [ -z "$SGXLKL_ROOT" ]; then
     echo "ERROR: 'SGXLKL_ROOT' is undefined. Please export SGXLKL_ROOT=<SGX-LKL-OE> source code repository"
     exit 1
 fi
 
+#shellcheck source=.azure-pipelines/scripts/junit_utils.sh
 . $SGXLKL_ROOT/.azure-pipelines/scripts/junit_utils.sh
+#shellcheck source=.azure-pipelines/scripts/test_utils.sh
 . $SGXLKL_ROOT/.azure-pipelines/scripts/test_utils.sh
 
 SGXLKL_STARTER=${SGXLKL_STARTER:-$SGXLKL_ROOT/build/sgx-lkl-run-oe}
@@ -26,10 +28,10 @@ case "$test_mode" in
 esac
 test_class="ltp"
 
-SGX_LKL_RUN_CMD="$SGXLKL_STARTER $run_flag sgxlkl-miniroot-fs.img"
+SGX_LKL_RUN_CMD=( "$SGXLKL_STARTER" $run_flag sgxlkl-miniroot-fs.img )
 
 csv_filename="sgxlkl_oe_ltp_test_result_$(date +%d%m%y_%H%M%S).csv"
-echo "SI No, Test Name, Stdout logfile name, Stderr logfile name, Execution Status" > $csv_filename
+echo "SI No, Test Name, Stdout logfile name, Stderr logfile name, Execution Status" > "$csv_filename"
 
 report_dir="report"
 # Delete all files except ltp-batch(debug).* or ltp-batch(nonrelease).*
@@ -52,63 +54,65 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ltp_tests=($(grep -vf ./ltp_disabled_tests.txt  ./.c_binaries_list))
 total_tests=${#ltp_tests[@]}
 
-for file in ${ltp_tests[@]}; do
+for file in "${ltp_tests[@]}"; do
     temp_test_name=${file}
     temp_test_name="${temp_test_name//.\//}"
     final_test_name="${temp_test_name//\//-}"
-    counter=$(($counter + 1))
+    counter=$((counter + 1))
     echo "[$counter/$total_tests] Running LTP test '$file' (Timeout = $timeout seconds)..."
 
     # Initialize the variables.
     test_name=${final_test_name#"-ltp-testcases-"}
-    ltp_testcase_name=$(echo ${test_name%.*.*} | sed 's/-/\//g; s/_/\//g')
-    test_name="${test_name}-($build_mode)-($test_mode)-($SGXLKL_ETHREADS-ethreads)"
+    ltp_testcase_name=$(echo "${test_name%.*.*}" | sed 's/-/\//g; s/_/\//g')
+    test_name="${test_name}-($SGXLKL_BUILD_MODE)-($test_mode)-($SGXLKL_ETHREADS-ethreads)"
     error_message_file_path="$report_dir/$test_name.error"
     stack_trace_file_path="$report_dir/$test_name.stack"
     stdout_file="$report_dir/$test_name.stdout.txt"
     # Start the test timer.
     JunitTestStarted "$test_name"
 
-    echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > \"$stdout_file\" 2>&1"
-    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > "$stdout_file" 2>&1
+    echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout ${SGX_LKL_RUN_CMD[*]} $file > $stdout_file 2>&1"
+    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout "${SGX_LKL_RUN_CMD[@]}" "$file" > "$stdout_file" 2>&1
     exit_code=$?
     if [[ $exit_code -eq  124 ]]; then
-        echo "$SGX_LKL_RUN_CMD $file : TIMED OUT after $timeout secs"
+        echo "${SGX_LKL_RUN_CMD[*]} $file : TIMED OUT after $timeout secs"
         echo "TIMED OUT after $timeout secs. TEST_FAILED" >> "$stdout_file"
     elif [[ $exit_code -ne 0 ]]; then
         echo "TEST_FAILED EXIT CODE: $exit_code" >> "$stdout_file"
     else
-        echo "$SGX_LKL_RUN_CMD $file: RETURNED EXIT CODE: $exit_code"
+        echo "${SGX_LKL_RUN_CMD[*]} $file: RETURNED EXIT CODE: $exit_code"
     fi
 
     # Copy last 50 lines of stdout into stacktrace for junit xml
     # Note: Azure DevOps supports only 4K characters in stack trace
-    echo "Note: Printing last 50 lines." >> "$stack_trace_file_path"
-    echo "----------output-start-------------" >> "$stack_trace_file_path"
-    cat "$stdout_file" | tail -50 >> "$stack_trace_file_path"
-    echo "----------output-end-------------" >> "$stack_trace_file_path"
+    {
+        echo "Note: Printing last 50 lines."
+        echo "----------output-start-------------"
+        tail -50 < "$stdout_file"
+        echo "----------output-end---------------"
+    } > "$stack_trace_file_path"
     
     if [[ $exit_code -eq 0 ]]; then
-        total_passed=$(($total_passed + 1))
+        total_passed=$((total_passed + 1))
         echo "'$test_name' passed."
         echo "'$test_name' passed." > "$error_message_file_path"
         echo "$counter, $test_name, $stdout_file, Pass"
-        echo "$counter, $ltp_testcase_name, $stdout_file, Pass" >> $csv_filename
+        echo "$counter, $ltp_testcase_name, $stdout_file, Pass" >> "$csv_filename"
         JunitTestFinished "$test_name" "passed" "$test_class" "$test_suite"
     else
-        total_failed=$(($total_failed + 1))
+        total_failed=$((total_failed + 1))
         echo "'$test_name' failed."
         echo "'$test_name' failed." > "$error_message_file_path"
         echo "'make $test_mode-single test=$file' can be used to test this individually failing ltp test"
         echo "'make $test_mode-single test=$file' can be used to test this individually failing ltp test" >> "$error_message_file_path"
         echo "$counter, $test_name, $stdout_file, Failed"
-        echo "$counter, $ltp_testcase_name, $stdout_file, Failed" >> $csv_filename
+        echo "$counter, $ltp_testcase_name, $stdout_file, Failed" >> "$csv_filename"
         JunitTestFinished "$test_name" "failed" "$test_class" "$test_suite"
     fi
     echo "-------------------------------------------------------------------"
 done
 echo "Generating LTP failure test analysis report"
-$DIR/ltp_test_failure_analyzer
+"$DIR/ltp_test_failure_analyzer"
 
 echo "-------------------------------"
 echo "Total passed  : $total_passed"

--- a/tools/gdb/sgx-lkl-gdb
+++ b/tools/gdb/sgx-lkl-gdb
@@ -6,7 +6,7 @@ shopt -s expand_aliases
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Are we running in the source tree?
-if [ -f $THIS_DIR/sgx-lkl-gdb.py ]; then
+if [ -f "$THIS_DIR/sgx-lkl-gdb.py" ]; then
     SGXLKL_GDB_HELPER_DIR=$THIS_DIR
     OE_GDB_PLUGIN_DIR=$THIS_DIR/../../build/openenclave/lib/openenclave/debugger
 else

--- a/tools/ncore.sh
+++ b/tools/ncore.sh
@@ -2,16 +2,16 @@
 
 # Thanks to the Fuchsia Authors for this!
 
-case `uname` in
+case $(uname) in
 Linux)
-    _N=`cat /proc/cpuinfo | grep processor | wc -l`
-    N=`expr $_N + $_N`
+    _N=$(grep -c processor /proc/cpuinfo)
+    N=$(( _N + _N ))
     ;;
 Darwin)
-    N=`sysctl -n hw.ncpu`
+    N=$(sysctl -n hw.ncpu)
     ;;
 FreeBSD)
-    N=`sysctl -n hw.ncpu`
+    N=$(sysctl -n hw.ncpu)
     ;;
 *)
     N=8

--- a/tools/sgx-lkl-disk
+++ b/tools/sgx-lkl-disk
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2002,SC2032,SC2033,SC2024
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-SELF="$(basename ${BASH_SOURCE})"
-SELF_DIR="$( cd "$( dirname ${BASH_SOURCE} )" >/dev/null 2>&1 && pwd )"
+SELF=$(basename "${BASH_SOURCE[0]}")
 
 ALPINE_MAJOR=3.10
 ALPINE_VERSION=3.10.0
@@ -22,7 +23,7 @@ CRYPTSETUP_VERBOSE_FLAGS=""
 SYSDIRS=(dev mnt tmp sys run proc)
 
 USER=$(who am i | awk '{print $1}')
-GROUP=$(id -gn ${USER})
+GROUP=$(id -gn "${USER}")
 
 # The lowest possible ext4 size seems to be ~140K. To be on the safe side, we require 512K.
 MIN_DISK_SIZE=524288
@@ -30,7 +31,10 @@ MIN_DISK_SIZE=524288
 BLOCK_SIZE=8192
 
 # mkfs options that reduce the filesystem overhead.
-MKFS_FLAGS="-m 0 -O ^has_journal,^resize_inode,sparse_super2"
+MKFS_FLAGS=(
+    -m 0
+    -O "^has_journal,^resize_inode,sparse_super2"
+)
 
 function usage() {
 cat << UsageMsg
@@ -86,15 +90,15 @@ Create ('create') options
   -P, --pbkdf=<pbkdf>       Use <pbkdf> to derive encryption key for LUKS key
                             slot (Default: PBKDF2) (Requires cryptsetup version
                             >= 2.0.0)
-  -H, --hash=<hash-alg>     Use hash-alg> to create encryption key from
+  -H, --hash=<hash-alg>     Use <hash-alg> to create encryption key from
                             passphrase.
  -v, --verity[=<alg>]       Use dm-verity for read-only integrity protection of
-                            the disk. Use <alg> as algorithm if specified
-                            (Default: hmac-sha256). Can be combined with
+                            the disk. Use <alg> as hash algorithm if specified
+                            (Default: sha256). Can be combined with
                             --encrypt.
  -I, --integrity[=<alg>]    Use dm-integrity for read/write integrity
-                            protection of the disk. Use <alg> als algorithm if
-                            specified (Default: sha256). Can be combined with
+                            protection of the disk. Use <alg> al algorithm if
+                            specified (Default: hmac-sha256). Can be combined with
                             --encrypt. Currently standalone dm-integrity is not
                             supported. (Requires cryptsetup version >= 2.0.0 and
                             kernel version >= 4.12).
@@ -199,7 +203,7 @@ function cleanup() {
     cleanup_file "${tmp_docker_context:-}"
     cleanup_file "${tmp_image:-}"
 
-    if [ ! -z ${tmp_mnt_point:-} ]; then
+    if [ ! -z "${tmp_mnt_point:-}" ]; then
         cleanup_echo
         if mountpoint -q "${tmp_mnt_point}" &> /dev/null; then sudo umount "${tmp_mnt_point}"; fi
         rm -r "${tmp_mnt_point}"
@@ -213,30 +217,30 @@ function cleanup() {
 
         if [[ -d "${mnt_point}" ]] && [[ -z "$(ls -A "${mnt_point}")" ]]; then
             cleanup_echo
-            rm -r ${mnt_point}
+            rm -r "${mnt_point}"
         fi
     fi
 
-    if [[ ! -z ${docker_container_id:-} ]] && [[ ! $(docker ps -qa | grep -q ${docker_container_id}) ]]; then
+    if [[ ! -z ${docker_container_id:-} ]] && docker ps -qa | grep -q "${docker_container_id}"; then
         cleanup_echo
-        docker rm --force ${docker_container_id} > /dev/null
+        docker rm --force "${docker_container_id}" > /dev/null
     fi
 
     if [[ ! -z ${tmp_cryptsetup_name:-} ]] && [[ -e "/dev/mapper/${tmp_cryptsetup_name}" ]]; then
         cleanup_echo
         sleep 1
-        sudo cryptsetup close ${tmp_cryptsetup_name}
+        sudo cryptsetup close "${tmp_cryptsetup_name}"
     fi
 
-    if [[ ! -z ${tmp_loop_device:-} ]] && [[ ! -z $(losetup -l | grep "${tmp_loop_device} ") ]]; then
+    if [[ ! -z ${tmp_loop_device:-} ]] && losetup -l | grep -q "${tmp_loop_device} "; then
         cleanup_echo
-        sudo losetup -d ${tmp_loop_device}
+        sudo losetup -d "${tmp_loop_device}"
     fi
 
     if [ "${cleanup:-}" = 1 ]; then
-        if [[ ! -z ${tmp_docker_image_id:-} ]] && [[ $(docker images -qa | grep ${tmp_docker_image_id}) ]]; then
+        if [[ ! -z ${tmp_docker_image_id:-} ]] && docker images -qa | grep -q "${tmp_docker_image_id}"; then
             cleanup_echo
-            docker rmi ${tmp_docker_image_id}
+            docker rmi "${tmp_docker_image_id}"
         fi
         if [[ ! -z ${alpine_tar:-} ]] && [[ -e ${alpine_tar} ]]; then
             cleanup_echo
@@ -245,6 +249,7 @@ function cleanup() {
     fi
 }
 
+# shellcheck disable=SC2154
 trap 'ec=$?; cleanup; exit $ec' EXIT
 trap 'exit 127' HUP INT PIPE QUIT TERM
 
@@ -300,7 +305,7 @@ function warn_exists() {
 
 # $1: Command/application being required
 function req() {
-    [[ -x "$(command -v $1)" ]] || (echo "The following application/package is required and could not be found: $1."; exit 1)
+    [[ -x "$(command -v "$1")" ]] || (echo "The following application/package is required and could not be found: $1."; exit 1)
 }
 
 # $1: Option that requires secondary argument
@@ -355,7 +360,6 @@ function is_encrypted() {
 # $2 Path to new key file
 function gen_keyfile() {
     head -c "$1" /dev/urandom > "$2"
-    echo "$2"
 }
 
 
@@ -365,7 +369,7 @@ function create_from_alpine() {
 
     echo "Creating base image from Alpine with packages ${alpine_pkgs}..."
 
-    home=$(echo ~)
+    home=~
     [[ -z $home ]] && alpine_tar_dir="." || alpine_tar_dir="$home/.cache/sgxlkl"
     mkdir -p ${alpine_tar_dir}
     alpine_tar="${alpine_tar_dir}/alpine-minirootfs-${ALPINE_VERSION}-${ALPINE_ARCH}.tar.gz"
@@ -396,23 +400,23 @@ function create_from_alpine() {
 
     tmp_mnt_point=$(mktemp -d -t sgxlkl_tmp_mnt_XXX)
     tmp_buildenv=$(mktemp -t sgxlkl_tmp_buildenv_XXX)
-    echo "${ALPINE_BUILDENV_TEMPLATE}" | sed -e "s/\${alpine_pkgs}/${alpine_pkgs}/" | sed -e "s/\${IMG_BUILDENV_RESOLV}/${IMG_BUILDENV_RESOLV}/" > ${tmp_buildenv}
+    echo "${ALPINE_BUILDENV_TEMPLATE}" | sed -e "s/\${alpine_pkgs}/${alpine_pkgs}/" | sed -e "s/\${IMG_BUILDENV_RESOLV}/${IMG_BUILDENV_RESOLV}/" > "${tmp_buildenv}"
 
-    dd if=/dev/zero of="${disk_image}" count=$((${disk_size}/512)) ibs=512 &> ${VERBOSE_OUT}
-    mkfs.ext4 $MKFS_FLAGS "${disk_image}" &> ${VERBOSE_OUT}
-    sudo mount -t ext4 -o loop "${disk_image}" ${tmp_mnt_point}
-    sudo tar -C ${tmp_mnt_point} -xf ${alpine_tar}
-    if [[ ! -z "${copy_src}" ]]; then sudo cp -r ${copy_src} ${tmp_mnt_point}; fi
+    dd if=/dev/zero of="${disk_image}" count=$((disk_size/512)) ibs=512 &> ${VERBOSE_OUT}
+    mkfs.ext4 "${MKFS_FLAGS[@]}" "${disk_image}" &> ${VERBOSE_OUT}
+    sudo mount -t ext4 -o loop "${disk_image}" "${tmp_mnt_point}"
+    sudo tar -C "${tmp_mnt_point}" -xf ${alpine_tar}
+    if [[ ! -z "${copy_src}" ]]; then sudo cp -r "${copy_src}" "${tmp_mnt_point}"; fi
     for sysdir in "${SYSDIRS[@]}"; do
         if [[ ! -e "${tmp_mnt_point}/${sysdir}" ]]; then
           echo "Creating required directory /${sysdir}..."
           sudo mkdir -p "${tmp_mnt_point}/${sysdir}"
         fi
     done
-    sudo install ${tmp_buildenv} ${tmp_mnt_point}/usr/sbin/buildenv.sh
-    sudo chroot ${tmp_mnt_point} /bin/sh /usr/sbin/buildenv.sh
-    sudo umount ${tmp_mnt_point}
-    sudo chown ${USER}:${GROUP} "${disk_image}"
+    sudo install "${tmp_buildenv}" "${tmp_mnt_point}/usr/sbin/buildenv.sh"
+    sudo chroot "${tmp_mnt_point}" /bin/sh /usr/sbin/buildenv.sh
+    sudo umount "${tmp_mnt_point}"
+    sudo chown "${USER}:${GROUP}" "${disk_image}"
 }
 
 function create_from_docker() {
@@ -423,68 +427,74 @@ function create_from_docker() {
     if [[ ! -z "${dockerfile:-}"  ]]; then
         if [[ "${nocontext:-}" == 1 ]]; then
             tmp_docker_context="$(mktemp -d -t sgxlkl_tmp_dc_XXX)"
-            cp "${dockerfile}" ${tmp_docker_context}
-            dockerfile="${tmp_docker_context}/$(basename ${dockerfile})"
+            cp "${dockerfile}" "${tmp_docker_context}"
+            dockerfile=${tmp_docker_context}/$(basename "${dockerfile}")
             docker_context=${tmp_docker_context}
-        else docker_context="$(dirname ${dockerfile})"; fi
+        else docker_context="$(dirname "${dockerfile}")"; fi
 
         echo "Creating ${disk_image} from Dockerfile ${dockerfile}..."
 
         echo "Building Docker image..."
         tmp_docker_image_id=$(cat /proc/sys/kernel/random/uuid) # Can be cleaned up at exit.
         docker_image=${tmp_docker_image_id}
-        docker build --rm=true -t ${docker_image} -f "${dockerfile}" "${docker_context}" > ${VERBOSE_OUT}
+        docker build --rm=true -t "${docker_image}" -f "${dockerfile}" "${docker_context}" > ${VERBOSE_OUT}
     fi
 
     echo "Creating disk image file from Docker container..."
 
     # Store metadata for use in sgx-lkl-cfg tool.
-    docker image inspect ${docker_image} > ${disk_image}.docker
+    docker image inspect "${docker_image}" > "${disk_image}.docker"
     
-    docker_container_id=$(docker create ${docker_image})
+    docker_container_id=$(docker create "${docker_image}")
 
-    dd if=/dev/zero of="${disk_image}" count=$((${disk_size}/512)) ibs=512 &> ${VERBOSE_OUT}
-    mkfs.ext4 $MKFS_FLAGS "${disk_image}" &> ${VERBOSE_OUT}
-    sudo mount -t ext4 -o loop "${disk_image}" ${tmp_mnt_point};
+    dd if=/dev/zero of="${disk_image}" count=$((disk_size/512)) ibs=512 &> ${VERBOSE_OUT}
+    mkfs.ext4 "${MKFS_FLAGS[@]}" "${disk_image}" &> ${VERBOSE_OUT}
+    sudo mount -t ext4 -o loop "${disk_image}" "${tmp_mnt_point}"
 
-    docker export ${docker_container_id} | sudo tar -C ${tmp_mnt_point} -xf - 
+    docker export "${docker_container_id}" | sudo tar -C "${tmp_mnt_point}" -xf - 
 
     # `docker image inspect` includes the entrypoint which may be relative.
     # Resolve it to an absolute path while we have access to the unencrypted filesystem.
-    path_env=$(docker inspect --format='{{range $i, $env := .Config.Env}}{{println $env}}{{end}}' ${docker_image} | grep PATH= || true)
+    # shellcheck disable=SC2016
+    path_env=$(docker inspect --format='{{range $i, $env := .Config.Env}}{{println $env}}{{end}}' "${docker_image}" | grep PATH= || true)
     path_env=${path_env/PATH=/}
-    wd=$(docker inspect --format='{{.Config.WorkingDir}}' ${docker_image} || true)
-    entrypoint=$(docker inspect --format='{{index .Config.Entrypoint 0}}' ${docker_image} 2>/dev/null || true)
-    cmd=$(docker inspect --format='{{index .Config.Cmd 0}}' ${docker_image} 2>/dev/null || true)
+    wd=$(docker inspect --format='{{.Config.WorkingDir}}' "${docker_image}" || true)
+    entrypoint=$(docker inspect --format='{{index .Config.Entrypoint 0}}' "${docker_image}" 2>/dev/null || true)
+    cmd=$(docker inspect --format='{{index .Config.Cmd 0}}' "${docker_image}" 2>/dev/null || true)
     entrypoint=${entrypoint:-$cmd}
-    rm -f ${disk_image}.docker_entrypoint
+    rm -f "${disk_image}.docker_entrypoint"
     if [[ "$path_env" != "" && "$entrypoint" != "" && "$entrypoint" != /* ]]; then
         path_env_mnt=${tmp_mnt_point}${path_env//:/:${tmp_mnt_point}}
-        entrypoint_abs=$(cd ${tmp_mnt_point}$wd && PATH=${path_env_mnt} /usr/bin/which ${entrypoint} | xargs realpath -s --relative-to=${tmp_mnt_point} || true)
+        # shellcheck disable=SC2015
+        entrypoint_abs=$(cd "${tmp_mnt_point}$wd" && PATH=${path_env_mnt} /usr/bin/which "${entrypoint}" | xargs realpath -s --relative-to="${tmp_mnt_point}" || true)
         if [[ "$entrypoint_abs" != "" ]]; then
-            echo "/$entrypoint_abs" > ${disk_image}.docker_entrypoint
+            echo "/$entrypoint_abs" > "${disk_image}.docker_entrypoint"
         fi
     fi
 
-    echo "${IMG_BUILDENV_RESOLV}" | sudo tee -a ${tmp_mnt_point}/etc/resolv.conf > /dev/null
-    if [[ ! -z "${copy_src}" ]]; then sudo cp -r ${copy_src} ${tmp_mnt_point}; fi
+    echo "${IMG_BUILDENV_RESOLV}" | sudo tee -a "${tmp_mnt_point}/etc/resolv.conf" > /dev/null
+    if [[ ! -z "${copy_src}" ]]; then sudo cp -r "${copy_src}" "${tmp_mnt_point}"; fi
     for sysdir in "${SYSDIRS[@]}"; do
         if [[ ! -e "${tmp_mnt_point}/${sysdir}" ]]; then
           echo "Creating required directory /${sysdir}..."
           sudo mkdir -p "${tmp_mnt_point}/${sysdir}"
         fi
     done
-    sudo umount ${tmp_mnt_point}
-    sudo chown ${USER}:${GROUP} "${disk_image}"
+    sudo umount "${tmp_mnt_point}"
+    sudo chown "${USER}:${GROUP}" "${disk_image}"
 }
 
 function create_from_image() {
     req e2fsck
     req resize2fs
-    [[ "$(is_encrypted ${image_src})" == "yes" ]] && err_image_src_enc || true
+    if [[ $(is_encrypted "${image_src}") == "yes" ]]; then
+        err_image_src_enc
+    fi
 
     src_size=$(du -b "${image_src}" | cut -f1)
-    [[ "${src_size}" -gt "${disk_size}" ]] && err_image_src_size || true
+    if [[ "${src_size}" -gt "${disk_size}" ]]; then
+        err_image_src_size
+    fi
 
     echo "Creating base image from source image ${image_src}..."
 
@@ -498,58 +508,61 @@ function create_from_image() {
     tmp_mnt_point=$(mktemp -d -t sgxlkl_tmp_mnt_XXX)
 
     cp "${image_src}" "${image_dst}"
-    size_in_kb="$(((${disk_size} + 1023) / 1024))k"
+    size_in_kb="$(((disk_size + 1023) / 1024))k"
     e2fsck -p -f "${image_dst}" > ${VERBOSE_OUT} || true
     resize2fs "${image_dst}" "${size_in_kb}" &> ${VERBOSE_OUT}
-    sudo mount -t ext4 -o loop "${disk_image}" ${tmp_mnt_point}
-    if [[ ! -z "${copy_src}" ]]; then sudo cp -r ${copy_src} ${tmp_mnt_point}; fi
+    sudo mount -t ext4 -o loop "${disk_image}" "${tmp_mnt_point}"
+    if [[ ! -z "${copy_src}" ]]; then sudo cp -r "${copy_src}" "${tmp_mnt_point}"; fi
     for sysdir in "${SYSDIRS[@]}"; do
         if [[ ! -e "${tmp_mnt_point}/${sysdir}" ]]; then
           echo "Creating required directory /${sysdir}..."
           sudo mkdir -p "${tmp_mnt_point}/${sysdir}"
         fi
     done
-    sudo umount ${tmp_mnt_point}
-    sudo chown ${USER}:${GROUP} "${disk_image}"
+    sudo umount "${tmp_mnt_point}"
+    sudo chown "${USER}:${GROUP}" "${disk_image}"
 
-    [[ ! -z "${tmp_image:-}" ]] && mv "${tmp_image}" "${disk_image}" || true
+    if [[ ! -z "${tmp_image:-}" ]]; then
+        mv "${tmp_image}" "${disk_image}"
+    fi
 }
 
 function create_from_tarfile() {
     src_size=$(du -b "${image_src}" | cut -f1)
-    [[ "${src_size}" -gt "${disk_size}" ]] && err_image_src_size || true
+    if [[ "${src_size}" -gt "${disk_size}" ]]; then
+        err_image_src_size
+    fi
 
     echo "Creating base image with the contents from ${image_src}..." >&6
-    tar_filesize=`du -b ${image_src} | cut -f1`
     tmp_mnt_point=$(mktemp -d -t sgxlkl_tmp_mnt_XXX)
 
-    block_count=$(((${disk_size} / ${BLOCK_SIZE}) + 1))
+    block_count=$(((disk_size / BLOCK_SIZE) + 1))
 
-    dd if=/dev/zero of=${disk_image} count="${block_count}" bs=${BLOCK_SIZE} status=none
-    mkfs.ext4 $MKFS_FLAGS -q ${disk_image}
-    sudo mkdir -p ${tmp_mnt_point}
-    sudo mount -t ext4 -o loop ${disk_image} ${tmp_mnt_point}
-    cat ${image_src} | sudo tar xp -C ${tmp_mnt_point}
-    echo "${IMG_BUILDENV_RESOLV}" | sudo tee -a  ${tmp_mnt_point}/etc/resolv.conf > /dev/null
-    sudo umount ${tmp_mnt_point}
+    dd if=/dev/zero of="${disk_image}" count="${block_count}" bs=${BLOCK_SIZE} status=none
+    mkfs.ext4 "${MKFS_FLAGS[@]}" -q "${disk_image}"
+    sudo mkdir -p "${tmp_mnt_point}"
+    sudo mount -t ext4 -o loop "${disk_image}" "${tmp_mnt_point}"
+    cat "${image_src}" | sudo tar xp -C "${tmp_mnt_point}"
+    echo "${IMG_BUILDENV_RESOLV}" | sudo tee -a "${tmp_mnt_point}/etc/resolv.conf" > /dev/null
+    sudo umount "${tmp_mnt_point}"
 }
 
 function create_from_dir() {
     echo "Creating base image from directory/file ${copy_src%/.*}..."
     tmp_mnt_point=$(mktemp -d -t sgxlkl_tmp_mnt_XXX)
 
-    dd if=/dev/zero of="${disk_image}" count=$((${disk_size}/512)) ibs=512 &> ${VERBOSE_OUT}
-    mkfs.ext4 $MKFS_FLAGS "${disk_image}" &> ${VERBOSE_OUT}
-    sudo mount -t ext4 -o loop "${disk_image}" ${tmp_mnt_point}
-    sudo cp -r ${copy_src} ${tmp_mnt_point}
+    dd if=/dev/zero of="${disk_image}" count=$((disk_size/512)) ibs=512 &> ${VERBOSE_OUT}
+    mkfs.ext4 "${MKFS_FLAGS[@]}" "${disk_image}" &> ${VERBOSE_OUT}
+    sudo mount -t ext4 -o loop "${disk_image}" "${tmp_mnt_point}"
+    sudo cp -r "${copy_src}" "${tmp_mnt_point}"
     for sysdir in "${SYSDIRS[@]}"; do
         if [[ ! -e "${tmp_mnt_point}/${sysdir}" ]]; then
           echo "Creating required directory /${sysdir}..."
           sudo mkdir -p "${tmp_mnt_point}/${sysdir}"
         fi
     done
-    sudo umount ${tmp_mnt_point}
-    sudo chown ${USER}:${GROUP} "${disk_image}"
+    sudo umount "${tmp_mnt_point}"
+    sudo chown "${USER}:${GROUP}" "${disk_image}"
 }
 
 function encrypt() {
@@ -571,52 +584,54 @@ function encrypt() {
     echo "  Hash Algorithm: ${hash}"
 
     if [[ ! -z "${int_alg:-}" ]]; then
-        integrity_cmd="--integrity ${int_alg}"
+        integrity_cmd=( "--integrity ${int_alg}" )
         pbkdf=${pbkdf:-pbkdf2}
-        pbkdf_cmd="--pbkdf=${pbkdf}"
+        pbkdf_cmd=( "--pbkdf=${pbkdf}" )
         type="luks2"
         echo "  Integrity: ${int_alg}"
         echo "  PBKDF: ${pbkdf}"
     else
-        integrity_cmd=""
+        integrity_cmd=( )
         type="luks"
         echo "  Integrity: Disabled"
-        pbkdf_cmd=""
+        pbkdf_cmd=( )
     fi
 
-    passphrase_cmd=""
-    keyfile_cmd=""
+    keyfile_cmd=( )
     if [[ ! -z "${passphrase:-}" ]]; then
         echo "Using passphrase for disk encryption..."
     elif [[ "$k" == 1 ]]; then
         if [[ -z "${keyfile:-}" ]]; then
             echo "Generating new key file ${disk_image}.key of size ${keyfile_size:-64} bytes..."
-            keyfile="$(gen_keyfile ${keyfile_size:-64} ${disk_image}.key)"
+            keyfile=${disk_image}.key
+            gen_keyfile "${keyfile_size:-64}" "${keyfile}"
         fi
-        keyfile_cmd="--key-file=${keyfile}"
+        keyfile_cmd=( "--key-file=${keyfile}" )
         echo "Using key file ${keyfile} for disk encryption..."
-    else err_passphrase_or_keyfile; fi
+    else
+        err_passphrase_or_keyfile
+    fi
 
     echo "Creating encrypted disk..."
-    dd if=/dev/zero of="${tmp_image}" count=$((${disk_size_enc} / 512)) bs=512 &> ${VERBOSE_OUT}
-    sudo losetup ${tmp_loop_device} "${tmp_image}"
+    dd if=/dev/zero of="${tmp_image}" count=$((disk_size_enc / 512)) bs=512 &> ${VERBOSE_OUT}
+    sudo losetup "${tmp_loop_device}" "${tmp_image}"
     echo "Formatting encrypted disk..."
     if [[ ! -z "${passphrase:-}" ]]; then
-        echo -ne "${passphrase}\n" | sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} --type ${type} luksFormat ${tmp_loop_device} --batch-mode ${pbkdf_cmd} --cipher=${cipher} --key-size ${key_size} --hash ${hash} ${integrity_cmd}
+        echo -ne "${passphrase}\n" | sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} --type ${type} luksFormat "${tmp_loop_device}" --batch-mode "${pbkdf_cmd[@]}" --cipher "${cipher}" --key-size "${key_size}" --hash "${hash}" "${integrity_cmd[@]}"
         echo "Opening encrypted disk..."
-        echo -ne "${passphrase}\n" | sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} open ${keyfile_cmd} ${tmp_loop_device} ${tmp_cryptsetup_name}
+        echo -ne "${passphrase}\n" | sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} open "${keyfile_cmd[@]}" "${tmp_loop_device}" "${tmp_cryptsetup_name}"
     else
-        sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} --type ${type} luksFormat ${tmp_loop_device} --batch-mode ${keyfile_cmd} ${pbkdf_cmd} --cipher=${cipher} --key-size ${key_size} --hash ${hash} ${integrity_cmd}
+        sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} --type ${type} luksFormat "${tmp_loop_device}" --batch-mode "${keyfile_cmd[@]}" "${pbkdf_cmd[@]}" --cipher "${cipher}" --key-size "${key_size}" --hash "${hash}" "${integrity_cmd[@]}"
         echo "Opening encrypted disk..."
-        sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} open ${keyfile_cmd} ${tmp_loop_device} ${tmp_cryptsetup_name}
+        sudo cryptsetup ${CRYPTSETUP_VERBOSE_FLAGS} open "${keyfile_cmd[@]}" "${tmp_loop_device}" "${tmp_cryptsetup_name}"
     fi
     sleep 1
     echo "Copying base image to encrypted disk..."
     sudo dd if="${disk_image}" of="/dev/mapper/${tmp_cryptsetup_name}" bs=1M &> ${VERBOSE_OUT}
     sleep 1
-    sudo cryptsetup close ${tmp_cryptsetup_name}
-    sudo losetup -d ${tmp_loop_device}
-    sudo chown ${USER}:${GROUP} "${tmp_image}"
+    sudo cryptsetup close "${tmp_cryptsetup_name}"
+    sudo losetup -d "${tmp_loop_device}"
+    sudo chown "${USER}:${GROUP}" "${tmp_image}"
 
     tmp_loop_device= # Don't try to detach loop device again in clean_exit.
 
@@ -641,28 +656,28 @@ function verity() {
 
     data_blocks=$((${disk_size_enc:-${disk_size}} / 512))
 
-    hash=${hash:-sha256}
+    ver_hash=${ver_hash:-sha256}
 
     echo "Creating integrity-protected (verity) disk..."
     e2fsck -p -f "${disk_image}" > ${VERBOSE_OUT} || true
-    dd if=/dev/zero of="${tmp_image}" count=$((${disk_size_verity} / 512)) bs=512 &> ${VERBOSE_OUT}
-    sudo losetup ${tmp_loop_device} "${tmp_image}"
+    dd if=/dev/zero of="${tmp_image}" count=$((disk_size_verity / 512)) bs=512 &> ${VERBOSE_OUT}
+    sudo losetup "${tmp_loop_device}" "${tmp_image}"
     echo "Copying base image to integrity-protected disk..."
     sudo dd if="${disk_image}" of="${tmp_loop_device}" bs=1M &> ${VERBOSE_OUT}
     echo "Calculating and storing integrity metadata..."
-    verity_out=$(sudo veritysetup ${CRYPTSETUP_VERBOSE_FLAGS} --data-block-size=512 --hash-block-size=512 --data-blocks=${data_blocks} --hash-offset=$((${data_blocks} * 512)) --hash=${hash} format ${tmp_loop_device} ${tmp_loop_device} |& tee ${VERBOSE_OUT})
+    verity_out=$(sudo veritysetup ${CRYPTSETUP_VERBOSE_FLAGS} --data-block-size=512 --hash-block-size=512 --data-blocks=${data_blocks} --hash-offset=$((data_blocks * 512)) --hash="${ver_hash}" format "${tmp_loop_device}" "${tmp_loop_device}" |& tee ${VERBOSE_OUT})
     root_hash=$(echo "${verity_out}" | grep "Root hash:" | cut -f2)
     sleep 1
-    sudo losetup -d ${tmp_loop_device}
-    sudo chown ${USER}:${GROUP} "${tmp_image}"
+    sudo losetup -d "${tmp_loop_device}"
+    sudo chown "${USER}:${GROUP}" "${tmp_image}"
 
     echo "  Hash Algorithm: ${hash}"
-    echo "  Hash Offset: $((${data_blocks} * 512))"
+    echo "  Hash Offset: $((data_blocks * 512))"
     echo "  Root Hash: ${root_hash}"
 
     echo "${root_hash}" > "${disk_image}.roothash"
     echo "Root hash stored in ${disk_image}.roothash."
-    echo "$((${data_blocks} * 512))" > "${disk_image}.hashoffset"
+    echo "$((data_blocks * 512))" > "${disk_image}.hashoffset"
     echo "Hash offset stored in ${disk_image}.hashoffset."
 
     tmp_loop_device= # Don't try to detach loop device again in clean_exit.
@@ -671,17 +686,19 @@ function verity() {
 }
 
 function create() {
-    req_arg "create" "--size" $sz
+    req_arg "create" "--size" "$sz"
 
     disk_size=$(to_bytes "$sz")
-    disk_size=$(( (${disk_size} + 511) / 512 * 512)) # 512 byte alignment
+    disk_size=$(( (disk_size + 511) / 512 * 512)) # 512 byte alignment
 
     if [[ $disk_size -lt $MIN_DISK_SIZE ]]; then
         echo "Requested disk size $sz too small, increasing to $MIN_DISK_SIZE bytes"
         disk_size=$MIN_DISK_SIZE
     fi
 
-    if [[ -e ${disk_image} ]] && [[ ${force} != 1 ]]; then warn_exists ${disk_image}; fi
+    if [[ -e ${disk_image} ]] && [[ ${force} != 1 ]]; then
+        warn_exists "${disk_image}"
+    fi
 
     # Check if we can detect the host DNS server when generating /etc/resolv.conf for the image
     if [[ "$d" = 1 ]] || [[ "$tar" = 1 ]] || [[ "$a" = 1 ]]; then
@@ -692,7 +709,9 @@ function create() {
         fi
     fi
 
-    if [[ ! $(($a + $d + $im + $tar)) == 1 ]] && [[ -z "${copy_src}" ]]; then err_create_op; # Exactly one of the below ops has to be specified.
+    if [[ ! $((a + d + im + tar)) == 1 ]] && [[ -z "${copy_src}" ]]; then
+        # Exactly one of the below ops has to be specified.
+        err_create_op
     elif [ "$a" = 1 ]; then create_from_alpine;
     elif [ "$d" = 1 ]; then create_from_docker;
     elif [ "$im" = 1 ]; then create_from_image;
@@ -702,18 +721,18 @@ function create() {
     luks_header_size=$(to_bytes "6M") # LUKS header size should be <= 6 MiB
 
     # TODO Proper calculation for integrity overhead, currently 15%
-    [[ "$i" == 1 ]] && integrity_overhead=$((${disk_size} / 100 * 15)) || integrity_overhead=0
+    [[ "$i" == 1 ]] && integrity_overhead=$((disk_size * 15 / 100)) || integrity_overhead=0
 
     if [[ "$e" == 1 ]]; then
-        disk_size_enc=$((${disk_size} + ${luks_header_size} + ${integrity_overhead}))
-        disk_size_enc=$(( (${disk_size_enc} + 511) / 512 * 512)) # 512 byte alignment
+        disk_size_enc=$((disk_size + luks_header_size + integrity_overhead))
+        disk_size_enc=$(( (disk_size_enc + 511) / 512 * 512)) # 512 byte alignment
     fi
 
     if [[ "$v" == 1 ]]; then
         # TODO Proper calculation for verity overhead, currently 10%
-        verity_overhead=$((${disk_size} / 10))
-        disk_size_verity=$((${disk_size} + ${luks_header_size} + ${verity_overhead}))
-        disk_size_verity=$(( (${disk_size_verity} + 511) / 512 * 512)) # 512 byte alignment
+        verity_overhead=$((disk_size / 10))
+        disk_size_verity=$((disk_size + luks_header_size + verity_overhead))
+        disk_size_verity=$(( (disk_size_verity + 511) / 512 * 512)) # 512 byte alignment
     fi
 
     if [ "$e" = 1 ]; then encrypt;
@@ -726,20 +745,20 @@ function create() {
 function status() {
     echo "Determining status of ${disk_image}..."
 
-    if [[ "$(is_encrypted ${disk_image})" == "unknown" ]]; then
+    if [[ "$(is_encrypted "${disk_image}")" == "unknown" ]]; then
         echo "Device status cannot be determined because cryptsetup installation could not be found."
         exit 0
-    elif [[ "$(is_encrypted ${disk_image})" == "yes" ]]; then
+    elif [[ "$(is_encrypted "${disk_image}")" == "yes" ]]; then
         echo "Device is encrypted. Cryptsetup info:"
         if [[ ! -z "${passphrase:-}" ]] || [[ ! -z "${keyfile:-}" ]]; then
             tmp_loop_device=$(losetup -f)
-            sudo losetup ${tmp_loop_device} "${disk_image}"
-            crypt_dev_id=$(hash_str ${tmp_loop_device})
+            sudo losetup "${tmp_loop_device}" "${disk_image}"
+            crypt_dev_id=$(hash_str "${tmp_loop_device}")
 
             if [[ ! -z "${passphrase:-}" ]]; then
-                echo -ne "${passphrase}\n" | sudo cryptsetup open ${tmp_loop_device} "${crypt_dev_id}" &> ${VERBOSE_OUT}
+                echo -ne "${passphrase}\n" | sudo cryptsetup open "${tmp_loop_device}" "${crypt_dev_id}" &> ${VERBOSE_OUT}
             elif [[ ! -z "${keyfile:-}" ]]; then
-                sudo cryptsetup open --key-file=${keyfile} ${tmp_loop_device} "${crypt_dev_id}" &> ${VERBOSE_OUT}
+                sudo cryptsetup open --key-file "${keyfile}" "${tmp_loop_device}" "${crypt_dev_id}" &> ${VERBOSE_OUT}
             fi
 
             sudo cryptsetup status "${crypt_dev_id}" | grep -v "is active"
@@ -756,12 +775,14 @@ function status() {
     if [[ "$v" == 1 ]]; then
         if [[ -z "${tmp_loop_device:-}" ]];then
             tmp_loop_device=$(losetup -f)
-            sudo losetup ${tmp_loop_device} "${disk_image}"
+            sudo losetup "${tmp_loop_device}" "${disk_image}"
         fi
-        verity_dev_id=$(hash_str ${tmp_loop_device})
+        verity_dev_id=$(hash_str "${tmp_loop_device}")
         root_hash=$(cat "${disk_image}.roothash")
-        [[ -e "${disk_image}.hashoffset" ]] && hash_offset_parm="--hash-offset=$(cat ${disk_image}.hashoffset)"
-        if sudo veritysetup open ${hash_offset_parm:-} ${tmp_loop_device} "${verity_dev_id}" ${tmp_loop_device} "${root_hash}" &> ${VERBOSE_OUT}; then
+        if [[ -e "${disk_image}.hashoffset" ]]; then
+            hash_offset_parm="--hash-offset=$(cat "${disk_image}.hashoffset")"
+        fi
+        if sudo veritysetup open "${hash_offset_parm:-}" "${tmp_loop_device}" "${verity_dev_id}" "${tmp_loop_device}" "${root_hash}" &> ${VERBOSE_OUT}; then
             echo "Veritysetup info:"
             sudo veritysetup status "${verity_dev_id}" | grep -v "is active"
             sleep 1
@@ -772,28 +793,29 @@ function status() {
 
 function mount_enc() {
     passphrase_cmd=""
-    keyfile_cmd=""
+    keyfile_cmd=( )
     if [[ ! -z "${passphrase:-}" ]]; then
         passphrase_cmd="echo -ne '${passphrase}\n' |"
         echo "Using passphrase for disk decryption..."
     elif [[ "$k" == 1 ]]; then
-        [[ -z "${keyfile}" ]] && keyfile="${disk_image}.key" || true
-        keyfile_cmd="--key-file=${keyfile}"
+        if [[ -z "${keyfile}" ]]; then
+            keyfile="${disk_image}.key"
+        fi
+        keyfile_cmd=( "--key-file=${keyfile}" )
         echo "Using key file ${keyfile} for disk decryption..."
     else err_passphrase_or_keyfile_mount; fi
 
-    #loop_device=$(losetup -f)
     cryptsetup_name=$(cat /proc/sys/kernel/random/uuid)
 
     sudo /bin/bash -euo pipefail -c "\
-        ${passphrase_cmd} cryptsetup open ${keyfile_cmd} ${disk_image} ${cryptsetup_name}; \
+        ${passphrase_cmd} cryptsetup open ${keyfile_cmd[*]} ${disk_image} ${cryptsetup_name}; \
         mount ${mnt_options_cmd} -t ext4 /dev/mapper/${cryptsetup_name} ${mnt_point}; \
-        chown ${USER}:${GROUP} "${mnt_point}"
+        chown ${USER}:${GROUP} ${mnt_point}
     "
 }
 
 function mount() {
-    req_arg "mount" "--mnt-point" $mnt_point
+    req_arg "mount" "--mnt-point" "$mnt_point"
 
     echo "Mounting ${disk_image}..."
 
@@ -805,11 +827,11 @@ function mount() {
         : # TODO veritysetup open
     fi
 
-    if [[ "$(is_encrypted ${disk_image})" == "yes" ]]; then
+    if [[ "$(is_encrypted "${disk_image}")" == "yes" ]]; then
         mount_enc
     else
-        sudo mount ${mnt_options_cmd} -t ext4 -o loop ${disk_image} ${mnt_point}
-        sudo chown ${USER}:${GROUP} "${mnt_point}"
+        sudo mount ${mnt_options_cmd} -t ext4 -o loop "${disk_image}" "${mnt_point}"
+        sudo chown "${USER}:${GROUP}" "${mnt_point}"
     fi
 
     echo "Successfully mounted ${disk_image} at ${mnt_point}";
@@ -830,11 +852,13 @@ function unmount() {
 
     sudo umount "${mnt_point}"
     # TODO veritysetup/integritysetup
-    [[ ! -z "${dm_target:-}" ]] && sudo cryptsetup close "${dm_target}" || true
+    if [[ ! -z "${dm_target:-}" ]]; then
+        sudo cryptsetup close "${dm_target}"
+    fi
 
     echo "Deleting empty mount point directory ${mnt_point}..."
     if [[ -d "${mnt_point}" ]] && [[ -z "$(ls -A "${mnt_point}")" ]]; then
-        rm -r ${mnt_point}
+        rm -r "${mnt_point}"
     fi
 
     echo "Successfully unmounted ${mnt_point}";
@@ -866,10 +890,9 @@ H,hash,: \
 v,verity,:: \
 I,integrity,:: \
 S,size,: \
-,roothash,: \
 "
 
-c=0 s=0 m=0 u=0 M=0 a=0 d=0 e=0 i=0 v=0 im=0 tar=0 sz=0 k=0 copy_src="" force=0
+c=0 s=0 m=0 u=0 a=0 d=0 e=0 i=0 v=0 im=0 tar=0 sz=0 k=0 copy_src="" force=0
 
 # Exit with a help text if no command line parameters are given
 [[ $# -eq 0 ]] && usage && exit 0
@@ -907,7 +930,7 @@ for OPT in "${OPTS_ARR[@]}"; do
     LONGOPTS="${LONGOPTS:-}${LONGOPT}${OPT_ARG_REQ},"
 done
 
-if ! ARGS=$(getopt --options=$SHORTOPTS --longoptions=$LONGOPTS --name "$0" -- "$@"); then
+if ! ARGS=$(getopt --options="$SHORTOPTS" --longoptions="$LONGOPTS" --name "$0" -- "$@"); then
     exit 2
 fi
 eval set -- "$ARGS"
@@ -941,13 +964,13 @@ while true; do
             shift
             ;;
         -a|--alpine)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             a=1
             alpine_pkgs=$2
             shift 2
             ;;
         -d|--docker)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             req docker
             d=1
             if [[ -e "$2" ]]; then
@@ -962,18 +985,18 @@ while true; do
             shift
             ;;
         -C|--copy)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             copy_src="$2"
             shift 2
             ;;
         -i|--from-image)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             im=1
             image_src=$2
             shift 2
             ;;
         -t|--from-tarfile)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             tar=1
             image_src=$2
             shift 2
@@ -983,12 +1006,12 @@ while true; do
             shift
             ;;
         --cipher)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             cipher="$2"
             shift 2
             ;;
         -p|--passphrase)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             passphrase="$2"
             shift 2
             ;;
@@ -1004,18 +1027,18 @@ while true; do
             shift 2
             ;;
         --keyfile-size)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             keyfile_size="$2"
             shift 2
             ;;
         -P|--pbkdf)
             req_cryptsetup_version "2.0.0" "--pbkdf"
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             pbkdf="$2"
             shift 2
             ;;
         -H|--hash)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             hash="$2"
             shift 2
             ;;
@@ -1028,27 +1051,22 @@ while true; do
             ;;
         -v|--verity)
             v=1
-            if [[ -z "$2" ]]; then ver_alg="sha256"; else ver_alg=$2; shift; fi
+            if [[ -z "$2" ]]; then ver_hash="sha256"; else ver_hash=$2; shift; fi
             shift 2
             ;;
         -S|--size)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             sz="$2"
             shift 2
             ;;
         --mnt-point)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             mnt_point="$2"
             shift 2
             ;;
         --mnt-options)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
+            if [[ $2 == -* ]]; then err_req_arg "$1"; fi
             mnt_options="$2"
-            shift 2
-            ;;
-        --roothash)
-            if [[ $2 == -* ]]; then err_req_arg $1; fi
-            roothash_file="$2"
             shift 2
             ;;
         --)
@@ -1069,7 +1087,7 @@ fi
 
 [[ "$u" == 1 ]] && mnt_point=$1 || disk_image=$1
 
-if [[ ! $(($c + $s + $m + $u)) == 1 ]]; then err_op; # Exactly one of the below ops has to be specified.
+if [[ ! $((c + s + m + u)) == 1 ]]; then err_op; # Exactly one of the below ops has to be specified.
 elif [ "$c" = 1 ]; then create;
 elif [ "$s" = 1 ]; then status;
 elif [ "$m" = 1 ]; then mount;

--- a/tools/sgx-lkl-disk
+++ b/tools/sgx-lkl-disk
@@ -22,7 +22,7 @@ CRYPTSETUP_VERBOSE_FLAGS=""
 
 SYSDIRS=(dev mnt tmp sys run proc)
 
-USER=$(who am i | awk '{print $1}')
+USER=$(id -un)
 GROUP=$(id -gn "${USER}")
 
 # The lowest possible ext4 size seems to be ~140K. To be on the safe side, we require 512K.

--- a/tools/sgx-lkl-docker
+++ b/tools/sgx-lkl-docker
@@ -20,7 +20,7 @@ fi
 
 function usage() {
     echo "Usage:"
-    echo "`basename $0` <command>"
+    echo "$(basename "$0") <command>"
     echo
     echo "where <command> is one of the following:"
     echo "  build                                              Re-package disk images and configuration as Docker image" 
@@ -40,7 +40,7 @@ function build() {
     context_dir=$(mktemp -d sgxlkl_docker_context_XXXX)
     echo "Using temporary directory ${context_dir}"
 
-    cat >>${context_dir}/Dockerfile << EOF
+    cat >>"${context_dir}/Dockerfile" << EOF
 FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y ca-certificates
 
@@ -87,25 +87,25 @@ ENTRYPOINT ["/opt/sgx-lkl/lib/external/ld-linux-x86-64", "/opt/sgx-lkl/bin/sgx-l
 CMD ["--hw-release"]
 EOF
 
-    cp ${cc_app_cfg} ${context_dir}/app-cfg.json
+    cp "${cc_app_cfg}" "${context_dir}/app-cfg.json"
 
-    disk_paths=$(${cmd_root}/sgx-lkl-cfg dockerize \
+    disk_paths=$("${cmd_root}/sgx-lkl-cfg" dockerize \
         --host-cfg=${cc_host_cfg} \
-        --host-cfg-docker=${context_dir}/host-cfg.json \
+        --host-cfg-docker="${context_dir}/host-cfg.json" \
         --print-disk-paths)
     
     while IFS= read -r line; do
         IFS=':' read -ra entry <<< "$line"
         img_path=${entry[0]}
         img_docker_path=${entry[1]}
-        cp $img_path $context_dir/$img_docker_path
+        cp "$img_path" "$context_dir/$img_docker_path"
     done <<< "${disk_paths}"
     
-    docker build -t $cc_name $context_dir
+    docker build -t $cc_name "$context_dir"
 
     echo "Done. Tagged '$cc_name'."
 
-    rm -rf $context_dir
+    rm -rf "$context_dir"
 }
 
 function main() {

--- a/tools/sgx-lkl-java
+++ b/tools/sgx-lkl-java
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# shellcheck disable=SC2086,SC2124
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 EXECUTION_MODE=$1

--- a/tools/sgx-lkl-setup
+++ b/tools/sgx-lkl-setup
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-SGXLKL_ROOT=`dirname "$0"`/..
+SGXLKL_ROOT=$(dirname "$0")/..
 
 echo -n "Creating tap network device for SGX-LKL..."
-sudo ip tuntap add dev sgxlkl_tap0 mode tap user `whoami`
+sudo ip tuntap add dev sgxlkl_tap0 mode tap user "$(whoami)"
 sudo ip link set dev sgxlkl_tap0 up
 sudo ip addr add dev sgxlkl_tap0 10.0.1.254/24
 echo "Done"
@@ -27,7 +27,7 @@ echo "Done"
 
 if [[ -f ${SGXLKL_ROOT}/tools/kmod-set-fsgsbase ]]; then
     echo "Setting up Linux kernel module to support userspace FSGSBase..."
-    sudo insmod ${SGXLKL_ROOT}/tools/kmod-set-fsgsbase/mod_set_cr4_fsgsbase.ko val=1
+    sudo insmod "${SGXLKL_ROOT}/tools/kmod-set-fsgsbase/mod_set_cr4_fsgsbase.ko" val=1
     sudo rmmod mod_set_cr4_fsgsbase
     dmesg | tail -n 10
     echo "Done"


### PR DESCRIPTION
This PR is copying some of the pre-commit scripts from OE. Currently I only enabled linting of shell scripts using `shellcheck` and fixed corresponding issues. There's also code formatting using `clang-format` but since this is much more disruptive I will enable that (and re-format code) once we agreed on the right strategic time for it.

cc @wintersteiger 