### PR TITLE
LTP:fix bad file descriptor error in sendfile tests

### DIFF
--- a/tests/ltp/patches/fix_sendfile_sendfile02.patch
+++ b/tests/ltp/patches/fix_sendfile_sendfile02.patch
@@ -1,10 +1,10 @@
-The original test case create a child process to test
-Sendfile system call. But, sgx-lkl environment supports single process.
+The original test case creates a child process to test
+Sendfile system call. But, sgx-lkl environment supports a single process.
 Hence, the test case is modified to use pthread instead of a child
 process.
 
 diff --git a/testcases/kernel/syscalls/sendfile/sendfile02.c b/testcases/kernel/syscalls/sendfile/sendfile02.c
-index e5f115146..08832748e 100644
+index e5f115146..acdac130b 100644
 --- a/testcases/kernel/syscalls/sendfile/sendfile02.c
 +++ b/testcases/kernel/syscalls/sendfile/sendfile02.c
 @@ -56,8 +56,10 @@
@@ -18,19 +18,54 @@ index e5f115146..08832748e 100644
  
  #ifndef OFF_T
  #define OFF_T off_t
-@@ -72,9 +74,10 @@ int out_fd;
- pid_t child_pid;
- static int sockfd, s;
+@@ -68,15 +70,15 @@ int TST_TOTAL = 4;
+ 
+ char in_file[100];
+ char out_file[100];
+-int out_fd;
+-pid_t child_pid;
+-static int sockfd, s;
++int out_fd = -1;
++static int sockfd = -1;
  static struct sockaddr_in sin1;	/* shared between do_child and create_server */
-+pthread_t ptid;
++pthread_t ptid = NULL;
  
  void cleanup(void);
 -void do_child(void);
 +void* do_child(void* parm);
  void setup(void);
- int create_server(void);
+-int create_server(void);
++void create_server(void);
  
