### PR TITLE
LTP: fix random failure in recvmsg01 test case

### DIFF
--- a/tests/ltp/patches/fix_recvmsg_recvmsg01.patch
+++ b/tests/ltp/patches/fix_recvmsg_recvmsg01.patch
@@ -15,7 +15,7 @@ EFAULT error behaviour is commented/disabled until github
 issue169 is fixed.
 
 diff --git a/testcases/kernel/syscalls/recvmsg/recvmsg01.c b/testcases/kernel/syscalls/recvmsg/recvmsg01.c
-index 13bcaa4e0..b5ea895f4 100644
+index 13bcaa4e0..9947f996d 100644
 --- a/testcases/kernel/syscalls/recvmsg/recvmsg01.c
 +++ b/testcases/kernel/syscalls/recvmsg/recvmsg01.c
 @@ -54,9 +54,11 @@
@@ -30,7 +30,7 @@ index 13bcaa4e0..b5ea895f4 100644
  
  char *TCID = "recvmsg01";
  int testno;
-@@ -83,7 +85,7 @@ void cleanup(void);
+@@ -83,10 +85,10 @@ void cleanup(void);
  void cleanup0(void);
  void cleanup1(void);
  void cleanup2(void);
@@ -38,7 +38,11 @@ index 13bcaa4e0..b5ea895f4 100644
 +void* do_child(void* prm);
  
  void sender(int);
- pid_t start_server(struct sockaddr_in *, struct sockaddr_un *);
+-pid_t start_server(struct sockaddr_in *, struct sockaddr_un *);
++void start_server(struct sockaddr_in *, struct sockaddr_un *);
+ 
+ struct test_case_t {		/* test case structure */
+ 	int domain;		/* PF_INET, PF_UNIX, ... */
 @@ -129,18 +131,19 @@ struct test_case_t {		/* test case structure */
  	PF_INET, SOCK_STREAM, 0, iov, 1, (void *)buf, sizeof(buf),
  		    &msgdat, -1, (struct sockaddr *)&from, -1, -1,
@@ -69,27 +73,39 @@ index 13bcaa4e0..b5ea895f4 100644
  /* 7 */
  	{
  	PF_INET, SOCK_STREAM, 0, iov, -1, (void *)buf, sizeof(buf),
-@@ -246,6 +249,7 @@ int main(int argc, char *argv[])
+@@ -245,7 +248,7 @@ int main(int argc, char *argv[])
+ 	tst_exit();
  }
  
- pid_t pid;
-+pthread_t tid;
+-pid_t pid;
++pthread_t tid = NULL;
  char tmpsunpath[1024];
  
  void setup(void)
-@@ -268,8 +272,9 @@ void setup(void)
+@@ -263,13 +266,19 @@ void setup(void)
+ 
+ 	signal(SIGPIPE, SIG_IGN);
+ 
+-	pid = start_server(&sin1, &sun1);
++	start_server(&sin1, &sun1);
+ }
  
  void cleanup(void)
  {
 -	if (pid > 0)
 -		(void)kill(pid, SIGKILL);	/* kill server */
-+	close(ufd);
-+	close(sfd);
-+	SAFE_PTHREAD_JOIN(tid, NULL);
++	if (tid != NULL)
++		SAFE_PTHREAD_JOIN(tid, NULL);
++
++	if (ufd >= 0)
++		close(ufd);
++	if (sfd >= 0)
++		close(sfd);
++	
  	if (tmpsunpath[0] != '\0')
  		(void)unlink(tmpsunpath);
  	tst_rmdir();
-@@ -341,15 +346,11 @@ void setup4(void)
+@@ -341,15 +350,11 @@ void setup4(void)
  void cleanup1(void)
  {
  	(void)close(s);
@@ -105,28 +121,76 @@ index 13bcaa4e0..b5ea895f4 100644
  	(void)close(s);
  	s = -1;
  
-@@ -407,9 +408,9 @@ pid_t start_server(struct sockaddr_in *ssin, struct sockaddr_un *ssun)
- 			tst_brkm(TBROK | TERRNO, cleanup,
- 				 "server self_exec failed");
- #else
+@@ -360,9 +365,8 @@ void cleanup2(void)
+ 	controllen = 0;
+ }
+ 
+-pid_t start_server(struct sockaddr_in *ssin, struct sockaddr_un *ssun)
++void start_server(struct sockaddr_in *ssin, struct sockaddr_un *ssun)
+ {
+-	pid_t pid;
+ 	socklen_t slen = sizeof(*ssin);
+ 
+ 	ssin->sin_family = AF_INET;
+@@ -373,15 +377,12 @@ pid_t start_server(struct sockaddr_in *ssin, struct sockaddr_un *ssun)
+ 	sfd = socket(PF_INET, SOCK_STREAM, 0);
+ 	if (sfd < 0) {
+ 		tst_brkm(TBROK | TERRNO, cleanup, "server socket failed");
+-		return -1;
+ 	}
+ 	if (bind(sfd, (struct sockaddr *)ssin, sizeof(*ssin)) < 0) {
+ 		tst_brkm(TBROK | TERRNO, cleanup, "server bind failed");
+-		return -1;
+ 	}
+ 	if (listen(sfd, 10) < 0) {
+ 		tst_brkm(TBROK | TERRNO, cleanup, "server listen failed");
+-		return -1;
+ 	}
+ 	SAFE_GETSOCKNAME(cleanup, sfd, (struct sockaddr *)ssin, &slen);
+ 
+@@ -389,39 +390,18 @@ pid_t start_server(struct sockaddr_in *ssin, struct sockaddr_un *ssun)
+ 	ufd = socket(PF_UNIX, SOCK_STREAM, 0);
+ 	if (ufd < 0) {
+ 		tst_brkm(TBROK | TERRNO, cleanup, "server UD socket failed");
+-		return -1;
+ 	}
+ 	if (bind(ufd, (struct sockaddr *)ssun, sizeof(*ssun))) {
+ 		tst_brkm(TBROK | TERRNO, cleanup, "server UD bind failed");
+-		return -1;
+ 	}
+ 	if (listen(ufd, 10) < 0) {
+ 		tst_brkm(TBROK | TERRNO, cleanup, "server UD listen failed");
+-		return -1;
+ 	}
+ 
+-	switch ((pid = FORK_OR_VFORK())) {
+-	case 0:		/* child */
+-#ifdef UCLINUX
+-		if (self_exec(argv0, "dd", sfd, ufd) < 0)
+-			tst_brkm(TBROK | TERRNO, cleanup,
+-				 "server self_exec failed");
+-#else
 -		do_child();
-+		SAFE_PTHREAD_CREATE(&tid, NULL, do_child, NULL);
- #endif
+-#endif
 -		break;
-+		return pid;
- 	case -1:
- 		tst_brkm(TBROK | TERRNO, cleanup, "server fork failed");
- 		/* fall through */
-@@ -421,7 +422,7 @@ pid_t start_server(struct sockaddr_in *ssin, struct sockaddr_un *ssun)
- 	exit(1);
+-	case -1:
+-		tst_brkm(TBROK | TERRNO, cleanup, "server fork failed");
+-		/* fall through */
+-	default:		/* parent */
+-		(void)close(sfd);
+-		(void)close(ufd);
+-		return pid;
+-	}
+-	exit(1);
++	SAFE_PTHREAD_CREATE(&tid, NULL, do_child, NULL);
  }
  
 -void do_child(void)
-+void* do_child(void* prm)
++void* do_child(void* prm LTP_ATTRIBUTE_UNUSED)
  {
  	struct sockaddr_in fsin;
  	struct sockaddr_un fsun;
-@@ -435,7 +436,7 @@ void do_child(void)
+@@ -435,7 +415,7 @@ void do_child(void)
  	nfds = MAX(sfd + 1, ufd + 1);
  
  	/* accept connections until killed */
@@ -135,7 +199,7 @@ index 13bcaa4e0..b5ea895f4 100644
  		socklen_t fromlen;
  
  		memcpy(&rfds, &afds, sizeof(rfds));
-@@ -483,6 +484,7 @@ void do_child(void)
+@@ -483,6 +463,7 @@ void do_child(void)
  				}
  			}
  	}

