### PR TITLE
fix: wireguard peer configuration without mandatory endpoint

### DIFF
--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -876,9 +876,16 @@ void set_wg(sgxlkl_config_t* conf)
         char* ips = strchrnul(key, ':');
         *ips = '\0';
         ips++;
+
         char* ips_end = strchrnul(ips, ':');
-        *ips_end = '\0';
-        char* endpoint = ++ips_end;
+	// another ':', possible endpoint following, need to advance string
+        if (*ips_end == ':')
+	{
+	    *ips_end = '\0';
+	    ips_end++;
+	}
+
+        char* endpoint = ips_end;
         peers_str = strchrnul(endpoint, ',');
         if (*peers_str == ',')
         {

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -308,7 +308,7 @@ static void help_config()
         "%-35s %s",
         "  SGXLKL_WG_PEERS",
         "Comma-separated list of Wireguard peers in the format "
-        "\"key1:allowedips1:endpointhost1:port1, key2:allowedips2, key3:...\".\n");
+        "\"{key 1}:{allowed IPs 1}:{endpoint host 1}:{port 1}, {key 2}:{allowed IPs 2}, {key 3}:...\".\n");
     printf("## Disk ##\n");
     printf(
         "%-35s %s",

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -308,7 +308,7 @@ static void help_config()
         "%-35s %s",
         "  SGXLKL_WG_PEERS",
         "Comma-separated list of Wireguard peers in the format "
-        "\"key1:allowedips1:endpointhost1:port1, key2:allowedips2:...\".\n");
+        "\"key1:allowedips1:endpointhost1:port1, key2:allowedips2, key3:...\".\n");
     printf("## Disk ##\n");
     printf(
         "%-35s %s",

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -880,10 +880,10 @@ void set_wg(sgxlkl_config_t* conf)
         char* ips_end = strchrnul(ips, ':');
 	// another ':', possible endpoint following, need to advance string
         if (*ips_end == ':')
-	{
+        {
 	    *ips_end = '\0';
 	    ips_end++;
-	}
+        }
 
         char* endpoint = ips_end;
         peers_str = strchrnul(endpoint, ',');

--- a/src/wireguard/wireguard_util.c
+++ b/src/wireguard/wireguard_util.c
@@ -271,12 +271,6 @@ int wgu_add_peers(
                         "ips configuration.\n");
             continue;
         }
-        if (!peers[i].endpoint || !strlen(peers[i].endpoint))
-        {
-            sgxlkl_warn(
-                "Unable to add wireguard peer due to missing endpoint.\n");
-            continue;
-        }
 
         memset(&new_peers[i], 0, sizeof(new_peers[i]));
         new_peers[i].flags = WGPEER_HAS_PUBLIC_KEY | WGPEER_REPLACE_ALLOWEDIPS;
@@ -294,11 +288,12 @@ int wgu_add_peers(
             goto err;
         }
 
-        if (!wgu_parse_endpoint(&new_peers[i].endpoint.addr, peer_cfg.endpoint))
+        if (peers[i].endpoint && strlen(peers[i].endpoint) && !wgu_parse_endpoint(&new_peers[i].endpoint.addr, peer_cfg.endpoint))
         {
             ret = -EINVAL;
             goto err;
         }
+
     }
 
     for (int i = 0; i < num_peers; i++)

--- a/src/wireguard/wireguard_util.c
+++ b/src/wireguard/wireguard_util.c
@@ -293,7 +293,6 @@ int wgu_add_peers(
             ret = -EINVAL;
             goto err;
         }
-
     }
 
     for (int i = 0; i < num_peers; i++)


### PR DESCRIPTION
Wireguard peers do not necessarily need an endpoint, as long as the other side (the enclave) provides an endpoint. I therefore removed the endpoint checks where necessary. This enables users to remotely attest and control enclaves behind NAT.