### PR TITLE
Add support for SYS_epoll_wait for new Node.JS sample

### DIFF
--- a/samples/languages/nodejs/Dockerfile
+++ b/samples/languages/nodejs/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.8
+
+RUN apk add --no-cache \
+    nodejs npm
+
+RUN npm i cpu-benchmark
+
+ADD app /app

--- a/samples/languages/nodejs/README.md
+++ b/samples/languages/nodejs/README.md
@@ -1,0 +1,20 @@
+Running NodeJS with SGX-LKL
+===========================
+
+1. Build a Docker container with NodeJS:
+```
+$ docker build -t nodejs .
+```
+
+2. Convert the container to an SGX-LKL root file system image:
+```
+$ sgx-lkl-disk create --docker=nodejs --size=100M nodejs.img
+```
+
+3. Run NodeJS demo program with SGX-LKL:
+```
+$ SGXLKL_MMAP_FILES=Shared sgx-lkl-run-oe --sw-debug --host-config=nodejs-host_config.json --enclave-config=nodejs-enclave_config.json 
+```
+
+Notes
+-----

--- a/samples/languages/nodejs/README.md
+++ b/samples/languages/nodejs/README.md
@@ -13,8 +13,5 @@ $ sgx-lkl-disk create --docker=nodejs --size=100M nodejs.img
 
 3. Run NodeJS demo program with SGX-LKL:
 ```
-$ SGXLKL_MMAP_FILES=Shared sgx-lkl-run-oe --sw-debug --host-config=nodejs-host_config.json --enclave-config=nodejs-enclave_config.json 
+$ sgx-lkl-run-oe --sw-debug --host-config=nodejs-host_config.json --enclave-config=nodejs-enclave_config.json
 ```
-
-Notes
------

--- a/samples/languages/nodejs/app/cpubench.js
+++ b/samples/languages/nodejs/app/cpubench.js
@@ -1,0 +1,9 @@
+const { fib, dist } = require('cpu-benchmark')
+
+console.log('Hello world from Node.JS from inside an SGX enclave!')
+
+const dur = fib(42) 
+console.log('time: ' + dur)
+
+const ops = dist(1000) 
+console.log('operations: ' + ops)

--- a/samples/languages/nodejs/nodejs-enclave_config.json
+++ b/samples/languages/nodejs/nodejs-enclave_config.json
@@ -1,7 +1,7 @@
 {
     "args": [
       "/usr/bin/node"
-      "app/cpubench.js"
+      "/app/cpubench.js"
     ],
 
     "ethreads": "8",
@@ -9,6 +9,8 @@
     "image_sizes": {
       "num_heap_pages": 262144
     },
+
+    "mmap_files": "shared",
 
     "verbose": false
   } 

--- a/samples/languages/nodejs/nodejs-enclave_config.json
+++ b/samples/languages/nodejs/nodejs-enclave_config.json
@@ -1,0 +1,14 @@
+{
+    "args": [
+      "/usr/bin/node"
+      "app/cpubench.js"
+    ],
+
+    "ethreads": "8",
+
+    "image_sizes": {
+      "num_heap_pages": 262144
+    },
+
+    "verbose": false
+  } 

--- a/samples/languages/nodejs/nodejs-host_config.json
+++ b/samples/languages/nodejs/nodejs-host_config.json
@@ -1,0 +1,9 @@
+{
+    "root": {
+        "image_path": "nodejs.img"
+    },
+
+    "tap_device": "sgxlkl_tap0",
+
+    "verbose": false
+} 

--- a/samples/languages/nodejs/nodejs-host_config.json
+++ b/samples/languages/nodejs/nodejs-host_config.json
@@ -3,7 +3,5 @@
         "image_path": "nodejs.img"
     },
 
-    "tap_device": "sgxlkl_tap0",
-
     "verbose": false
 } 

--- a/tests/languages/nodejs/Dockerfile
+++ b/tests/languages/nodejs/Dockerfile
@@ -1,3 +1,5 @@
+# This test explicitly uses Alpine 3.8, as that Node.JS version 
+# requires a working epoll_wait syscall, which we want to test. 
 FROM alpine:3.8
 
 RUN apk add --no-cache \

--- a/tests/languages/nodejs/Dockerfile
+++ b/tests/languages/nodejs/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:lts-alpine3.9
-RUN mkdir -p /app
-COPY index.js /app/index.js
+FROM alpine:3.8
 
+RUN apk add --no-cache \
+    nodejs
+
+RUN mkdir -p /app
+
+COPY index.js /app/index.js

--- a/tests/languages/nodejs/Makefile
+++ b/tests/languages/nodejs/Makefile
@@ -1,7 +1,7 @@
 include ../../common.mk
 
 PROG=/app/index.js
-ENCLAVE_CMD=/usr/local/bin/node ${PROG}
+ENCLAVE_CMD=/usr/bin/node ${PROG}
 
 DISK_IMAGE=sgxlkl-nodejs.img
 IMAGE_SIZE=1.2G


### PR DESCRIPTION
This PR adds support for `SYS_epoll_wait` by redirecting it to `SYS_epoll_pwait`. This is needed to run Node.JS from Alpine 3.8, and the PR adds a new sample for that.

It also only outputs redirected syscalls when the syscall tracing is turned on, otherwise the verbose output is overwhelmed by syscall invocation messages.

Fixes https://github.com/lsds/sgx-lkl/issues/661.