--- a/tests/ltp/patches/fix_recvmsg_recvmsg01.patch
+++ b/tests/ltp/patches/fix_recvmsg_recvmsg01.patch
@@ -1,17 +1,17 @@
-In original test case the main process create a child process
-to wirte/read to/from sockets infinitely. In sgx-lkl supports single
+In the original test case, the main process creates a child process
+to write/read to/from sockets infinitely. SGX-LKL supports a single
 process environment. The test case is modified to use a child
-pthread  instead of forking a child process.
+pthread instead of forking a child process.
 
-One of the sub test case designed to test generation of EFAULT
-by accessing invalid address values. Currently sgx behaviour is 
-to call enclave abort, if address is not within enclave address
-range. Because of this test program is causing enclave abort
-and exiting with non-zero exit code. 
+One of the subtest cases is designed to test the generation of
+EFAULT by accessing invalid address values. Currently, SGX behavior
+is to call enclave abort, if the address is not within the enclave
+address range. Because of this test program is causing enclave
+abort and exiting with non-zero exit code.
 
-Github issue169 (https://github.com/lsds/sgx-lkl/issues/169)
-is raised to fix this behaviour. The sub test cases which test
-EFAULT error behaviour is commented/disabled until github
+Github issue169 (#169)
+is raised to fix this behavior. The subtest cases which test
+EFAULT error behavior is commented/disabled until GitHub
 issue169 is fixed.
 
 diff --git a/testcases/kernel/syscalls/recvmsg/recvmsg01.c b/testcases/kernel/syscalls/recvmsg/recvmsg01.c


### PR DESCRIPTION
Fixed the random failure due to “Bad file descriptor”
at the time of clean up. This error is observed because
socket file descriptors (“sfd” & “ufd”), used in server
thread is closed before exiting from server thread.
Also some clean-up of unused code is performed.