### PR TITLE
LTP:Fix for mknodat02

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -529,7 +529,7 @@
 /ltp/testcases/kernel/syscalls/mknod/mknod08
 /ltp/testcases/kernel/syscalls/mknod/mknod09
 /ltp/testcases/kernel/syscalls/mknodat/mknodat01
-/ltp/testcases/kernel/syscalls/mknodat/mknodat02
+#/ltp/testcases/kernel/syscalls/mknodat/mknodat02
 /ltp/testcases/kernel/syscalls/mlock/mlock01
 /ltp/testcases/kernel/syscalls/mlock/mlock02
 /ltp/testcases/kernel/syscalls/mlock/mlock03

--- a/tests/ltp/patches/mknodat02.patch
+++ b/tests/ltp/patches/mknodat02.patch
@@ -1,0 +1,55 @@
+Patch to use root file system for the test as loop device file
+system cannot be used as lkl Kernel Memory is set to 32M.
+
+diff --git a/testcases/kernel/syscalls/mknodat/mknodat02.c b/testcases/kernel/syscalls/mknodat/mknodat02.c
+index 6c5054bbc..5339ab841 100644
+--- a/testcases/kernel/syscalls/mknodat/mknodat02.c
++++ b/testcases/kernel/syscalls/mknodat/mknodat02.c
+@@ -69,9 +69,11 @@ static struct test_case_t {
+ 	{ &curfd, "tnode1", FIFOMODE, 0 },
+ 	{ &curfd, "tnode2", FREGMODE, 0 },
+ 	{ &curfd, "tnode3", SOCKMODE, 0 },
+-	{ &dir_fd, "tnode4", FIFOMODE, EROFS },
+-	{ &dir_fd, "tnode5", FREGMODE, EROFS },
+-	{ &dir_fd, "tnode6", SOCKMODE, EROFS },
++// Below tests are disabled as we dont have a device
++// with read only file system in SGX
++//	{ &dir_fd, "tnode4", FIFOMODE, EROFS },
++//	{ &dir_fd, "tnode5", FREGMODE, EROFS },
++//	{ &dir_fd, "tnode6", SOCKMODE, EROFS },
+ 	{ &curfd, elooppathname, FIFOMODE, ELOOP },
+ 	{ &curfd, elooppathname, FREGMODE, ELOOP },
+ 	{ &curfd, elooppathname, SOCKMODE, ELOOP },
+@@ -118,12 +120,6 @@ static void setup(void)
+ 	tst_tmpdir();
+ 
+ 	fs_type = tst_dev_fs_type();
+-	device = tst_acquire_device(cleanup);
+-
+-	if (!device)
+-		tst_brkm(TCONF, cleanup, "Failed to acquire device");
+-
+-	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+ 
+ 	TEST_PAUSE;
+ 
+@@ -131,7 +127,6 @@ static void setup(void)
+ 	 * mount a read-only file system for EROFS test
+ 	 */
+ 	SAFE_MKDIR(cleanup, MNT_POINT, DIR_MODE);
+-	SAFE_MOUNT(cleanup, device, MNT_POINT, fs_type, MS_RDONLY, NULL);
+ 	mount_flag = 1;
+ 	dir_fd = SAFE_OPEN(cleanup, MNT_POINT, O_DIRECTORY);
+ 
+@@ -174,11 +169,6 @@ static void cleanup(void)
+ {
+ 	if (dir_fd > 0 && close(dir_fd) < 0)
+ 		tst_resm(TWARN | TERRNO, "close(%d) failed", dir_fd);
+-	if (mount_flag && tst_umount(MNT_POINT) < 0)
+-		tst_resm(TWARN | TERRNO, "umount device:%s failed", device);
+-
+-	if (device)
+-		tst_release_device(device);
+ 
+ 	tst_rmdir();
+ }


### PR DESCRIPTION
Issue: Test requires a test file system. This was failing due to memory of SGXs set to 32MB and test file system needs256 MB.
Fix: Use root file system for the test 