### PR TITLE
Move ignored / unsupported syscalls into the kernel.

### DIFF
--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -13,8 +13,6 @@ void sgxlkl_warn(char* msg, ...);
 
 void sgxlkl_info(char* msg, ...);
 
-void __sgxlkl_log_syscall(int type, long n, long res, int params_len, ...);
-
 int int_log2(unsigned long long arg);
 
 #ifdef DEBUG

--- a/src/include/lkl/lkl_util.h
+++ b/src/include/lkl/lkl_util.h
@@ -3,6 +3,10 @@
 
 #include <openenclave/enclave.h>
 
+// Eventually we will want to turn system call tracing on and off independently
+// of the debug configuration, but for now they are the same.
+#define SGXLKL_ENABLE_SYSCALL_TRACING DEBUG
+
 /**
  * The mechanism used to implement a specified system call.
  */
@@ -45,7 +49,7 @@ typedef enum
  * This function returns `res`, so that it can be tail called on the return
  * path.
  */
-#if DEBUG
+#if SGXLKL_ENABLE_SYSCALL_TRACING
 long __sgxlkl_log_syscall(
     sgxlkl_syscall_kind type,
     long n,

--- a/src/include/lkl/lkl_util.h
+++ b/src/include/lkl/lkl_util.h
@@ -3,13 +3,66 @@
 
 #include <openenclave/enclave.h>
 
-#define SGXLKL_LKL_SYSCALL 1
-#define SGXLKL_INTERNAL_SYSCALL 3
-#define SGXLKL_IGNORED_SYSCALL 4
-#define SGXLKL_UNSUPPORTED_SYSCALL 5
-#define SGXLKL_REDIRECT_SYSCALL 6
+/**
+ * The mechanism used to implement a specified system call.
+ */
+typedef enum
+{
+    /**
+     * System calls that are implemented by LKL as a normal Linux system call.
+     */
+    SGXLKL_LKL_SYSCALL = 1,
+    /**
+     * System calls that are implemented using SGX-LKL custom code paths that
+     * bypass the Linux kernel.  Eventually, these will all be replaced.
+     */
+    SGXLKL_INTERNAL_SYSCALL = 3,
+    /**
+     * System calls that are not possible to implement in an SGX environment but
+     * software that expects it to work can act as if it does.  For example,
+     * `mlock` is ignored because memory is all locked by the SGX environment.
+     */
+    SGXLKL_IGNORED_SYSCALL = 4,
+    /**
+     * System calls that are not supported in the SGX
+     * environment at all and which callers may handle.
+     */
+    SGXLKL_UNSUPPORTED_SYSCALL = 5,
+    /**
+     * System calls that were invoked using the normal
+     * architecture's system call numbers and
+     * redirected.
+     */
+    SGXLKL_REDIRECT_SYSCALL = 6,
+} sgxlkl_syscall_kind;
 
-void __sgxlkl_log_syscall(int type, long n, long res, int params_len, ...);
+/**
+ * Logs a trace message for the specified syscall.  The type argument
+ * identifies how the system call is implemented, `n` gives the number of
+ * parameters, `res` the result value. There are `params_len` variadic
+ * parameters (0 to 6) that give the arguments for the system call.
+ *
+ * This function returns `res`, so that it can be tail called on the return
+ * path.
+ */
+#if DEBUG
+long __sgxlkl_log_syscall(
+    sgxlkl_syscall_kind type,
+    long n,
+    long res,
+    int params_len,
+    ...);
+#else
+static inline long __sgxlkl_log_syscall(
+    sgxlkl_syscall_kind type,
+    long n,
+    long res,
+    int params_len,
+    ...)
+{
+	return res;
+}
+#endif
 
 int int_log2(unsigned long long arg);
 
@@ -99,8 +152,8 @@ extern int sgxlkl_trace_redirect_syscall;
         oe_host_printf("[[  SIGNAL  ]] " x, ##__VA_ARGS__); \
     }
 
-#define SGXLKL_TRACE_DISK(x, ...)                         \
-    if (sgxlkl_trace_disk)                                \
+#define SGXLKL_TRACE_DISK(x, ...)                           \
+    if (sgxlkl_trace_disk)                                  \
     {                                                       \
         oe_host_printf("[[   DISK   ]] " x, ##__VA_ARGS__); \
     }

--- a/src/lkl/lkl_util.c
+++ b/src/lkl/lkl_util.c
@@ -106,22 +106,22 @@ static void parse_epoll_event_flags(
     buf[0] = '\0';
 }
 
-void __sgxlkl_log_syscall(int type, long n, long res, int params_len, ...)
+long __sgxlkl_log_syscall(sgxlkl_syscall_kind type, long n, long res, int params_len, ...)
 {
     const char* name = NULL;
     char errmsg[255] = {0};
 
     if (!sgxlkl_trace_ignored_syscall && type == SGXLKL_IGNORED_SYSCALL)
-        return;
+        return res;
 
     if (!sgxlkl_trace_unsupported_syscall && type == SGXLKL_UNSUPPORTED_SYSCALL)
-        return;
+        return res;
 
     if (!sgxlkl_trace_lkl_syscall && type == SGXLKL_LKL_SYSCALL)
-        return;
+        return res;
 
     if (!sgxlkl_trace_internal_syscall && type == SGXLKL_INTERNAL_SYSCALL)
-        return;
+        return res;
 
     long params[6] = {0};
     va_list valist;
@@ -282,14 +282,6 @@ void __sgxlkl_log_syscall(int type, long n, long res, int params_len, ...)
             res,
             errmsg);
     }
-}
-#else
-inline void __sgxlkl_log_syscall(
-    int type,
-    long n,
-    long res,
-    int params_len,
-    ...)
-{ /* empty */
+	return res;
 }
 #endif /* DEBUG */

