### PR TITLE
LTP: fix oom error in mknod07 test case

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -525,7 +525,7 @@
 #/ltp/testcases/kernel/syscalls/mknod/mknod04
 #/ltp/testcases/kernel/syscalls/mknod/mknod05
 #/ltp/testcases/kernel/syscalls/mknod/mknod06
-/ltp/testcases/kernel/syscalls/mknod/mknod07
+#/ltp/testcases/kernel/syscalls/mknod/mknod07
 #/ltp/testcases/kernel/syscalls/mknod/mknod08
 #/ltp/testcases/kernel/syscalls/mknod/mknod09
 #/ltp/testcases/kernel/syscalls/mknodat/mknodat01

--- a/tests/ltp/patches/fix_mknod_mknod07.patch
+++ b/tests/ltp/patches/fix_mknod_mknod07.patch
@@ -1,0 +1,111 @@
+One of the test cases is to create a special file in read-only fs.
+while creating a read-only fs, LTP framework causing the oom error. 
+Please read the below details.
+ ------------------------------------------------
+ The default size of LKL memory is set to 32M. 
+ This is kept low due to the limited size of EPC (Enclave page cache)
+ and to avoid page cache being swapped out.
+
+ In tests, where loop device is used ltp framework was causing a problem,
+ as it tries to create a 256M in-memory file system.
+ ltp framework performs the below activity.
+ 1. Create a .img of size 256M
+ 2. Create a loop device and mount.
+ 
+ Also, it needs to run mkfs utility using an unsupported system() system call. 
+ ------------------------------------------------
+
+In sgx-lkl environment, explicit mount and unmount of fs are not preferred,
+which may corrupt the existing file system. Hence, this subtest case is removed.
+
+diff --git a/testcases/kernel/syscalls/mknod/mknod07.c b/testcases/kernel/syscalls/mknod/mknod07.c
+index 69cff02d9..d99df8b5a 100644
+--- a/testcases/kernel/syscalls/mknod/mknod07.c
++++ b/testcases/kernel/syscalls/mknod/mknod07.c
+@@ -26,9 +26,7 @@
+  *	the caller is not super-user.
+  *   2) mknod(2) returns -1 and sets errno to EACCES if parent directory
+  *	does not allow  write  permission  to  the process.
+- *   3) mknod(2) returns -1 and sets errno to EROFS if pathname refers to
+- *	a file on a read-only file system.
+- *   4) mknod(2) returns -1 and sets errno to ELOOP if too many symbolic
++ *   3) mknod(2) returns -1 and sets errno to ELOOP if too many symbolic
+  *	links were encountered in resolving pathname.
+  *
+  */
+@@ -42,7 +40,6 @@
+ #include <pwd.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+-#include <sys/mount.h>
+ 
+ #include "test.h"
+ #include "safe_macros.h"
+@@ -51,7 +48,6 @@
+ #define DIR_TEMP_MODE		(S_IRUSR | S_IXUSR)
+ #define DIR_MODE		(S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP| \
+ 				 S_IXGRP|S_IROTH|S_IXOTH)
+-#define MNT_POINT		"mntpoint"
+ 
+ #define FIFO_MODE	(S_IFIFO | S_IRUSR | S_IRGRP | S_IROTH)
+ #define SOCKET_MODE	(S_IFSOCK | S_IRWXU | S_IRWXG | S_IRWXO)
+@@ -62,9 +58,6 @@
+ 
+ static char elooppathname[sizeof(ELOPFILE) * 43] = ".";
+ 
+-static const char *device;
+-static int mount_flag;
+-
+ static struct test_case_t {
+ 	char *pathname;
+ 	int mode;
+@@ -74,7 +67,6 @@ static struct test_case_t {
+ 	{ "testdir_1/tnode_2", FIFO_MODE, EACCES },
+ 	{ "tnode_3", CHR_MODE, EPERM },
+ 	{ "tnode_4", BLK_MODE, EPERM },
+-	{ "mntpoint/tnode_5", SOCKET_MODE, EROFS },
+ 	{ elooppathname, FIFO_MODE, ELOOP },
+ };
+ 
+@@ -109,7 +101,6 @@ static void setup(void)
+ {
+ 	int i;
+ 	struct passwd *ltpuser;
+-	const char *fs_type;
+ 
+ 	tst_require_root();
+ 
+@@ -117,21 +108,8 @@ static void setup(void)
+ 
+ 	tst_tmpdir();
+ 
+-	fs_type = tst_dev_fs_type();
+-	device = tst_acquire_device(cleanup);
+-
+-	if (!device)
+-		tst_brkm(TCONF, cleanup, "Failed to acquire device");
+-
+-	tst_mkfs(cleanup, device, fs_type, NULL, NULL);
+-
+ 	TEST_PAUSE;
+ 
+-	/* mount a read-only file system for EROFS test */
+-	SAFE_MKDIR(cleanup, MNT_POINT, DIR_MODE);
+-	SAFE_MOUNT(cleanup, device, MNT_POINT, fs_type, MS_RDONLY, NULL);
+-	mount_flag = 1;
+-
+ 	ltpuser = SAFE_GETPWNAM(cleanup, "nobody");
+ 	SAFE_SETEUID(cleanup, ltpuser->pw_uid);
+ 
+@@ -171,11 +149,5 @@ static void cleanup(void)
+ 	if (seteuid(0) == -1)
+ 		tst_resm(TWARN | TERRNO, "seteuid(0) failed");
+ 
+-	if (mount_flag && tst_umount(MNT_POINT) < 0)
+-		tst_resm(TWARN | TERRNO, "umount device:%s failed", device);
+-
+-	if (device)
+-		tst_release_device(device);
+-
+ 	tst_rmdir();
+ }


### PR DESCRIPTION
One of the test cases is to create a special file in read-only fs.
To perform this subtest case, it mounts a file system in read-only mode.
There is an out of memory error while it creating the loop device and mount.

This subtest case is removed.