### PR TITLE
Output lthread stack traces on sgxlkl_fail and unhandled exceptions

### DIFF
--- a/src/enclave/enclave_signal.c
+++ b/src/enclave/enclave_signal.c
@@ -143,6 +143,13 @@ static uint64_t sgxlkl_enclave_signal_handler(
             exception_record->address,
             opcode);
 
+#ifdef DEBUG
+        if (sgxlkl_trace_signal)
+        {
+            sgxlkl_print_backtrace((void*)oe_ctx->rbp);
+        }
+#endif
+
         /**
          * If LKL has not yet been initialised, we cannot handle the
          * exception and fail instead.

--- a/src/enclave/enclave_util.c
+++ b/src/enclave/enclave_util.c
@@ -5,7 +5,9 @@
 
 #include "openenclave/internal/print.h"
 #include "openenclave/corelibc/oemalloc.h"
+#ifdef DEBUG
 #include "openenclave/internal/backtrace.h"
+#endif
 
 #define OE_STDERR_FILENO 1
 
@@ -74,7 +76,10 @@ void* oe_calloc_or_die(size_t nmemb, size_t size, const char* fail_msg, ...)
 }
 
 #ifdef DEBUG
-// Provide access to an internal OE function
+/**
+ * Provide access to an internal OE function. We cannot use the public oe_backtrace
+ * function because we need to pass in custom frame pointers of other lthreads.
+ */
 extern int oe_backtrace_impl(void** start_frame, void** buffer, int size);
 
 void sgxlkl_print_backtrace(void** start_frame)

--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -25,6 +25,11 @@ void* oe_malloc_or_die(size_t size, const char* fail_msg, ...);
  */
 void* oe_calloc_or_die(size_t nmemb, size_t size, const char* fail_msg, ...);
 
+/**
+ *
+ * Note that generating a stack trace by unwinding stack frames could be exploited
+ * by an attacker and therefore should only be possible in a DEBUG build.
+ */
 #ifdef DEBUG
 /**
  * Prints a stacktrace using oe_backtrace() from start_frame. If start_frame

--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -25,6 +25,14 @@ void* oe_malloc_or_die(size_t size, const char* fail_msg, ...);
  */
 void* oe_calloc_or_die(size_t nmemb, size_t size, const char* fail_msg, ...);
 