--- a/src/lkl/syscall-overrides-fstat.c
+++ b/src/lkl/syscall-overrides-fstat.c
@@ -74,8 +74,8 @@ void syscall_register_fstat_overrides()
 {
     orig_fstat = (syscall_fstat_handler)lkl_replace_syscall(
         __lkl__NR_fstat,
-        (syscall_fstat_handler)syscall_fstat_override);
+        (lkl_syscall_handler_t)syscall_fstat_override);
     orig_newfstatat = (syscall_newfstatat_handler)lkl_replace_syscall(
         __lkl__NR_newfstatat,
-        (syscall_fstat_handler)syscall_newfstatat_override);
+        (lkl_syscall_handler_t)syscall_newfstatat_override);
 }

--- a/src/lkl/syscall-overrides.c
+++ b/src/lkl/syscall-overrides.c
@@ -1,10 +1,73 @@
+#include <asm-generic/errno.h>
 #include <sys/syscall.h>
+#include "lkl/posix-host.h"
 #include "lkl/syscall-overrides-fstat.h"
 #include "lkl/syscall-overrides-sysinfo.h"
-#include "lkl/posix-host.h"
+
+/**
+ * List of system calls that we treat as no-ops that silently succeed.  The
+ * mlock family may be removed from this list if we transition to using the
+ * Linux built-in nommu mode for mmap, because then Linux should silently ignore
+ * them.
+ *
+ * We ignore sched_setaffinity because the Linux scheduler is not responsible
+ * for scheduling userspace threads in the LKL model and so cannot support this
+ * call.  The lthread scheduler could be extended to provide ethread affinity
+ * but does not currently.  We silently report success because it keeps OpenMP
+ * runtimes and similar code quiet.
+ */
+static const long ignored_syscalls[] = {__lkl__NR_mlock,
+                                        __lkl__NR_mlockall,
+                                        __lkl__NR_munlock,
+                                        __lkl__NR_munlockall,
+                                        __lkl__NR_sched_setaffinity};
+
+/**
+ * List of system calls that can't work properly in this environment that we
+ * report failure to the program.  Currently, this is only brk, which would
+ * work if we used the nommu code from Linux for our memory management.
+ */
+static const long unsupported_syscalls[] = {
+    // FIXME: Should sbrk be on this list?
+    __lkl__NR_brk};
+
+/**
+ * Function used to implement silently ignored system calls.  Ignores all
+ * arguments and returns success.
+ */
+static long ignored_syscall()
+{
+    return 0;
+}
+
+/**
+ * Function used to implement unsupported system calls.  Ignores all arguments
+ * and returns a not-implemented error.
+ */
+static long unsupported_syscall()
+{
+    return -ENOSYS;
+}
 
 void register_lkl_syscall_overrides()
 {
     syscall_register_fstat_overrides();
-    lkl_replace_syscall(__lkl__NR_sysinfo, syscall_sysinfo_override);
+    lkl_replace_syscall(
+        __lkl__NR_sysinfo, (lkl_syscall_handler_t)syscall_sysinfo_override);
+    // Register all of the ignored system calls.
+    for (int i = 0; i < (sizeof(ignored_syscalls) / sizeof(*ignored_syscalls));
+         i++)
+    {
+        lkl_replace_syscall(
+            ignored_syscalls[i], (lkl_syscall_handler_t)ignored_syscall);
+    }
+    // Register all of the unsupported system calls.
+    for (int i = 0;
+         i < (sizeof(unsupported_syscalls) / sizeof(*unsupported_syscalls));
+         i++)
+    {
+        lkl_replace_syscall(
+            unsupported_syscalls[i],
+            (lkl_syscall_handler_t)unsupported_syscall);
+    }
 }

