### PR TITLE
CI: add missing package python3-setuptools

### DIFF
--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y \
     make gcc g++ bc python xutils-dev flex bison autogen libgcrypt20-dev libjson-c-dev \
     autopoint pkgconf autoconf libtool libcurl4-openssl-dev libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler libssl-dev \
     ninja-build ansible "linux-headers-$(uname -r)" \
-    python3 python3-pip unzip dkms debhelper apt-utils pax-utils openjdk-8-jdk-headless \
+    python3 python3-setuptools python3-pip unzip dkms debhelper apt-utils pax-utils openjdk-8-jdk-headless \
     expect \
     shellcheck clang-format
 


### PR DESCRIPTION
This prevented installing sdist packages. It failed only in the publish stage because the VM environment is different (hosted agent vs scaleset pool).

Fixes https://dev.azure.com/sgx-lkl/sgx-lkl/_build/results?buildId=1007&view=results.