### PR TITLE
LTP: Fix for fsync01 to use already mounted root file system

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -261,7 +261,7 @@
 /ltp/testcases/kernel/syscalls/fstatat/fstatat01
 /ltp/testcases/kernel/syscalls/fstatfs/fstatfs01
 /ltp/testcases/kernel/syscalls/fstatfs/fstatfs02
-/ltp/testcases/kernel/syscalls/fsync/fsync01
+#/ltp/testcases/kernel/syscalls/fsync/fsync01
 /ltp/testcases/kernel/syscalls/fsync/fsync02
 /ltp/testcases/kernel/syscalls/fsync/fsync03
 /ltp/testcases/kernel/syscalls/fsync/fsync04

--- a/tests/ltp/patches/ltp_fsync_fsync01.patch
+++ b/tests/ltp/patches/ltp_fsync_fsync01.patch
@@ -1,34 +1,23 @@
 + // Patch Description: Tests are failing with kernel panic while using loop device filesystem
 + // So modified the tests to use root file system.
 diff --git a/testcases/kernel/syscalls/fsync/fsync01.c b/testcases/kernel/syscalls/fsync/fsync01.c
-index 9af38dce0..5bea2773a 100644
+index 9af38dce0..4a3f68039 100644
 --- a/testcases/kernel/syscalls/fsync/fsync01.c
 +++ b/testcases/kernel/syscalls/fsync/fsync01.c
-@@ -33,6 +33,8 @@ static void verify_fsync(void)
-
+@@ -33,7 +33,7 @@ static void verify_fsync(void)
+ 
  static void setup(void)
  {
-+       SAFE_MKDIR("mntpoint", 0644);
-+       SAFE_MOUNT("/dev/vda", "mntpoint", "ext4", 0, NULL);
-        sprintf(fname, "mntpoint/tfile_%d", getpid());
-        fd = SAFE_OPEN(fname, O_RDWR | O_CREAT, 0700);
+-	sprintf(fname, "mntpoint/tfile_%d", getpid());
++	sprintf(fname, "tfile_%d", getpid());
+ 	fd = SAFE_OPEN(fname, O_RDWR | O_CREAT, 0700);
  }
-@@ -41,6 +43,9 @@ static void cleanup(void)
- {
-        if (fd > 0)
-                SAFE_CLOSE(fd);
-+       remove(fname);
-+       SAFE_UMOUNT("mntpoint");
-+       SAFE_RMDIR("mntpoint");
- }
-
- static struct tst_test test = {
-@@ -49,7 +54,4 @@ static struct tst_test test = {
-        .test_all = verify_fsync,
-        .needs_tmpdir = 1,
-        .needs_root = 1,
--       .mount_device = 1,
--       .mntpoint = "mntpoint",
--       .all_filesystems = 1,
+ 
+@@ -49,7 +49,4 @@ static struct tst_test test = {
+ 	.test_all = verify_fsync,
+ 	.needs_tmpdir = 1,
+ 	.needs_root = 1,
+-	.mount_device = 1,
+-	.mntpoint = "mntpoint",
+-	.all_filesystems = 1,
  };
-


### PR DESCRIPTION
Issue: Remove mount of root file system already mounted.
Fix:   Create test files on already mounted root filesystem.
Ref: https://github.com/lsds/sgx-lkl/issues/552