### PR TITLE
Use fresh copy of image for each LTP test

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -52,23 +52,23 @@ run-sw: $(ROOT_FS)
 	@${LTP_TEST_SCRIPT} run-sw
 
 run-hw-single: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --hw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-sw-single: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --sw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-hw-single-gdb: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-sw-single-gdb: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 clean:

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -52,18 +52,22 @@ run-sw: $(ROOT_FS)
 	@${LTP_TEST_SCRIPT} run-sw
 
 run-hw-single: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --hw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-sw-single: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --sw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-hw-single-gdb: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-sw-single-gdb: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS_FRESH_COPY) $(test)
 

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -4,7 +4,8 @@ ALPINE_MAJOR=3.8
 ALPINE_VERSION=3.8.0
 ALPINE_ARCH=x86_64
 
-ROOT_FS=sgxlkl-miniroot-fs.img
+ROOT_FS=sgxlkl-miniroot-fs.img.master
+ROOT_FS_FRESH_COPY=sgxlkl-miniroot-fs.img
 ALPINE_TAR=alpine-minirootfs.tar.gz
 MOUNTPOINT=/media/ext4disk
 IMAGE_SIZE_MB=1500
@@ -51,19 +52,24 @@ run-sw: $(ROOT_FS)
 	@${LTP_TEST_SCRIPT} run-sw
 
 run-hw-single: $(ROOT_FS)
