### PR TITLE
LTP: fcntl cleanup fcntl24 fcntl25 fcntl32

### DIFF
--- a/tests/ltp/patches/fcntl24.patch
+++ b/tests/ltp/patches/fcntl24.patch
@@ -1,6 +1,6 @@
 Test was failing as it used RAMFS. Fix is to use root file system.
 diff --git a/testcases/kernel/syscalls/fcntl/fcntl24.c b/testcases/kernel/syscalls/fcntl/fcntl24.c
-index 63c716ff6..21b62d10d 100644
+index 63c716ff6..b51d3ecb8 100644
 --- a/testcases/kernel/syscalls/fcntl/fcntl24.c
 +++ b/testcases/kernel/syscalls/fcntl/fcntl24.c
 @@ -93,7 +93,11 @@
@@ -41,13 +41,12 @@ index 63c716ff6..21b62d10d 100644
      /***************************************************************
       * check looping state if -c option given
       ***************************************************************/
-@@ -185,13 +181,12 @@ void setup(void)
+@@ -185,13 +181,11 @@ void setup(void)
  {
  
  	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 +	rmdir(MNTPOINT);
 +	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
-+	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, NULL);
  
 -	TEST_PAUSE;
  
@@ -59,14 +58,13 @@ index 63c716ff6..21b62d10d 100644
  		tst_brkm(TBROK, cleanup,
  			 "open(%s, O_RDWR|O_CREAT,0777) Failed, errno=%d : %s",
  			 fname, errno, strerror(errno));
-@@ -210,7 +205,8 @@ void cleanup(void)
+@@ -210,7 +204,7 @@ void cleanup(void)
  		tst_resm(TWARN, "close(%s) Failed, errno=%d : %s", fname, errno,
  			 strerror(errno));
  	}
 -
 -	tst_rmdir();
 +	remove(FILENAME);
-+	SAFE_UMOUNT(NULL, MNTPOINT);
 +	SAFE_RMDIR(NULL, MNTPOINT);
  
  }

--- a/tests/ltp/patches/fcntl25.patch
+++ b/tests/ltp/patches/fcntl25.patch
@@ -1,6 +1,6 @@
 Test was failing as it used RAMFS. Fix is to use root file system.
 diff --git a/testcases/kernel/syscalls/fcntl/fcntl25.c b/testcases/kernel/syscalls/fcntl/fcntl25.c
-index 4917584c9..bef760cc9 100644
+index 4917584c9..b39eab8f3 100644
 --- a/testcases/kernel/syscalls/fcntl/fcntl25.c
 +++ b/testcases/kernel/syscalls/fcntl/fcntl25.c
 @@ -94,6 +94,11 @@
@@ -41,13 +41,12 @@ index 4917584c9..bef760cc9 100644
      /***************************************************************
       * check looping state if -c option given
       ***************************************************************/
-@@ -186,13 +183,11 @@ void setup(void)
+@@ -186,13 +183,10 @@ void setup(void)
  {
  
  	tst_sig(NOFORK, DEF_HANDLER, cleanup);
 +	rmdir(MNTPOINT);
 +	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
-+	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, NULL);
  
 -	TEST_PAUSE;
 -
@@ -59,14 +58,13 @@ index 4917584c9..bef760cc9 100644
  		tst_brkm(TBROK, cleanup,
  			 "open(%s, O_RDONLY|O_CREAT,0777) Failed, errno=%d : %s",
  			 fname, errno, strerror(errno));
-@@ -211,7 +206,8 @@ void cleanup(void)
+@@ -211,7 +205,7 @@ void cleanup(void)
  		tst_resm(TWARN, "close(%s) Failed, errno=%d : %s", fname, errno,
  			 strerror(errno));
  	}
 -
 -	tst_rmdir();
 +	remove(FILENAME);
-+	SAFE_UMOUNT(NULL, MNTPOINT);
 +	SAFE_RMDIR(NULL, MNTPOINT);
  
  }

--- a/tests/ltp/patches/fcntl32.patch
+++ b/tests/ltp/patches/fcntl32.patch
@@ -1,6 +1,6 @@
 Test was failing as it used RAMFS. Fix is to use root file system.
 diff --git a/testcases/kernel/syscalls/fcntl/fcntl32.c b/testcases/kernel/syscalls/fcntl/fcntl32.c
-index f567acc70..2d9b574cc 100644
+index f567acc70..eeea3896b 100644
 --- a/testcases/kernel/syscalls/fcntl/fcntl32.c
 +++ b/testcases/kernel/syscalls/fcntl/fcntl32.c
 @@ -31,6 +31,9 @@ static void verify_fcntl(int);
@@ -22,7 +22,7 @@ index f567acc70..2d9b574cc 100644
  
  int main(int ac, char **av)
  {
-@@ -77,29 +82,17 @@ int main(int ac, char **av)
+@@ -77,29 +82,16 @@ int main(int ac, char **av)
  static void setup(void)
  {
  	tst_sig(NOFORK, DEF_HANDLER, cleanup);
@@ -43,7 +43,6 @@ index f567acc70..2d9b574cc 100644
 -	}
 +	rmdir(MNTPOINT);
 +	SAFE_MKDIR(cleanup, MNTPOINT, DIR_MODE);
-+	SAFE_MOUNT(cleanup, device, MNTPOINT, fs_type, 0, NULL);
  
 -	SAFE_TOUCH(cleanup, "file", FILE_MODE, NULL);
 +	SAFE_TOUCH(cleanup, FILENAME, FILE_MODE, NULL);
@@ -58,12 +57,11 @@ index f567acc70..2d9b574cc 100644
  
  	TEST(fcntl(fd1, F_SETLEASE, F_WRLCK));
  
-@@ -132,6 +125,8 @@ static void cleanup(void)
+@@ -132,6 +124,7 @@ static void cleanup(void)
  
  	if (fd2 > 0 && close(fd2))
  		tst_resm(TWARN | TERRNO, "Failed to close file");
 +	remove(FILENAME);
-+	SAFE_UMOUNT(NULL, MNTPOINT);
 +	SAFE_RMDIR(NULL, MNTPOINT);
  
 -	tst_rmdir();


### PR DESCRIPTION
Issue: These tests were mounting root file system again though it is already available
Fix : Remove mount / unmount so tests use already mounted root file system.