### PR TITLE
Fix race condition in initialize_enclave_event_channel()

### DIFF
--- a/src/enclave/enclave_event_channel.c
+++ b/src/enclave/enclave_event_channel.c
@@ -179,14 +179,15 @@ void initialize_enclave_event_channel(
 
         *dev_id = enc_dev_config[i].dev_id;
 
-        struct lthread* lt = NULL;
         if (lthread_create(
-                &lt, NULL, vio_enclave_process_host_event, (void*)dev_id) != 0)
+                &vio_tasks[i],
+                NULL,
+                vio_enclave_process_host_event,
+                (void*)dev_id) != 0)
         {
             oe_free(vio_tasks);
             sgxlkl_fail("Failed to create lthread for event channel\n");
         }
-        vio_tasks[i] = lt;
     }
     /* Mark event channel as initialized to be picked up by scheduler */
     _event_channel_initialized = true;

--- a/src/enclave/enclave_event_channel.c
+++ b/src/enclave/enclave_event_channel.c
@@ -44,20 +44,27 @@ static inline void set_thread_state(void* lth)
 }
 
 /*
- * Function to yeild the virtio event channel task
+ * Function to yield the virtio event channel task
  */
 static inline void vio_wait_for_host_event(
     uint8_t dev_id,
     evt_t* evt_chn,
     evt_t val)
 {
-    struct lthread* lt = vio_tasks[dev_id];
+    SGXLKL_ASSERT(vio_tasks);
+    SGXLKL_ASSERT(evt_chn);
 
-    /* return if the event channel was signaled */
+    struct lthread* lt = vio_tasks[dev_id];
+    SGXLKL_ASSERT(lt);
+
+    /* Return if the event channel was signaled */
     if ((__atomic_load_n(evt_chn, __ATOMIC_SEQ_CST) != val) ||
         vio_shutdown_requested())
+    {
         return;
-    /* release cpu for other tasks */
+    }
+
+    /* Release CPU for other tasks */
     _lthread_yield_cb(lt, set_thread_state, lt);
 }
 

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1527,7 +1527,7 @@ void lkl_start_init()
     create_lkl_termination_thread();
 
     // Now that our kernel is ready to handle syscalls, mount root
-    SGXLKL_VERBOSE("calling lkl_mount_virtial()\n");
+    SGXLKL_VERBOSE("calling lkl_mount_virtual()\n");
     lkl_mount_virtual();
 
     SGXLKL_VERBOSE("calling init_random()\n");


### PR DESCRIPTION
This PR fixes a race condition in the VIO event channel initialisation.

When creating enclave threads for processing host events via the event channel mechanism, the event channels are distinguished based on the associated lthread pointer. This pointer is only updated after `lthread_create()` has returned, which means that a thread may access an uninitialised value. 

Fixes https://github.com/lsds/sgx-lkl/issues/564.