+#ifdef DEBUG
+/**
+ * Prints a stacktrace using oe_backtrace() from start_frame. If start_frame
+ * is NULL, it uses the current stack frame.
+ */
+void sgxlkl_print_backtrace(void** start_frame);
+#endif
+
 int int_log2(unsigned long long arg);
 
 /**

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -313,9 +313,12 @@ extern "C"
     /**
      * Print stack traces for all lthreads that currently exist.
      *
-     * This prints the active stack frame for the current lthread (marking it
-     * with '*') and stack traces at the time of the last context switch for
-     * all other lthreads.
+     * This outputs the stack frames of all lthreads based on the frame
+     * pointers saved by the lthread scheduler. It shows the stack traces
+     * at the time of the last context switch.
+     *
+     * For the current lthread (marked with a '*'), it prints the active
+     * stack frames.
      */
     void lthread_dump_all_threads(void);
 #endif

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -311,7 +311,11 @@ extern "C"
 
 #ifdef DEBUG
     /**
-     * Show all the threads that currently exist.
+     * Print stack traces for all lthreads that currently exist.
+     *
+     * This prints the active stack frame for the current lthread (marking it
+     * with '*') and stack traces at the time of the last context switch for
+     * all other lthreads.
      */
     void lthread_dump_all_threads(void);
 #endif

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -325,7 +325,7 @@ static void lkl_mount_overlayfs(
     const char* mnt_point)
 {
     char opts[200];
-    snprintf(
+    oe_snprintf(
             opts,
             sizeof(opts),
             "lowerdir=%s,upperdir=%s,workdir=%s",

--- a/src/lkl/virtio.c
+++ b/src/lkl/virtio.c
@@ -14,6 +14,8 @@
 #include <linux/virtio_blk.h>
 #include <linux/virtio_mmio.h>
 
+#include "openenclave/corelibc/oestring.h"
+
 #define VIRTIO_DEV_MAGIC 0x74726976
 #define VIRTIO_DEV_VERSION 2
 
@@ -311,7 +313,7 @@ int lkl_virtio_dev_setup(
     if (!lkl_is_running())
     {
         avail = sizeof(lkl_virtio_devs) - (devs - lkl_virtio_devs);
-        num_bytes = snprintf(
+        num_bytes = oe_snprintf(
             devs,
             avail,
             " virtio_mmio.device=%d@0x%" PRIxPTR ":%d",

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -35,7 +35,6 @@
 #include <stdatomic.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <string.h>
 
 #include "pthread_impl.h"
 #include "stdio_impl.h"
@@ -48,7 +47,9 @@
 #include "enclave/sgxlkl_t.h"
 #include "enclave/ticketlock.h"
 #include "shared/tree.h"
+
 #include "openenclave/corelibc/oemalloc.h"
+#include "openenclave/corelibc/oestring.h"
 
 extern int vio_enclave_wakeup_event_channel(void);
 
@@ -634,7 +635,11 @@ int lthread_create_primitive(
     lt->robust_list.head = &lt->robust_list.head;
 
     static unsigned long long n = 0;
-    snprintf(lt->funcname, 64, "cloned host task %llu", __atomic_fetch_add(&n, 1, __ATOMIC_SEQ_CST));
+    oe_snprintf(
+        lt->funcname,
+        64,
+        "cloned host task %llu",
+        __atomic_fetch_add(&n, 1, __ATOMIC_SEQ_CST));
 
     if (new_lt)
     {

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -1085,7 +1085,8 @@ void lthread_dump_all_threads(void)
 {
     struct lthread_queue* lt_queue = __active_lthreads;
 
-    SGXLKL_VERBOSE("Dumping all lthreads:\n");
+    sgxlkl_info("=============================================================\n");
+    sgxlkl_info("Stack traces for all lthreads:\n");
 
     for (int i = 1; lt_queue; i++)
     {
@@ -1093,9 +1094,13 @@ void lthread_dump_all_threads(void)
         SGXLKL_ASSERT(lt);
         int tid = lt->tid;
         char* funcname = lt->funcname;
-        SGXLKL_VERBOSE_RAW("%i: tid=%i [%s]\n", i, tid, funcname);
+        sgxlkl_info("-------------------------------------------------------------\n");
+        sgxlkl_info("%s%i: tid=%i [%s]\n", lt == lthread_self() ? "*" : "", i, tid, funcname);
+        sgxlkl_print_backtrace(lt == lthread_self() ? __builtin_frame_address(0) : lt->ctx.ebp);
 
         lt_queue = lt_queue->next;
     }
+
+    sgxlkl_info("=============================================================\n");
 }
 #endif

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -50,6 +50,7 @@
 
 #include "openenclave/corelibc/oemalloc.h"
 #include "openenclave/corelibc/oestring.h"
+#include "openenclave/internal/safecrt.h"
 
 extern int vio_enclave_wakeup_event_channel(void);
 
@@ -370,7 +371,7 @@ void _lthread_free(struct lthread* lt)
         enclave_munmap(lt->attr.stack, lt->attr.stack_size);
         lt->attr.stack = NULL;
     }
-    memset(lt, 0, sizeof(*lt));
+    oe_memset_s(lt, sizeof(*lt), 0, sizeof(*lt));
     if (a_fetch_add(&libc.threads_minus_1, -1) == 0)
     {
         libc.threads_minus_1 = 0;
@@ -563,7 +564,8 @@ int _lthread_sched_init(size_t stack_size)
 
     c->sched.default_timeout = 3000000u;
 
-    memset(&c->sched.ctx, 0, sizeof(struct cpu_ctx));
+    oe_memset_s(
+        &c->sched.ctx, sizeof(struct cpu_ctx), 0, sizeof(struct cpu_ctx));
 
     return (0);
 }
@@ -903,7 +905,7 @@ void lthread_detach2(struct lthread* lt)
 
 void lthread_set_funcname(struct lthread* lt, const char* f)
 {
-    strncpy(lt->funcname, f, 64);
+    oe_strncpy_s(lt->funcname, 64, f, 64);
     lt->funcname[64 - 1] = 0;
 }
 


### PR DESCRIPTION
This PR outputs stack traces for all threads when `sgxlkl_fail()` is called for a DEBUG build. It also outputs a stacktrace when a signal handler cannot pass an exception to LKL.

The output looks as follows:
```
...
[[  SGX-LKL ]] startmain(): enter
[[  SGX-LKL ]] lkl_start_init(): calling register_lkl_syscall_overrides()
[[  SGX-LKL ]] lkl_start_init(): fetching configuration from environment variables
[[  SGX-LKL ]] lkl_start_init(): calling initialize_enclave_event_channel()
[[  SGX-LKL ]] lkl_start_init(): calling lkl_virtio_console_add()
[[  SGX-LKL ]] WARN: Stack trace before the signal handler was invoked:
[[  SGX-LKL ]]     #0: 7fde005a58a1 in startmain(...)
[[  SGX-LKL ]]     #1: 7fde005b1430 in _exec(...)
[[  SGX-LKL ]] FAIL: Exception SIGSEGV (page fault) received before LKL is running (lt->tid=1 [kernel] code=5 addr=0x0 opcode=0x8b ret=0)
[[  SGX-LKL ]] =============================================================
[[  SGX-LKL ]] Stack traces for all lthreads:
[[  SGX-LKL ]] -------------------------------------------------------------
[[  SGX-LKL ]] *1: tid=1 [kernel]
[[  SGX-LKL ]]     #0: 7fde00b445d0 in <unknown>(...)
[[  SGX-LKL ]] -------------------------------------------------------------
[[  SGX-LKL ]] 2: tid=2 [vio-0]
[[  SGX-LKL ]]     #0: 7fde005a4eba in vio_wait_for_host_event(...)
[[  SGX-LKL ]]     #1: 7fde005a508a in vio_enclave_process_host_event(...)
[[  SGX-LKL ]]     #2: 7fde005b1430 in _exec(...)
[[  SGX-LKL ]] -------------------------------------------------------------
[[  SGX-LKL ]] 3: tid=3 [vio-1]
[[  SGX-LKL ]]     #0: 7fde005a4eba in vio_wait_for_host_event(...)
[[  SGX-LKL ]]     #1: 7fde005a508a in vio_enclave_process_host_event(...)
[[  SGX-LKL ]]     #2: 7fde005b1430 in _exec(...)
[[  SGX-LKL ]] -------------------------------------------------------------
[[  SGX-LKL ]] 4: tid=4 [vio-2]
[[  SGX-LKL ]]     #0: 7fde005a4eba in vio_wait_for_host_event(...)
[[  SGX-LKL ]]     #1: 7fde005a508a in vio_enclave_process_host_event(...)
[[  SGX-LKL ]]     #2: 7fde005b1430 in _exec(...)
[[  SGX-LKL ]] =============================================================
2020-07-03T22:08:26.000000Z [(H)ERROR] tid(0x7fdefccdc700) | :OE_ENCLAVE_ABORTING [/home/prp/sgx-lkl/openenclave/host/calls.c:oe_call_enclave_function_by_table_id:91]
[   SGX-LKL  ] init (0: 19 exit=0) [   SGX-LKL  ] FAIL: sgxlkl_ethread_init() failed (ethread_id=0 result=19 (OE_ENCLAVE_ABORTING))
Makefile:32: recipe for target 'run-sw' failed
make: *** [run-sw] Error 1
```

A current limitation is that for all but the lthread that calls `lthread_dump_all_threads()`, the stack traces reflect the stack at the time of the last context switch by the lthread scheduler.

The PR fleshes out the POC from https://github.com/lsds/sgx-lkl/pull/584.