### PR TITLE
Implement nighly build test mechanism

### DIFF
--- a/.azure-pipelines/azure-pipelines-master.yml
+++ b/.azure-pipelines/azure-pipelines-master.yml
@@ -12,4 +12,5 @@ extends:
   template: template.yml
   parameters:
     publish: true
+    nightly_build: false
     apt_repo_blob_container: apt-dev

--- a/.azure-pipelines/azure-pipelines-master.yml
+++ b/.azure-pipelines/azure-pipelines-master.yml
@@ -12,5 +12,5 @@ extends:
   template: template.yml
   parameters:
     publish: true
-    nightly_build: false
+    nightly_build: 0
     apt_repo_blob_container: apt-dev

--- a/.azure-pipelines/azure-pipelines-nightly.yml
+++ b/.azure-pipelines/azure-pipelines-nightly.yml
@@ -12,6 +12,7 @@ extends:
   template: template.yml
   parameters:
     publish: false
+    nightly_build: true
     test_timeout_minutes: 120 # ethread==1 takes longer to run
     ethreads:
     - 1

--- a/.azure-pipelines/azure-pipelines-nightly.yml
+++ b/.azure-pipelines/azure-pipelines-nightly.yml
@@ -12,7 +12,7 @@ extends:
   template: template.yml
   parameters:
     publish: false
-    nightly_build: true
+    nightly_build: 1
     test_timeout_minutes: 120 # ethread==1 takes longer to run
     ethreads:
     - 1

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -5,7 +5,7 @@ extends:
   template: template.yml
   parameters:
     publish: true
-    nightly_build: false
+    nightly_build: 0
     apt_repo_blob_container: apt
     test_timeout_minutes: 120 # ethread==1 takes longer to run
     ethreads:

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -5,6 +5,7 @@ extends:
   template: template.yml
   parameters:
     publish: true
+    nightly_build: false
     apt_repo_blob_container: apt
     test_timeout_minutes: 120 # ethread==1 takes longer to run
     ethreads:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,4 +12,4 @@ extends:
   template: template.yml
   parameters:
     publish: false
-    nightly_build: false
+    nightly_build: 0

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,3 +12,4 @@ extends:
   template: template.yml
   parameters:
     publish: false
+    nightly_build: false

--- a/.azure-pipelines/other/nightly_run_only_tests.txt
+++ b/.azure-pipelines/other/nightly_run_only_tests.txt
@@ -1,0 +1,1 @@
+tests/ml/openvino/Makefile

--- a/.azure-pipelines/scripts/junit_utils.sh
+++ b/.azure-pipelines/scripts/junit_utils.sh
@@ -136,12 +136,12 @@ function JunitTestFinished()
         fi
 	# Replace STACK_TRACE place holder with stack trace file
         AddLogFileToJunit "$stack_trace_file_path" "$junit_file_path" "STACK_TRACE"
-    fi
 