-@@ -99,8 +102,6 @@ void do_sendfile(OFF_T offset, int i)
+ struct test_case_t {
+ 	char *desc;
+@@ -91,19 +93,32 @@ struct test_case_t {
+ 	"Test sendfile(2) with offset in the middle of file", 6, 20, 26}
+ };
+ 
+-#ifdef UCLINUX
+-static char *argv0;
+-#endif
++void close_server(void)
++{
++	if (ptid != NULL) {
++		SAFE_PTHREAD_JOIN(ptid, NULL);
++		ptid = NULL;
++	}
++
++	if (sockfd >= 0) {
++		close(sockfd);
++		sockfd = -1;
++	}
++
++	if (out_fd >= 0) {
++		close(out_fd);
++		out_fd = -1;
++	}
++
++}
+ 
+ void do_sendfile(OFF_T offset, int i)
  {
  	int in_fd;
  	struct stat sb;
@@ -38,26 +73,37 @@ index e5f115146..08832748e 100644
 -	int wait_stat;
  	off_t before_pos, after_pos;
  
- 	out_fd = create_server();
-@@ -130,7 +131,7 @@ void do_sendfile(OFF_T offset, int i)
+-	out_fd = create_server();
++	create_server();
+ 
+ 	if ((in_fd = open(in_file, O_RDONLY)) < 0) {
+ 		tst_brkm(TBROK, cleanup, "open failed: %d", errno);
+@@ -124,13 +139,12 @@ void do_sendfile(OFF_T offset, int i)
+ 
+ 	/* Close the sockets */
+ 	shutdown(sockfd, SHUT_RDWR);
+-	shutdown(s, SHUT_RDWR);
++	shutdown(out_fd, SHUT_RDWR);
+ 	if (TEST_RETURN != testcases[i].exp_retval) {
+ 		tst_resm(TFAIL, "sendfile(2) failed to return "
  			 "expected value, expected: %d, "
  			 "got: %ld", testcases[i].exp_retval,
  			 TEST_RETURN);
 -		kill(child_pid, SIGKILL);
-+		pthread_cancel(ptid);
  	} else if (offset != testcases[i].exp_updated_offset) {
  		tst_resm(TFAIL, "sendfile(2) failed to update "
  			 "OFFSET parameter to expected value, "
-@@ -145,7 +146,7 @@ void do_sendfile(OFF_T offset, int i)
+@@ -145,27 +159,25 @@ void do_sendfile(OFF_T offset, int i)
  	} else {
  		tst_resm(TPASS, "functionality of sendfile() is "
  			 "correct");
 -		wait_status = waitpid(-1, &wait_stat, 0);
-+		SAFE_PTHREAD_JOIN(ptid, NULL);
  	}
  
++	close_server();
  	close(in_fd);
-@@ -154,18 +155,16 @@ void do_sendfile(OFF_T offset, int i)
+ }
+ 
  /*
   * do_child
   */
@@ -82,15 +128,38 @@ index e5f115146..08832748e 100644
  }
  
  /*
-@@ -202,6 +201,7 @@ void setup(void)
+@@ -201,14 +213,15 @@ void setup(void)
+  */
  void cleanup(void)
  {
- 
-+	close(sockfd);
- 	close(out_fd);
+-
+-	close(out_fd);
++	if(sockfd >= 0)
++		shutdown(sockfd, SHUT_RDWR);
++	close_server();
  	/* delete the test directory created in setup() */
  	tst_rmdir();
-@@ -230,23 +230,7 @@ int create_server(void)
+ 
+ }
+ 
+-int create_server(void)
++void create_server(void)
+ {
+ 	static int count = 0;
+ 	socklen_t slen = sizeof(sin1);
+@@ -217,7 +230,6 @@ int create_server(void)
+ 	if (sockfd < 0) {
+ 		tst_brkm(TBROK, cleanup, "call to socket() failed: %s",
+ 			 strerror(errno));
+-		return -1;
+ 	}
+ 	sin1.sin_family = AF_INET;
+ 	sin1.sin_port = 0; /* pick random free port */
+@@ -226,37 +238,18 @@ int create_server(void)
+ 	if (bind(sockfd, (struct sockaddr *)&sin1, sizeof(sin1)) < 0) {
+ 		tst_brkm(TBROK, cleanup, "call to bind() failed: %s",
+ 			 strerror(errno));
+-		return -1;
  	}
  	SAFE_GETSOCKNAME(cleanup, sockfd, (struct sockaddr *)&sin1, &slen);
  
@@ -113,5 +182,29 @@ index e5f115146..08832748e 100644
 -	}
 +	SAFE_PTHREAD_CREATE(&ptid, NULL, do_child, NULL);
  
- 	s = socket(PF_INET, SOCK_DGRAM, 0);
+-	s = socket(PF_INET, SOCK_DGRAM, 0);
++	out_fd = socket(PF_INET, SOCK_DGRAM, 0);
  	inet_aton("127.0.0.1", &sin1.sin_addr);
+-	if (s < 0) {
++	if (out_fd < 0) {
+ 		tst_brkm(TBROK, cleanup, "call to socket() failed: %s",
+ 			 strerror(errno));
+-		return -1;
+ 	}
+-	SAFE_CONNECT(cleanup, s, (struct sockaddr *)&sin1, sizeof(sin1));
+-	return s;
++	SAFE_CONNECT(cleanup, out_fd, (struct sockaddr *)&sin1, sizeof(sin1));
+ 
+ }
+ 
+@@ -266,10 +259,6 @@ int main(int ac, char **av)
+ 	int lc;
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+-#ifdef UCLINUX
+-	argv0 = av[0];
+-	maybe_run_child(&do_child, "");
+-#endif
+ 
+ 	setup();
+ 

--- a/tests/ltp/patches/fix_sendfile_sendfile05.patch
+++ b/tests/ltp/patches/fix_sendfile_sendfile05.patch
@@ -1,10 +1,10 @@
-The original test case create a child process to test
-Sendfile system call. But, sgx-lkl environment supports single process.
+The original test case creates a child process to test
+Sendfile system call. But, sgx-lkl environment supports a single process.
 Hence, the test case is modified to use pthread instead of a child
 process.
 
 diff --git a/testcases/kernel/syscalls/sendfile/sendfile05.c b/testcases/kernel/syscalls/sendfile/sendfile05.c
-index 0f268ceb3..e2d37fa05 100644
+index 0f268ceb3..c9a902cf7 100644
 --- a/testcases/kernel/syscalls/sendfile/sendfile05.c
 +++ b/testcases/kernel/syscalls/sendfile/sendfile05.c
 @@ -51,8 +51,10 @@
@@ -18,26 +18,68 @@ index 0f268ceb3..e2d37fa05 100644
  
  #ifndef OFF_T
  #define OFF_T off_t
-@@ -64,11 +66,12 @@ char in_file[100];
+@@ -62,29 +64,44 @@ TCID_DEFINE(sendfile05);
+ 
+ char in_file[100];
  char out_file[100];
- int out_fd;
- pid_t child_pid;
-+pthread_t child_tid;
- static int sockfd, s;
+-int out_fd;
+-pid_t child_pid;
+-static int sockfd, s;
++int out_fd = 1;
++pthread_t child_tid = NULL;
++static int sockfd = -1;
  static struct sockaddr_in sin1;	/* shared between do_child and create_server */
  
  void cleanup(void);
 -void do_child(void);
 +void* do_child(void* parm);
  void setup(void);
- int create_server(void);
+-int create_server(void);
++void create_server(void);
  
-@@ -109,14 +112,14 @@ void do_sendfile(void)
+ int TST_TOTAL = 1;
+ 
+-#ifdef UCLINUX
+-static char *argv0;
+-#endif
++void close_server(void)
++{
++	if(child_tid != NULL) {
++		SAFE_PTHREAD_JOIN(child_tid, NULL);
++		child_tid = NULL;
++	}
+ 
++	if (sockfd >= 0) {
++		close(sockfd);
++		sockfd = -1;
++	}
++
++	if (out_fd >= 0) {
++		close(out_fd);
++		out_fd = -1;
++	}
++
++		
++}
+ void do_sendfile(void)
+ {
+ 	OFF_T offset;
+ 	int in_fd;
+ 	struct stat sb;
+ 
+-	out_fd = create_server();
++	create_server();
+ 
+ 	if ((in_fd = open(in_file, O_RDONLY)) < 0) {
+ 		tst_brkm(TBROK, cleanup, "open failed: %d", errno);
+@@ -108,26 +125,23 @@ void do_sendfile(void)
+ 	}
  
  	shutdown(sockfd, SHUT_RDWR);
- 	shutdown(s, SHUT_RDWR);
+-	shutdown(s, SHUT_RDWR);
 -	kill(child_pid, SIGKILL);
-+	SAFE_PTHREAD_JOIN(child_tid, NULL);
++	shutdown(out_fd, SHUT_RDWR);
++	close_server();
  	close(in_fd);
  }
  
@@ -45,25 +87,102 @@ index 0f268ceb3..e2d37fa05 100644
   * do_child
   */
 -void do_child(void)
-+void* do_child(void* parm)
++void* do_child(void* parm LTP_ATTRIBUTE_UNUSED)
  {
- 	int lc;
+-	int lc;
  	socklen_t length;
-@@ -127,7 +130,7 @@ void do_child(void)
- 		recvfrom(sockfd, rbuf, 4096, 0, (struct sockaddr *)&sin1,
- 			 &length);
- 	}
+ 	char rbuf[4096];
+ 
+-	for (lc = 0; TEST_LOOPING(lc); lc++) {
+-		length = sizeof(sin1);
+-		recvfrom(sockfd, rbuf, 4096, 0, (struct sockaddr *)&sin1,
+-			 &length);
+-	}
 -	exit(0);
++	length = sizeof(sin1);
++	recvfrom(sockfd, rbuf, 4096, 0, (struct sockaddr *)&sin1, &length);
++
 +	pthread_exit(0);
  }
  
  /*
-@@ -206,7 +209,7 @@ int create_server(void)
+@@ -163,14 +177,15 @@ void setup(void)
+  */
+ void cleanup(void)
+ {
+-
+-	close(out_fd);
++	if (sockfd >= 0)
++		shutdown(sockfd, SHUT_RDWR);
++	close_server();
+ 	/* delete the test directory created in setup() */
+ 	tst_rmdir();
  
- 		}
- #else
--		do_child();
-+		SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child, NULL);
- #endif
+ }
+ 
+-int create_server(void)
++void create_server(void)
+ {
+ 	static int count = 0;
+ 	socklen_t slen = sizeof(sin1);
+@@ -179,7 +194,6 @@ int create_server(void)
+ 	if (sockfd < 0) {
+ 		tst_brkm(TBROK, cleanup, "call to socket() failed: %s",
+ 			 strerror(errno));
+-		return -1;
  	}
+ 	sin1.sin_family = AF_INET;
+ 	sin1.sin_port = 0; /* pick random free port */
+@@ -188,37 +202,18 @@ int create_server(void)
+ 	if (bind(sockfd, (struct sockaddr *)&sin1, sizeof(sin1)) < 0) {
+ 		tst_brkm(TBROK, cleanup, "call to bind() failed: %s",
+ 			 strerror(errno));
+-		return -1;
+ 	}
+ 	SAFE_GETSOCKNAME(cleanup, sockfd, (struct sockaddr *)&sin1, &slen);
+ 
+-	child_pid = FORK_OR_VFORK();
+-	if (child_pid < 0) {
+-		tst_brkm(TBROK, cleanup, "client/server fork failed: %s",
+-			 strerror(errno));
+-		return -1;
+-	}
+-	if (!child_pid) {	/* child */
+-#ifdef UCLINUX
+-		if (self_exec(argv0, "") < 0) {
+-			tst_brkm(TBROK, cleanup, "self_exec failed");
+-			return -1;
+-
+-		}
+-#else
+-		do_child();
+-#endif
+-	}
++	SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child, NULL);
+ 
+-	s = socket(PF_INET, SOCK_DGRAM, 0);
++	out_fd = socket(PF_INET, SOCK_DGRAM, 0);
+ 	inet_aton("127.0.0.1", &sin1.sin_addr);
+-	if (s < 0) {
++	if (out_fd < 0) {
+ 		tst_brkm(TBROK, cleanup, "call to socket() failed: %s",
+ 			 strerror(errno));
+-		return -1;
+ 	}
+-	SAFE_CONNECT(cleanup, s, (struct sockaddr *)&sin1, sizeof(sin1));
+-	return s;
++	SAFE_CONNECT(cleanup, out_fd, (struct sockaddr *)&sin1, sizeof(sin1));
+ 
+ }
+ 
+@@ -227,10 +222,6 @@ int main(int ac, char **av)
+ 	int lc;
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+-#ifdef UCLINUX
+-	argv0 = av[0];
+-	maybe_run_child(&do_child, "");
+-#endif
+ 
+ 	setup();
  

