### PR TITLE
Report unhandled exceptions during LKL shutdown

### DIFF
--- a/src/enclave/enclave_signal.c
+++ b/src/enclave/enclave_signal.c
@@ -8,6 +8,7 @@
 #include <asm-generic/ucontext.h>
 
 #include <lkl_host.h>
+#include <lkl/setup.h>
 #include <string.h>
 #include "enclave/sgxlkl_t.h"
 #include "enclave/lthread.h"
@@ -151,10 +152,11 @@ static uint64_t sgxlkl_enclave_signal_handler(
 #endif
 
         /**
-         * If LKL has not yet been initialised, we cannot handle the
-         * exception and fail instead.
+         * If LKL has not yet been initialised or is terminating (and thus no
+         * longer accepts signals), we cannot handle the exception and fail
+         * instead.
          */
-        if (!lkl_is_running())
+        if (!lkl_is_running() || is_lkl_terminating())
         {
 #ifdef DEBUG
             sgxlkl_error("Exception received before LKL can handle it. "

--- a/src/enclave/enclave_signal.c
+++ b/src/enclave/enclave_signal.c
@@ -159,7 +159,7 @@ static uint64_t sgxlkl_enclave_signal_handler(
         if (!lkl_is_running() || is_lkl_terminating())
         {
 #ifdef DEBUG
-            sgxlkl_error("Exception received before LKL can handle it. "
+            sgxlkl_error("Exception received but LKL is unable to handle it. "
                          "Printing stack trace saved by exception handler:\n");
             /**
              * Since we cannot unwind the frames in the OE exception handler,
@@ -171,7 +171,8 @@ static uint64_t sgxlkl_enclave_signal_handler(
 
             struct lthread* lt = lthread_self();
             sgxlkl_fail(
-                "Exception %s received before LKL is running (lt->tid=%i [%s] "
+                "Exception %s received before LKL initialisation/after LKL "
+                "shutdown (lt->tid=%i [%s] "
                 "code=%i "
                 "addr=0x%lx opcode=0x%x "
                 "ret=%i)\n",

--- a/src/include/lkl/setup.h
+++ b/src/include/lkl/setup.h
@@ -17,4 +17,7 @@ void lkl_mount_disks(
 /* Shutdown the running LKL kernel */
 void lkl_terminate(int exit_status);
 
+/* Return if LKL is currently terminating */
+bool is_lkl_terminating();
+
 #endif /* SETUP_H */

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1182,7 +1182,7 @@ static void display_mount_table()
 static struct lkl_sem* termination_sem;
 
 /* Record whether we are terminmating LKL */
-static _Atomic(bool) is_lkl_terminating = false;
+static _Atomic(bool) _is_lkl_terminating = false;
 
 /* Function to carry out the shutdown sequence */
 static void* lkl_termination_thread(void* args)
@@ -1344,14 +1344,20 @@ void lkl_terminate(int exit_status)
      * We only want to trigger the shutdown once. Since we are shutting down
      * the applicaton and the kernel, many other threads will be exiting now.
      */
-    if (!is_lkl_terminating)
+    if (!_is_lkl_terminating)
     {
         SGXLKL_VERBOSE("terminating LKL (exit_status=%i)\n", exit_status);
-        is_lkl_terminating = true;
+        _is_lkl_terminating = true;
         sgxlkl_exit_status = exit_status;
         /* Wake up LKL termination thread to carry out the work. */
         sgxlkl_host_ops.sem_up(termination_sem);
     }
+}
+
+/* Return if LKL is currently terminating */
+bool is_lkl_terminating()
+{
+    return _is_lkl_terminating;
 }
 
 static void init_enclave_clock()

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -263,7 +263,7 @@ void lthread_run(void)
         if (_lthread_should_stop)
         {
             SGXLKL_TRACE_THREAD(
-                "[tid=%-3d] lthread_run(): quiting\n", lt ? lt->tid : -1);
+                "[tid=%-3d] lthread_run(): quitting\n", lt ? lt->tid : -1);
             break;
         }
     }

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -225,9 +225,8 @@ void lthread_run(void)
                 pauses = sleepspins;
                 a_dec(&schedqueuelen);
                 SGXLKL_TRACE_THREAD(
-                    "[tid=%-3d] lthread_run() lthread_resume (dequeue sched "
-                    "queue) \n",
-                    lt->tid);
+                    "[tid=%-3d] lthread_run(): lthread_resume (dequeue)\n",
+                    lt ? lt->tid : -1);
                 _lthread_resume(lt);
             }
 
@@ -263,7 +262,8 @@ void lthread_run(void)
         /* Break out of scheduler loop when enclave is terminating */
         if (_lthread_should_stop)
         {
-            SGXLKL_TRACE_THREAD("[tid=%-3d] lthread_run() quiting.\n", lt->tid);
+            SGXLKL_TRACE_THREAD(
+                "[tid=%-3d] lthread_run(): quiting\n", lt ? lt->tid : -1);
             break;
         }
     }


### PR DESCRIPTION
This PR tries to fix https://github.com/lsds/sgx-lkl/issues/560:

- It reports unhandled exceptions during LKL shutdown, which otherwise may be ignored silently.

- It also removes access to deallocated lthread state.
