### PR TITLE
LTP: Fix setregid02 test cases failure

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -844,7 +844,7 @@
 /ltp/testcases/kernel/syscalls/setpriority/setpriority01
 #/ltp/testcases/kernel/syscalls/setpriority/setpriority02
 #/ltp/testcases/kernel/syscalls/setregid/setregid01
-/ltp/testcases/kernel/syscalls/setregid/setregid02
+#/ltp/testcases/kernel/syscalls/setregid/setregid02
 #/ltp/testcases/kernel/syscalls/setregid/setregid03
 #/ltp/testcases/kernel/syscalls/setregid/setregid04
 #/ltp/testcases/kernel/syscalls/setresgid/setresgid01

--- a/tests/ltp/patches/fix_setregid_setregid02.patch
+++ b/tests/ltp/patches/fix_setregid_setregid02.patch
@@ -1,0 +1,24 @@
+"nobody" user cannot read other user details from /etc/passwd file.
+code related to setting UID & GID to "nobody" is moved after getting
+group details of other users.
+
+diff --git a/testcases/kernel/syscalls/setregid/setregid02.c b/testcases/kernel/syscalls/setregid/setregid02.c
+index 310eb3a21..96ec981fe 100644
+--- a/testcases/kernel/syscalls/setregid/setregid02.c
++++ b/testcases/kernel/syscalls/setregid/setregid02.c
+@@ -114,12 +114,12 @@ static void setup(void)
+ {
+ 	ltpuser = SAFE_GETPWNAM("nobody");
+ 
+-	SAFE_SETGID(ltpuser->pw_gid);
+-	SAFE_SETUID(ltpuser->pw_uid);
+-
+ 	root = get_group_by_name("root");
+ 	ltpgroup = get_group_by_gid(ltpuser->pw_gid);
+ 	bin = get_group_by_name("bin");
++
++	SAFE_SETGID(ltpuser->pw_gid);
++	SAFE_SETUID(ltpuser->pw_uid);
+ }
+ 
+ static struct tst_test test = {


### PR DESCRIPTION
"nobody" user cannot read other user details from /etc/passwd file.
code related to setting UID & GID to "nobody" is moved after getting
group details of other users.