--- a/tests/ltp/patches/fix_sendfile_sendfile06.patch
+++ b/tests/ltp/patches/fix_sendfile_sendfile06.patch
@@ -1,13 +1,13 @@
-The original test case create a child process to test
-Sendfile system call. But, sgx-lkl environment supports single process.
+The original test case creates a child process to test
+Sendfile system call. But, sgx-lkl environment supports a single process.
 Hence, the test case is modified to use pthread instead of a child
 process.
 
 diff --git a/testcases/kernel/syscalls/sendfile/sendfile06.c b/testcases/kernel/syscalls/sendfile/sendfile06.c
-index abb67604f..8e079aa97 100644
+index abb67604f..a1bf9facd 100644
 --- a/testcases/kernel/syscalls/sendfile/sendfile06.c
 +++ b/testcases/kernel/syscalls/sendfile/sendfile06.c
-@@ -39,8 +39,10 @@
+@@ -39,21 +39,24 @@
  #include <netinet/in.h>
  #include <arpa/inet.h>
  #include <string.h>
@@ -18,14 +18,16 @@ index abb67604f..8e079aa97 100644
  
  TCID_DEFINE(sendfile06);
  
-@@ -48,12 +50,13 @@ TCID_DEFINE(sendfile06);
+ #define IN_FILE		"infile"
  #define OUT_FILE	"outfile"
  