--- a/src/lkl/syscall-overrides.c
+++ b/src/lkl/syscall-overrides.c
@@ -1,73 +1,254 @@
 #include <asm-generic/errno.h>
 #include <sys/syscall.h>
+#include "lkl/lkl_util.h"
 #include "lkl/posix-host.h"
 #include "lkl/syscall-overrides-fstat.h"
 #include "lkl/syscall-overrides-sysinfo.h"
 
 /**
- * List of system calls that we treat as no-ops that silently succeed.  The
- * mlock family may be removed from this list if we transition to using the
- * Linux built-in nommu mode for mmap, because then Linux should silently ignore
- * them.
- *
- * We ignore sched_setaffinity because the Linux scheduler is not responsible
- * for scheduling userspace threads in the LKL model and so cannot support this
- * call.  The lthread scheduler could be extended to provide ethread affinity
- * but does not currently.  We silently report success because it keeps OpenMP
- * runtimes and similar code quiet.
+ * Macros for generating functions for implementing ignored system calls and
+ * for their log variants.
  */
-static const long ignored_syscalls[] = {__lkl__NR_mlock,
-                                        __lkl__NR_mlockall,
-                                        __lkl__NR_munlock,
-                                        __lkl__NR_munlockall,
-                                        __lkl__NR_sched_setaffinity};
-
-/**
- * List of system calls that can't work properly in this environment that we
- * report failure to the program.  Currently, this is only brk, which would
- * work if we used the nommu code from Linux for our memory management.
- */
-static const long unsupported_syscalls[] = {
-    // FIXME: Should sbrk be on this list?
-    __lkl__NR_brk};
-
-/**
- * Function used to implement silently ignored system calls.  Ignores all
- * arguments and returns success.
- */
-static long ignored_syscall()
-{
-    return 0;
-}
-
+#if DEBUG
+#define IGNORED_SYSCALL(name, args)                           \
+    static long ignore##name(                                 \
+        long a1, long a2, long a3, long a4, long a5, long a6) \
+    {                                                         \
+        return 0;                                             \
+    }                                                         \
+    static long log_and_ignore##name(                         \
+        long a1, long a2, long a3, long a4, long a5, long a6) \
+    {                                                         \
+        return __sgxlkl_log_syscall(                          \
+            SGXLKL_IGNORED_SYSCALL,                           \
+            __lkl__NR##name,                                  \
+            0,                                                \
+            args,                                             \
+            a1,                                               \
+            a2,                                               \
+            a3,                                               \
+            a4,                                               \
+            a5,                                               \
+            a6);                                              \
+    }
+#else
+#define IGNORED_SYSCALL(name, args)                           \
+    static long ignore##name(                                 \
+        long a1, long a2, long a3, long a4, long a5, long a6) \
+    {                                                         \
+        return 0;                                             \
+    }
+#endif
 /**
  * Function used to implement unsupported system calls.  Ignores all arguments
- * and returns a not-implemented error.
+ * and returns a not-implemented error.  The log variant logs that the system
+ * call was unsupported.
  */
