### PR TITLE
LTP: Enable fsync02 and fsync03 test cases

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -262,8 +262,8 @@
 /ltp/testcases/kernel/syscalls/fstatfs/fstatfs01
 /ltp/testcases/kernel/syscalls/fstatfs/fstatfs02
 #/ltp/testcases/kernel/syscalls/fsync/fsync01
-/ltp/testcases/kernel/syscalls/fsync/fsync02
-/ltp/testcases/kernel/syscalls/fsync/fsync03
+#/ltp/testcases/kernel/syscalls/fsync/fsync02
+#/ltp/testcases/kernel/syscalls/fsync/fsync03
 /ltp/testcases/kernel/syscalls/fsync/fsync04
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate01
 /ltp/testcases/kernel/syscalls/ftruncate/ftruncate03

--- a/tests/ltp/patches/fix_fsync_fsync03.patch
+++ b/tests/ltp/patches/fix_fsync_fsync03.patch
@@ -1,0 +1,15 @@
+Closing the open file descriptors in clean up
+
+diff --git a/testcases/kernel/syscalls/fsync/fsync03.c b/testcases/kernel/syscalls/fsync/fsync03.c
+index 60d15f429..aa42ec966 100644
+--- a/testcases/kernel/syscalls/fsync/fsync03.c
++++ b/testcases/kernel/syscalls/fsync/fsync03.c
+@@ -135,6 +135,8 @@ void setup(void)
+ void cleanup(void)
+ {
+ 
++	close(fd[0]);
++	close(fd[1]);
+ 	/* delete the test directory created in setup() */
+ 	tst_rmdir();
+ 


### PR DESCRIPTION
the fsync02, fsync03 test cases are not explicitly mounting any fs.
fsync02 creates a file in already mounted rootfs. fsync03 performs
the test on pipe descriptors.

fixed minor issue in fsync03. The pipe descriptors are force closed
in the cleanup function.