### PR TITLE
Adding credentials as env variables for remote attestation test

### DIFF
--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -1,4 +1,5 @@
 variables:
+  - group: remote_attestation_credentials
   - name: SGXLKL_ROOT
     value: $(Build.SourcesDirectory)
 
@@ -152,6 +153,11 @@ stages:
                 SGXLKL_PREFIX: ${{ parameters.install_prefix_mapping[build_mode] }}
                 SGXLKL_ETHREADS: ${{ ethreads }}
                 SGXLKL_NIGHTLY_BUILD: ${{ parameters.nightly_build }}
+                MAA_CLIENT_ID: $(MaaClientId)
+                MAA_CLIENT_SECRET: $(MaaClientSecret)
+                MAA_APP_ID: $(MaaAppId)
+                MAA_ADDR: $(MaaAddr)
+                MAA_ADDR_APP: $(MaaAddrApp)
 
             - task: PublishTestResults@2
               displayName: "Publish Test Results *.xml"


### PR DESCRIPTION
We need some credentials for remote attestation scenario tests.
These secrets are defined on ADO and stored encrypted as variable group in library and used in pipeline. 

With this PR we are mapping these credentials to some environment variables on the running VM so that can be consumed by scenario tests. 

These credentials as env variables are will be needed for several scenario tests that will be added soon.