### PR TITLE
Disable shallow submodule update

### DIFF
--- a/.azure-pipelines/scripts/checkout_submodules.sh
+++ b/.azure-pipelines/scripts/checkout_submodules.sh
@@ -8,7 +8,7 @@ ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 find .git -type f -name '*.lock' -exec rm -v {} +
 git reset --hard
 git submodule sync
-git submodule update --init --force --recursive --depth 1
+git submodule update --init --force --recursive
 git submodule foreach git reset --hard
 git clean -xdf
 git submodule foreach git clean -xdf


### PR DESCRIPTION
There are repeated CI failures like
> fatal: shallow file has changed since we read it
Fetched in submodule path 'openenclave/3rdparty/optee/optee_os', but it did not contain d1634ce8ff4a39242d4d333392e260e00405e471. Direct fetching of that commit failed.

I think this happens when a submodule points to a commit that is not a tag. GitHub disallows direct fetching of commits. Cloning submodules in full will not have that issue at the cost of slightly longer checkout time.