- static pid_t child_pid;
-+static pthread_t child_tid;
- static int sockfd;
+-static pid_t child_pid;
+-static int sockfd;
++static pthread_t child_tid = NULL;
++static int sockfd = -1;
  static struct sockaddr_in sin1;
  static struct stat sb;
++static int stop_server = 0;
  
  static void cleanup(void);
 -static void do_child(void);
@@ -33,12 +35,38 @@ index abb67604f..8e079aa97 100644
  static void setup(void);
  static int create_server(void);
  
-@@ -86,18 +89,18 @@ static void do_sendfile(void)
+@@ -63,11 +66,24 @@ int TST_TOTAL = 1;
+ static char *argv0;
+ #endif
+ 
++void close_server(void)
++{
++	if (child_tid != NULL) {
++		SAFE_PTHREAD_JOIN(child_tid, NULL);
++		child_tid = NULL;
++	}
++
++	if (sockfd >= 0) {
++		close(sockfd);
++		sockfd = -1;
++	}
++
++}
++
+ static void do_sendfile(void)
+ {
+ 	int in_fd, out_fd;
+ 	off_t after_pos;
+-	int wait_stat;
+ 
+ 	out_fd = create_server();
+ 
+@@ -86,32 +102,31 @@ static void do_sendfile(void)
  		tst_resm(TFAIL, "sendfile(2) failed to return "
  			 "expected value, expected: %" PRId64 ", "
  			 "got: %ld", (int64_t) sb.st_size, TEST_RETURN);
 -		SAFE_KILL(cleanup, child_pid, SIGKILL);
-+		pthread_cancel(child_tid);
++		stop_server = 1;
  	} else if (after_pos != sb.st_size) {
  		tst_resm(TFAIL, "sendfile(2) failed to update "
  			 " the file position of in_fd, "
@@ -46,25 +74,33 @@ index abb67604f..8e079aa97 100644
  			 "actual file position %" PRId64,
  			 (int64_t) sb.st_size, (int64_t) after_pos);
 -		SAFE_KILL(cleanup, child_pid, SIGKILL);
-+		pthread_cancel(child_tid);
++		stop_server = 1;
  	} else {
  		tst_resm(TPASS, "functionality of sendfile() is "
  			 "correct");
 -		waitpid(-1, &wait_stat, 0);
-+		SAFE_PTHREAD_JOIN(child_tid, NULL);
  	}