-static long unsupported_syscall()
-{
-    return -ENOSYS;
-}
+#if DEBUG
+#define UNSUPPORTED_SYSCALL(name, args)                       \
+    static long unsupported##name()                           \
+    {                                                         \
+        return -ENOSYS;                                       \
+    }                                                         \
+                                                              \
+    static long log_unsupported##name(                        \
+        long a1, long a2, long a3, long a4, long a5, long a6) \
+    {                                                         \
+        return __sgxlkl_log_syscall(                          \
+            SGXLKL_UNSUPPORTED_SYSCALL,                       \
+            __lkl__NR##name,                                  \
+            -ENOSYS,                                          \
+            args,                                             \
+            a1,                                               \
+            a2,                                               \
+            a3,                                               \
+            a4,                                               \
+            a5,                                               \
+            a6);                                              \
+    }
+#else
+#define UNSUPPORTED_SYSCALL(name, args)                       \
+    static long unsupported##name()                           \
+    {                                                         \
+        return -ENOSYS;                                       \
+    }
+#endif
+
+#include "unsupported-syscalls.h"
+
+#if DEBUG
+static lkl_syscall_handler_t real_syscalls[__lkl__NR_syscalls];
+
+#undef LKL_SYSCALL_DEFINE0
+#undef LKL_SYSCALL_DEFINE1
+#undef LKL_SYSCALL_DEFINE2
+#undef LKL_SYSCALL_DEFINE3
+#undef LKL_SYSCALL_DEFINE4
+#undef LKL_SYSCALL_DEFINE5
+#undef LKL_SYSCALL_DEFINE6
+#define LKL_SYSCALL_DEFINE0(name, ...)                                     \
+    static long log##name()                                                \
+    {                                                                      \
+        int ret = ((int (*)(void))real_syscalls[__lkl__NR##name])();       \
+        __sgxlkl_log_syscall(SGXLKL_LKL_SYSCALL, __lkl__NR##name, 1, ret); \
+        return ret;                                                        \
+    }
+
+#define LKL_SYSCALL_DEFINE1(name, t1, a1)                                      \
+    static long log##name(t1 a1)                                               \
+    {                                                                          \
+        int ret = ((int (*)(t1))real_syscalls[__lkl__NR##name])(a1);           \
+        __sgxlkl_log_syscall(SGXLKL_LKL_SYSCALL, __lkl__NR##name, 1, ret, a1); \
+        return ret;                                                            \
+    }
+
+#define LKL_SYSCALL_DEFINE2(name, t1, a1, t2, a2)                            \
+    static long log##name(t1 a1, t2 a2)                                      \
+    {                                                                        \
+        int ret = ((int (*)(t1, t2))real_syscalls[__lkl__NR##name])(a1, a2); \
+        __sgxlkl_log_syscall(                                                \
+            SGXLKL_LKL_SYSCALL, __lkl__NR##name, 2, ret, a1, a2);            \
+        return ret;                                                          \
+    }
+
+#define LKL_SYSCALL_DEFINE3(name, t1, a1, t2, a2, t3, a3)                      \
+    static long log##name(t1 a1, t2 a2, t3 a3)                                 \
+    {                                                                          \
+        int ret =                                                              \
+            ((int (*)(t1, t2, t3))real_syscalls[__lkl__NR##name])(a1, a2, a3); \
+        __sgxlkl_log_syscall(                                                  \
+            SGXLKL_LKL_SYSCALL, __lkl__NR##name, 3, ret, a1, a2, a3);          \
+        return ret;                                                            \
+    }
+
+#define LKL_SYSCALL_DEFINE4(name, t1, a1, t2, a2, t3, a3, t4, a4)            \
+    static long log##name(t1 a1, t2 a2, t3 a3, t4 a4)                        \
+    {                                                                        \
+        int ret = ((int (*)(t1, t2, t3, t4))real_syscalls[__lkl__NR##name])( \
+            a1, a2, a3, a4);                                                 \
+        __sgxlkl_log_syscall(                                                \
+            SGXLKL_LKL_SYSCALL, __lkl__NR##name, 4, ret, a1, a2, a3, a4);    \
+        return ret;                                                          \
+    }
+
+#define LKL_SYSCALL_DEFINE5(name, t1, a1, t2, a2, t3, a3, t4, a4, t5, a5)     \
+    static long log##name(t1 a1, t2 a2, t3 a3, t4 a4, t5 a5)                  \
+    {                                                                         \
+        int ret =                                                             \
+            ((int (*)(t1, t2, t3, t4, t5))real_syscalls[__lkl__NR##name])(    \
+                a1, a2, a3, a4, a5);                                          \
+        __sgxlkl_log_syscall(                                                 \
+            SGXLKL_LKL_SYSCALL, __lkl__NR##name, 5, ret, a1, a2, a3, a4, a5); \
+        return ret;                                                           \
+    }
+
+#define LKL_SYSCALL_DEFINE6(                                                   \
+    name, t1, a1, t2, a2, t3, a3, t4, a4, t5, a5, t6, a6)                      \
+    static long log##name(t1 a1, t2 a2, t3 a3, t4 a4, t5 a5, t6 a6)            \
+    {                                                                          \
+        int ret =                                                              \
+            ((int (*)(t1, t2, t3, t4, t5, t6))real_syscalls[__lkl__NR##name])( \
+                a1, a2, a3, a4, a5, a6);                                       \
+        __sgxlkl_log_syscall(                                                  \
+            SGXLKL_LKL_SYSCALL,                                                \
+            __lkl__NR##name,                                                   \
+            6,                                                                 \
+            ret,                                                               \
+            a1,                                                                \
+            a2,                                                                \
+            a3,                                                                \
+            a4,                                                                \
+            a5,                                                                \
+            a6);                                                               \
+        return ret;                                                            \
+    }
+
+#include <lkl/asm/syscall_defs.h>
+#endif
 
 void register_lkl_syscall_overrides()
 {
+    // Register fstat overrides early.  These are ABI compat wrappers, so we
+    // count them as LKL syscalls for the purpose of tracing.
     syscall_register_fstat_overrides();
+
+#if DEBUG
+    // If tracing is enabled, register syscall overrides that call the tracing
+    // functions.
+#undef LKL_SYSCALL_DEFINE0
+#undef LKL_SYSCALL_DEFINE1
+#undef LKL_SYSCALL_DEFINE2
+#undef LKL_SYSCALL_DEFINE3
+#undef LKL_SYSCALL_DEFINE4
+#undef LKL_SYSCALL_DEFINE5
+#undef LKL_SYSCALL_DEFINE6
+#define LKL_SYSCALL_DEFINE0(name, ...)                    \
+    real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
+        __lkl__NR##name, (lkl_syscall_handler_t)log##name);
+#define LKL_SYSCALL_DEFINE1(name, ...)                    \
+    real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
+        __lkl__NR##name, (lkl_syscall_handler_t)log##name);
+#define LKL_SYSCALL_DEFINE2(name, ...)                    \
+    real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
+        __lkl__NR##name, (lkl_syscall_handler_t)log##name);
+#define LKL_SYSCALL_DEFINE3(name, ...)                    \
+    real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
+        __lkl__NR##name, (lkl_syscall_handler_t)log##name);
+#define LKL_SYSCALL_DEFINE4(name, ...)                    \
+    real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
+        __lkl__NR##name, (lkl_syscall_handler_t)log##name);
+#define LKL_SYSCALL_DEFINE5(name, ...)                    \
+    real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
+        __lkl__NR##name, (lkl_syscall_handler_t)log##name);
+#define LKL_SYSCALL_DEFINE6(name, ...)                    \
+    real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
+        __lkl__NR##name, (lkl_syscall_handler_t)log##name);
+    if (sgxlkl_trace_lkl_syscall)
+    {
+#include <lkl/asm/syscall_defs.h>
+    }
+#endif
+
+    // We currently provide our own sysinfo override, because LKL is not aware
+    // of the total amount of RAM (or of the number of cores)
     lkl_replace_syscall(
         __lkl__NR_sysinfo, (lkl_syscall_handler_t)syscall_sysinfo_override);
-    // Register all of the ignored system calls.
-    for (int i = 0; i < (sizeof(ignored_syscalls) / sizeof(*ignored_syscalls));
-         i++)
+
+    // If tracing ignored syscalls is enabled, replace the ignored set with a
+    // version that does the tracing and exits, otherwise replace them with a
+    // version that silently returns success.
+#if DEBUG
+    if (sgxlkl_trace_ignored_syscall)
     {
-        lkl_replace_syscall(
-            ignored_syscalls[i], (lkl_syscall_handler_t)ignored_syscall);
+#define IGNORED_SYSCALL(name, args) \
+    lkl_replace_syscall(            \
+        __lkl__NR##name, (lkl_syscall_handler_t)log_and_ignore##name);
+#include "unsupported-syscalls.h"
     }
-    // Register all of the unsupported system calls.
-    for (int i = 0;
-         i < (sizeof(unsupported_syscalls) / sizeof(*unsupported_syscalls));
-         i++)
+    else
+#endif
     {
-        lkl_replace_syscall(
-            unsupported_syscalls[i],
-            (lkl_syscall_handler_t)unsupported_syscall);
+#define IGNORED_SYSCALL(name, args) \
+    lkl_replace_syscall(__lkl__NR##name, (lkl_syscall_handler_t)ignore##name);
+#include "unsupported-syscalls.h"
+    }
+    // If tracing unsupported syscalls is enabled, replace the ignored set with
+    // a version that does the tracing and exits, otherwise replace them with a
+    // version that silently returns failure.
+#if DEBUG
+    if (sgxlkl_trace_unsupported_syscall)
+    {
+#define UNSUPPORTED_SYSCALL(name, args) \
+    lkl_replace_syscall(                \
+        __lkl__NR##name, (lkl_syscall_handler_t)log_unsupported##name);
+#include "unsupported-syscalls.h"
+    }
+    else
+#endif
+    {
+#define UNSUPPORTED_SYSCALL(name, args) \
+    lkl_replace_syscall(                \
+        __lkl__NR##name, (lkl_syscall_handler_t)unsupported##name);
+#include "unsupported-syscalls.h"
     }
 }

--- a/src/lkl/syscall-overrides.c
+++ b/src/lkl/syscall-overrides.c
@@ -9,7 +9,7 @@
  * Macros for generating functions for implementing ignored system calls and
  * for their log variants.
  */
-#if DEBUG
+#if SGXLKL_ENABLE_SYSCALL_TRACING
 #define IGNORED_SYSCALL(name, args)                           \
     static long ignore##name(                                 \
         long a1, long a2, long a3, long a4, long a5, long a6) \
@@ -44,7 +44,7 @@
  * and returns a not-implemented error.  The log variant logs that the system
  * call was unsupported.
  */
-#if DEBUG
+#if SGXLKL_ENABLE_SYSCALL_TRACING
 #define UNSUPPORTED_SYSCALL(name, args)                       \
     static long unsupported##name()                           \
     {                                                         \
@@ -76,7 +76,7 @@
 
 #include "unsupported-syscalls.h"
 
-#if DEBUG
+#if SGXLKL_ENABLE_SYSCALL_TRACING
 static lkl_syscall_handler_t real_syscalls[__lkl__NR_syscalls];
 
 #undef LKL_SYSCALL_DEFINE0
@@ -172,7 +172,7 @@ void register_lkl_syscall_overrides()
     // count them as LKL syscalls for the purpose of tracing.
     syscall_register_fstat_overrides();
 
-#if DEBUG
+#if SGXLKL_ENABLE_SYSCALL_TRACING
     // If tracing is enabled, register syscall overrides that call the tracing
     // functions.
 #undef LKL_SYSCALL_DEFINE0
@@ -217,7 +217,7 @@ void register_lkl_syscall_overrides()
     // If tracing ignored syscalls is enabled, replace the ignored set with a
     // version that does the tracing and exits, otherwise replace them with a
     // version that silently returns success.
-#if DEBUG
+#if SGXLKL_ENABLE_SYSCALL_TRACING
     if (sgxlkl_trace_ignored_syscall)
     {
 #define IGNORED_SYSCALL(name, args) \
@@ -235,7 +235,7 @@ void register_lkl_syscall_overrides()
     // If tracing unsupported syscalls is enabled, replace the ignored set with
     // a version that does the tracing and exits, otherwise replace them with a
     // version that silently returns failure.
-#if DEBUG
+#if SGXLKL_ENABLE_SYSCALL_TRACING
     if (sgxlkl_trace_unsupported_syscall)
     {
 #define UNSUPPORTED_SYSCALL(name, args) \

--- a/src/lkl/unsupported-syscalls.h
+++ b/src/lkl/unsupported-syscalls.h
@@ -1,0 +1,31 @@
+/**
+ * List of system calls that we treat as no-ops that silently succeed.  The
+ * mlock family may be removed from this list if we transition to using the
+ * Linux built-in nommu mode for mmap, because then Linux should silently ignore
+ * them.
+ *
+ * We ignore sched_setaffinity because the Linux scheduler is not responsible
+ * for scheduling userspace threads in the LKL model and so cannot support this
+ * call.  The lthread scheduler could be extended to provide ethread affinity
+ * but does not currently.  We silently report success because it keeps OpenMP
+ * runtimes and similar code quiet.
+ */
+#ifdef IGNORED_SYSCALL
+IGNORED_SYSCALL(_munlockall, 0)
+IGNORED_SYSCALL(_mlockall, 1)
+IGNORED_SYSCALL(_mlock, 2)
+IGNORED_SYSCALL(_munlock, 2)
+IGNORED_SYSCALL(_mlock2, 3)
+IGNORED_SYSCALL(_sched_setaffinity, 3)
+#undef IGNORED_SYSCALL
+#endif
+/**
+ * List of system calls that can't work properly in this environment that we
+ * report failure to the program.  Currently, this is only brk, which would
+ * work if we used the nommu code from Linux for our memory management.
+ */
+// FIXME: Should sbrk be on this list?
+#ifdef UNSUPPORTED_SYSCALL
+UNSUPPORTED_SYSCALL(_brk, 1);
+#undef UNSUPPORTED_SYSCALL
+#endif


### PR DESCRIPTION
Userspace can issue these via the normal mechanism, their
implementations are replaced with no-op versions.