-	${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	${SGXLKL_STARTER} --hw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-sw-single: $(ROOT_FS)
-	${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	${SGXLKL_STARTER} --sw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-hw-single-gdb: $(ROOT_FS)
-	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 run-sw-single-gdb: $(ROOT_FS)
-	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS_FRESH_COPY) $(test)
 
 clean:
 	@test -f $(ALPINE_TAR) && rm $(ALPINE_TAR) || true
 	@test -f $(ROOT_FS) && rm $(ROOT_FS) || true
+	@test -f $(ROOT_FS_FRESH_COPY) && rm $(ROOT_FS_FRESH_COPY) || true
 	@rm -f .c_binaries_list
 

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -52,18 +52,22 @@ run-sw: $(ROOT_FS)
 	@${LTP_TEST_SCRIPT} run-sw
 
 run-hw-single: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
 
 run-sw-single: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 
 run-hw-single-gdb: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
 
 run-sw-single-gdb: $(ROOT_FS)
+	@rm -fr $(ROOT_FS_FRESH_COPY)
 	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -52,23 +52,23 @@ run-sw: $(ROOT_FS)
 	@${LTP_TEST_SCRIPT} run-sw
 
 run-hw-single: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
 
 run-sw-single: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 
 run-hw-single-gdb: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
 
 run-sw-single-gdb: $(ROOT_FS)
-	@rm -fr $(ROOT_FS_FRESH_COPY)
-	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
+	@rm -f $(ROOT_FS_FRESH_COPY)
+	@cp $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 
 clean:

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -4,7 +4,8 @@ ALPINE_MAJOR=3.8
 ALPINE_VERSION=3.8.0
 ALPINE_ARCH=x86_64
 
-ROOT_FS=sgxlkl-miniroot-fs.img
+ROOT_FS=sgxlkl-miniroot-fs.img.master
+ROOT_FS_FRESH_COPY=sgxlkl-miniroot-fs.img
 ALPINE_TAR=alpine-minirootfs.tar.gz
 MOUNTPOINT=/media/ext4disk
 IMAGE_SIZE_MB=1500
@@ -51,19 +52,24 @@ run-sw: $(ROOT_FS)
 	@${LTP_TEST_SCRIPT} run-sw
 
 run-hw-single: $(ROOT_FS)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
 
 run-sw-single: $(ROOT_FS)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 
 run-hw-single-gdb: $(ROOT_FS)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug $(ROOT_FS) $(test)
 
 run-sw-single-gdb: $(ROOT_FS)
+	@cp -f $(ROOT_FS) $(ROOT_FS_FRESH_COPY)
 	${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug $(ROOT_FS) $(test)
 
 clean:
 	@test -f $(ALPINE_TAR) && rm $(ALPINE_TAR) || true
 	@test -f $(ROOT_FS) && rm $(ROOT_FS) || true
+	@test -f $(ROOT_FS_FRESH_COPY) && rm $(ROOT_FS_FRESH_COPY) || true
 	@rm -f .c_binaries_list
 

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -73,8 +73,8 @@ for file in "${ltp_tests[@]}"; do
 
     # Master copy of image is sgxlkl-miniroot-fs.img.master
     # Before running each test copy a fresh copy of image
-    rm -fr sgxlkl-miniroot-fs.img
-    cp -f sgxlkl-miniroot-fs.img.master sgxlkl-miniroot-fs.img
+    rm -f sgxlkl-miniroot-fs.img
+    cp sgxlkl-miniroot-fs.img.master sgxlkl-miniroot-fs.img
     cp_exit_code=$?
     if [[ $cp_exit_code -ne 0 ]]; then
       echo "Cannot find sgxlkl-miniroot-fs.img.master"

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -80,7 +80,7 @@ for file in "${ltp_tests[@]}"; do
     fi
 
     echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout ${SGX_LKL_RUN_CMD[*]} $file > $stdout_file 2>&1"
-    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout "${SGX_LKL_RUN_CMD[@]}" "$file" > "$stdout_file" 2>&
+    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout "${SGX_LKL_RUN_CMD[@]}" "$file" > "$stdout_file" 2>&1
     exit_code=$?
     if [[ $exit_code -eq  124 ]]; then
         echo "${SGX_LKL_RUN_CMD[*]} $file : TIMED OUT after $timeout secs"

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -74,6 +74,11 @@ for file in "${ltp_tests[@]}"; do
     # Master copy of image is sgxlkl-miniroot-fs.img.master
     # Before running each test copy a fresh copy of image
     cp -f sgxlkl-miniroot-fs.img.master sgxlkl-miniroot-fs.img
+    if [[ $? -ne 0 ]]; then
+      echo "Cannot find sgxlkl-miniroot-fs.img.master"
+      exit 1
+    fi
+
     echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > \"$stdout_file\" 2>&1"
     SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > "$stdout_file" 2>&1
     exit_code=$?

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -79,8 +79,8 @@ for file in "${ltp_tests[@]}"; do
       exit 1
     fi
 
-    echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > \"$stdout_file\" 2>&1"
-    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > "$stdout_file" 2>&1
+    echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout ${SGX_LKL_RUN_CMD[*]} $file > $stdout_file 2>&1"
+    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout "${SGX_LKL_RUN_CMD[@]}" "$file" > "$stdout_file" 2>&
     exit_code=$?
     if [[ $exit_code -eq  124 ]]; then
         echo "${SGX_LKL_RUN_CMD[*]} $file : TIMED OUT after $timeout secs"

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -71,8 +71,11 @@ for file in "${ltp_tests[@]}"; do
     # Start the test timer.
     JunitTestStarted "$test_name"
 
-    echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout ${SGX_LKL_RUN_CMD[*]} $file > $stdout_file 2>&1"
-    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout "${SGX_LKL_RUN_CMD[@]}" "$file" > "$stdout_file" 2>&1
+    # Master copy of image is sgxlkl-miniroot-fs.img.master
+    # Before running each test copy a fresh copy of image
+    cp -f sgxlkl-miniroot-fs.img.master sgxlkl-miniroot-fs.img
+    echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > \"$stdout_file\" 2>&1"
+    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout $SGX_LKL_RUN_CMD $file > "$stdout_file" 2>&1
     exit_code=$?
     if [[ $exit_code -eq  124 ]]; then
         echo "${SGX_LKL_RUN_CMD[*]} $file : TIMED OUT after $timeout secs"

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -74,7 +74,8 @@ for file in "${ltp_tests[@]}"; do
     # Master copy of image is sgxlkl-miniroot-fs.img.master
     # Before running each test copy a fresh copy of image
     cp -f sgxlkl-miniroot-fs.img.master sgxlkl-miniroot-fs.img
-    if [[ $? -ne 0 ]]; then
+    cp_exit_code=$?
+    if [[ $cp_exit_code -ne 0 ]]; then
       echo "Cannot find sgxlkl-miniroot-fs.img.master"
       exit 1
     fi

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -73,6 +73,7 @@ for file in "${ltp_tests[@]}"; do
 
     # Master copy of image is sgxlkl-miniroot-fs.img.master
     # Before running each test copy a fresh copy of image
+    rm -fr sgxlkl-miniroot-fs.img
     cp -f sgxlkl-miniroot-fs.img.master sgxlkl-miniroot-fs.img
     cp_exit_code=$?
     if [[ $cp_exit_code -ne 0 ]]; then


### PR DESCRIPTION
Currently we are using same image file for each LTP test.
If any test corrupts the image file (like mounting /dev/vda) it will affect following tests.
With this change we are creating a fresh copy of master/original image for each LTP test.

cc @prp @letmaik 