### PR TITLE
LTP: Fix test case splice02 failure

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -909,7 +909,7 @@
 #/ltp/testcases/kernel/syscalls/socketpair/socketpair02
 /ltp/testcases/kernel/syscalls/sockioctl/sockioctl01
 #/ltp/testcases/kernel/syscalls/splice/splice01
-/ltp/testcases/kernel/syscalls/splice/splice02
+#/ltp/testcases/kernel/syscalls/splice/splice02
 #/ltp/testcases/kernel/syscalls/splice/splice03
 #/ltp/testcases/kernel/syscalls/splice/splice04
 #/ltp/testcases/kernel/syscalls/splice/splice05

--- a/tests/ltp/patches/fix_splice_splice02.patch
+++ b/tests/ltp/patches/fix_splice_splice02.patch
@@ -1,0 +1,49 @@
+As per the man page, one of the file descriptor passed
+to splice system call should refer to a pipe else it will generate
+EINVAL error.
+In this test case, both file descriptors passed to splice
+system call referred to the file. This test case is modified
+to pass one pipe and one file descriptors to splice system call.
+
+diff --git a/testcases/kernel/syscalls/splice/splice02.c b/testcases/kernel/syscalls/splice/splice02.c
+index b579667b9..5afb96246 100644
+--- a/testcases/kernel/syscalls/splice/splice02.c
++++ b/testcases/kernel/syscalls/splice/splice02.c
+@@ -14,15 +14,21 @@
+ #include "tst_test.h"
+ #include "lapi/splice.h"
+ 
+-#define SPLICE_SIZE (64*1024)
++#define SPLICE_SIZE (1024)
+ 
+ static void splice_test(void)
+ {
+-	int fd;
++	int pipefd[2];
++	FILE* fptr;
+ 
+-	fd = SAFE_OPEN("splice02-temp", O_WRONLY | O_CREAT | O_TRUNC, 0644);
++	fptr = fopen("splice02-temp", "w+");
++	if (fptr == NULL) {
++		tst_brk(TBROK|TERRNO, "Openning of file is failed");
++	}
++
++	SAFE_PIPE(pipefd);
+ 
+-	TEST(splice(STDIN_FILENO, NULL, fd, NULL, SPLICE_SIZE, 0));
++	TEST(splice(fileno(fptr), NULL, pipefd[1], NULL, SPLICE_SIZE, 0));
+ 	if (TST_RET < 0) {
+ 		tst_res(TFAIL, "splice failed - errno = %d : %s",
+ 			TST_ERR, strerror(TST_ERR));
+@@ -30,7 +36,10 @@ static void splice_test(void)
+ 		tst_res(TPASS, "splice() system call Passed");
+ 	}
+ 
+-	SAFE_CLOSE(fd);
++	SAFE_CLOSE(pipefd[0]);
++	SAFE_CLOSE(pipefd[1]);
++
++	fclose(fptr);
+ }
+ 
+ static struct tst_test test = {


### PR DESCRIPTION
As per the man page, one of the file descriptor passed
to splice system call should refer to a pipe else it will generate
EINVAL error.
In this test case, both file descriptors passed to splice
system call referred to the file. This test case is modified
to pass one pipe and one file descriptors to splice system call.