### PR TITLE
ltp: enabling openat02 testcase

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -627,7 +627,7 @@
 /ltp/testcases/kernel/syscalls/open/open13
 /ltp/testcases/kernel/syscalls/open/open14
 #/ltp/testcases/kernel/syscalls/openat/openat01
-/ltp/testcases/kernel/syscalls/openat/openat02
+#/ltp/testcases/kernel/syscalls/openat/openat02
 /ltp/testcases/kernel/syscalls/openat/openat02_child
 /ltp/testcases/kernel/syscalls/openat/openat03
 #/ltp/testcases/kernel/syscalls/pathconf/pathconf01


### PR DESCRIPTION
The test is passing continuously in local, so enabled in pipeline. 