### PR TITLE
Rebase OE with master for new EEID changes

### DIFF
--- a/src/enclave/enclave_util.c
+++ b/src/enclave/enclave_util.c
@@ -98,7 +98,7 @@ void sgxlkl_print_backtrace(void** start_frame)
     for (i = 0; i < size; i++)
         sgxlkl_info("    #%ld: %p in %s(...)\n", i, buf[i], strings[i]);
 
-    oe_free(strings);
+    oe_backtrace_symbols_free(strings);
 }
 #endif
 

--- a/src/include/openenclave/internal/backtrace.h
+++ b/src/include/openenclave/internal/backtrace.h
@@ -26,6 +26,11 @@ int oe_backtrace(void** buffer, int size);
 char** oe_backtrace_symbols(void* const* buffer, int size);
 
 /**
+ * Free symbols allocated with oe_backtrace_symbols
+ */
+void oe_backtrace_symbols_free(char** ptr);
+
+/**
  * Print a backtrace for the current function.
  */
 oe_result_t oe_print_backtrace(void);

--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -695,7 +695,10 @@ static void host_free(void *ptr)
 		kernel_mem = 0;
 		kernel_mem_size = 0;
 	}
-	oe_free(ptr);
+    else
+    {
+        oe_free(ptr);
+    }
 }
 
 struct lkl_host_operations sgxlkl_host_ops = {

--- a/src/sgxlkl.edl
+++ b/src/sgxlkl.edl
@@ -18,7 +18,7 @@ enclave {
     from "openenclave/edl/logging.edl" import *;
     from "openenclave/edl/sgx/cpu.edl" import *;
     from "openenclave/edl/sgx/debug.edl" import *;
-    from "openenclave/edl/sgx/sgx_attestation.edl" import *;
+    from "openenclave/edl/sgx/attestation.edl" import *;
 
     include "shared/sgxlkl_config.h"
 


### PR DESCRIPTION
Update OE submodule after rebase of branch.

Note that this PR also contains fixes for:
* Name change in sgx/attestation.edl
* Some instances where oe_free was being used to free memory not allocated by oe_malloc. This was caught by new debugmalloc functionality in OE.