- 
+-
++	
++	close_server();
  	SAFE_CLOSE(cleanup, in_fd);
-@@ -105,7 +108,7 @@ static void do_sendfile(void)
- 	SAFE_CLOSE(cleanup, sockfd);
+ 	SAFE_CLOSE(cleanup, out_fd);
+-	SAFE_CLOSE(cleanup, sockfd);
  }
  
 -static void do_child(void)
-+static void* do_child(void* prm)
++static void* do_child(void* prm LTP_ATTRIBUTE_UNUSED)
  {
  	socklen_t length = sizeof(sin1);
  	char rbuf[4096];
-@@ -122,7 +125,7 @@ static void do_child(void)
+ 	ssize_t ret, bytes_total_received = 0;
+ 
+-	while (bytes_total_received < sb.st_size) {
++	while (bytes_total_received < sb.st_size && !stop_server) {
+ 		ret = recvfrom(sockfd, rbuf, 4096, 0, (struct sockaddr *)&sin1,
+ 			       &length);
+ 		if (ret < 0) {
+@@ -122,7 +137,7 @@ static void do_child(void)
  		bytes_total_received += ret;
  	}
  
@@ -73,12 +109,41 @@ index abb67604f..8e079aa97 100644
  }
  
  static void setup(void)
-@@ -186,7 +189,7 @@ static int create_server(void)
- 
- 		}
- #else
--		do_child();
-+		SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child, NULL);
- #endif
+@@ -171,24 +186,7 @@ static int create_server(void)
  	}
+ 	SAFE_GETSOCKNAME(cleanup, sockfd, (struct sockaddr *)&sin1, &slen);
  
+-	child_pid = FORK_OR_VFORK();
+-	if (child_pid < 0) {
+-		tst_brkm(TBROK, cleanup, "client/server fork failed: %s",
+-			 strerror(errno));
+-		return -1;
+-	}
+-
+-	if (!child_pid) {
+-#ifdef UCLINUX
+-		if (self_exec(argv0, "") < 0) {
+-			tst_brkm(TBROK, cleanup, "self_exec failed");
+-			return -1;
+-
+-		}
+-#else
+-		do_child();
+-#endif
+-	}
++	SAFE_PTHREAD_CREATE(&child_tid, NULL, do_child, NULL);
+ 
+ 	s = socket(PF_INET, SOCK_DGRAM, 0);
+ 	inet_aton("127.0.0.1", &sin1.sin_addr);
+@@ -210,11 +208,6 @@ int main(int ac, char **av)
+ 
+ 	tst_parse_opts(ac, av, NULL, NULL);
+ 
+-#ifdef UCLINUX
+-	argv0 = av[0];
+-	maybe_run_child(&do_child, "");
+-#endif
+-
+ 	setup();
+ 
+ 	for (lc = 0; TEST_LOOPING(lc); lc++) {


### PR DESCRIPTION
Fixed bad file descriptor error in sendfile02, sendfile05
sendfile06 test cases and also performed code cleanup.