-    # Add stdout file to junit if exist
-    if [[ -f "$stdout_file_path" ]]; then
-        echo "      <system-out>STD_OUT_MESSAGE</system-out>" >> "$junit_file_path"
-        AddLogFileToJunit "$stdout_file_path" "$junit_file_path" "STD_OUT_MESSAGE"
+        # Add stdout file to junit if exist
+        if [[ -f "$stdout_file_path" ]]; then
+            echo "      <system-out>STD_OUT_MESSAGE</system-out>" >> "$junit_file_path"
+            AddLogFileToJunit "$stdout_file_path" "$junit_file_path" "STD_OUT_MESSAGE"
+        fi
     fi
 
     {

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -200,7 +200,7 @@ suite_test_start_time=$(date +%s)
 
 failure_identifiers=()
 while IFS= read -r line; do failure_identifiers+=("$line"); done < "$failure_identifiers_file"
-
+echo "Nightly build: $SGXLKL_NIGHTLY_BUILD"
 for file in "${file_list[@]}";
 do
     SkipTestIfDisabled

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -19,7 +19,7 @@ if [ -z "$SGXLKL_BUILD_MODE" ]; then
     exit 1
 fi
 if [ -z "$SGXLKL_NIGHTLY_BUILD" ]; then
-    echo "ERROR: 'SGXLKL_NIGHTLY_BUILD' is undefined. Please export SGXLKL_NIGHTLY_BUILD_MODE=true|false"
+    echo "ERROR: 'SGXLKL_NIGHTLY_BUILD' is undefined. Please export SGXLKL_NIGHTLY_BUILD_MODE=0|1"
     exit 1
 fi
 
@@ -146,7 +146,7 @@ function SkipTestIfDisabled()
     fi
 
     # If this test is in $nightly_tests_file and this is not a nightly build skip it
-    if [[ $is_test_disabled -eq 0 && $SGXLKL_NIGHTLY_BUILD -eq 1 ]]; then
+    if [[ $is_test_disabled -eq 0 && $SGXLKL_NIGHTLY_BUILD -eq 0 ]]; then
         is_test_nightly_only=$(grep -c "$file" "$nightly_tests_file")
         if [[ $is_test_nightly_only -ge 1 ]]; then
             echo "Test $file is marked nighlty build only. Skipping test..."

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -19,8 +19,7 @@ if [ -z "$SGXLKL_BUILD_MODE" ]; then
     exit 1
 fi
 if [ -z "$SGXLKL_NIGHTLY_BUILD" ]; then
-    echo "ERROR: 'SGXLKL_NIGHTLY_BUILD' is undefined. Please export SGXLKL_NIGHTLY_BUILD_MODE=0|1"
-    exit 1
+    export SGXLKL_NIGHTLY_BUILD=0
 fi
 
 #shellcheck source=.azure-pipelines/scripts/test_utils.sh
@@ -147,15 +146,15 @@ function SkipTestIfDisabled()
 
     # If this test is in $nightly_tests_file and this is not a nightly build skip it
     if [[ $is_test_disabled -eq 0 && $SGXLKL_NIGHTLY_BUILD -eq 0 ]]; then
-        is_test_nightly_only=$(grep -c "$file" "$nightly_tests_file")
-        if [[ $is_test_nightly_only -ge 1 ]]; then
+        is_test_disabled=$(grep -c "$file" "$nightly_tests_file")
+        if [[ $is_test_disabled -ge 1 ]]; then
             echo "Test $file is marked nightly build only. Skipping test..."
             echo "To enable the test remove $file from $nightly_tests_file"
         fi
     fi
 
     # if this test is disabled set counters and skip to next test
-    if [[ $is_test_disabled -ge 1 || $is_test_nightly_only -ge 1 ]]; then
+    if [[ $is_test_disabled -ge 1 ]]; then
         total_disabled=$((total_disabled + 1))
         counter=$((counter + 1))
         total_remaining=$((total_tests - counter))
@@ -200,7 +199,8 @@ suite_test_start_time=$(date +%s)
 
 failure_identifiers=()
 while IFS= read -r line; do failure_identifiers+=("$line"); done < "$failure_identifiers_file"
-echo "This is Nightly Build: $SGXLKL_NIGHTLY_BUILD"
+[[ $SGXLKL_NIGHTLY_BUILD -eq 1 ]] && echo "This is Nightly Build. Tests marked for nightly build only will be run."
+
 for file in "${file_list[@]}";
 do
     SkipTestIfDisabled

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -146,7 +146,7 @@ function SkipTestIfDisabled()
     fi
 
     # If this test is in $nightly_tests_file and this is not a nightly build skip it
-    if [[ $is_test_disabled -eq 0 && "$SGXLKL_NIGHTLY_BUILD" = "false" ]]; then
+    if [[ $is_test_disabled -eq 0 && $SGXLKL_NIGHTLY_BUILD -eq 1 ]]; then
         is_test_nightly_only=$(grep -c "$file" "$nightly_tests_file")
         if [[ $is_test_nightly_only -ge 1 ]]; then
             echo "Test $file is marked nighlty build only. Skipping test..."
@@ -200,7 +200,7 @@ suite_test_start_time=$(date +%s)
 
 failure_identifiers=()
 while IFS= read -r line; do failure_identifiers+=("$line"); done < "$failure_identifiers_file"
-echo "Nightly build: $SGXLKL_NIGHTLY_BUILD"
+echo "This is Nightly Build: $SGXLKL_NIGHTLY_BUILD"
 for file in "${file_list[@]}";
 do
     SkipTestIfDisabled

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -149,7 +149,7 @@ function SkipTestIfDisabled()
     if [[ $is_test_disabled -eq 0 && $SGXLKL_NIGHTLY_BUILD -eq 0 ]]; then
         is_test_nightly_only=$(grep -c "$file" "$nightly_tests_file")
         if [[ $is_test_nightly_only -ge 1 ]]; then
-            echo "Test $file is marked nighlty build only. Skipping test..."
+            echo "Test $file is marked nightly build only. Skipping test..."
             echo "To enable the test remove $file from $nightly_tests_file"
         fi
     fi

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -18,6 +18,10 @@ if [ -z "$SGXLKL_BUILD_MODE" ]; then
     echo "ERROR: 'SGXLKL_BUILD_MODE' is undefined. Please export SGXLKL_BUILD_MODE=<mode>"
     exit 1
 fi
+if [ -z "$SGXLKL_NIGHTLY_BUILD" ]; then
+    echo "ERROR: 'SGXLKL_NIGHTLY_BUILD' is undefined. Please export SGXLKL_NIGHTLY_BUILD_MODE=true|false"
+    exit 1
+fi
 
 #shellcheck source=.azure-pipelines/scripts/test_utils.sh
 . "$SGXLKL_ROOT/.azure-pipelines/scripts/test_utils.sh"
@@ -134,12 +138,24 @@ function GetReadyToRunNextTest()
 function SkipTestIfDisabled()
 {
     skip_test=false
+    # If this test is in $disabled_tests_file skip it
     is_test_disabled=$(grep -c "$file" "$disabled_tests_file")
-    # if this test is disabled set counters and skip to next test
     if [[ $is_test_disabled -ge 1 ]]; then
         echo "Test $file is disabled. Skipping test..."
         echo "To enable the test remove $file from $disabled_tests_file"
+    fi
 
+    # If this test is in $nightly_tests_file and this is not a nightly build skip it
+    if [[ $is_test_disabled -eq 0 && "$SGXLKL_NIGHTLY_BUILD" = "false" ]]; then
+        is_test_nightly_only=$(grep -c "$file" "$nightly_tests_file")
+        if [[ $is_test_nightly_only -ge 1 ]]; then
+            echo "Test $file is marked nighlty build only. Skipping test..."
+            echo "To enable the test remove $file from $nightly_tests_file"
+        fi
+    fi
+
+    # if this test is disabled set counters and skip to next test
+    if [[ $is_test_disabled -ge 1 || $is_test_nightly_only -ge 1 ]]; then
         total_disabled=$((total_disabled + 1))
         counter=$((counter + 1))
         total_remaining=$((total_tests - counter))
@@ -151,6 +167,7 @@ test_folder_name="tests"
 test_folder_identifier="Makefile"
 test_runner_script="$SGXLKL_ROOT/.azure-pipelines/scripts/run_test.sh"
 disabled_tests_file="$SGXLKL_ROOT/.azure-pipelines/scripts/disabled_tests.txt"
+nightly_tests_file="$SGXLKL_ROOT/.azure-pipelines/other/nightly_run_only_tests.txt"
 # test which needs not to be executed as part of CI e.g (test_name1\|test_name2...)
 test_exception_list="ltp"
 

--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -47,6 +47,9 @@ parameters:
 - name: 'publish'
   type: boolean
   default: false
+- name: 'nightly_build'
+  type: boolean
+  default: false
 - name: 'apt_repo_blob_container'
   type: string
   default: 'apt-dev'
@@ -148,6 +151,7 @@ stages:
                 run_mode: "run-${{ run_mode }}"
                 SGXLKL_PREFIX: ${{ parameters.install_prefix_mapping[build_mode] }}
                 SGXLKL_ETHREADS: ${{ ethreads }}
+                SGXLKL_NIGHTLY_BUILD: ${{ parameters.nightly_build }}
 
             - task: PublishTestResults@2
               displayName: "Publish Test Results *.xml"

--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -48,8 +48,8 @@ parameters:
   type: boolean
   default: false
 - name: 'nightly_build'
-  type: boolean
-  default: false
+  type: number
+  default: 0
 - name: 'apt_repo_blob_container'
   type: string
   default: 'apt-dev'


### PR DESCRIPTION
With this PR we can mark any test (long running ones for example) as nightly build only
by adding them to file .azure-pipelines/other/nighlty_run_only_tests.txt

If SGXLKL_NIGHTLY_BUILD environment variable is set to false, the tests in this file will be skipped.
These tests will run only if SGXLKL_NIGHTLY_BUILD env variable is true.