### PR TITLE
Set memory as PROT_NONE when unmapping memory

### DIFF
--- a/src/enclave/enclave_mem.c
+++ b/src/enclave/enclave_mem.c
@@ -456,6 +456,7 @@ int enclave_munmap(void* addr, size_t length)
     used_pages -= occupied_pages;
 
     bitmap_clear(mmap_bitmap, index_top, pages);
+		mprotect(addr, length, PROT_NONE);
     ticket_unlock(&mmaplock);
 
 #if DEBUG


### PR DESCRIPTION
To see what goes boom.