### PR TITLE
LTP: Enabling linkat01 testcase

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -466,7 +466,7 @@
 /ltp/testcases/kernel/syscalls/link/link06
 /ltp/testcases/kernel/syscalls/link/link07
 /ltp/testcases/kernel/syscalls/link/link08
-/ltp/testcases/kernel/syscalls/linkat/linkat01
+#/ltp/testcases/kernel/syscalls/linkat/linkat01
 #/ltp/testcases/kernel/syscalls/linkat/linkat02
 /ltp/testcases/kernel/syscalls/listen/listen01
 /ltp/testcases/kernel/syscalls/listxattr/listxattr01


### PR DESCRIPTION
Test is passing in local, so enabled the test in pipeline.

Logs:
[[  SGX-LKL ]] libc_start_main_stage2(): Calling app main: /ltp/testcases/kernel/syscalls/linkat/linkat01
linkat01    1  TPASS  :  linkat is functionality correct
linkat01    2  TPASS  :  linkat succeeded as expected
linkat01    3  TPASS  :  linkat is functionality correct
linkat01    4  TPASS  :  linkat is functionality correct
linkat01    5  TPASS  :  linkat is functionality correct
linkat01    6  TPASS  :  linkat succeeded as expected
linkat01    7  TPASS  :  linkat is functionality correct
linkat01    8  TPASS  :  linkat failed as expected: TEST_ERRNO=ENOTDIR(20): Not a directory
linkat01    9  TPASS  :  linkat failed as expected: TEST_ERRNO=ENOTDIR(20): Not a directory
linkat01   10  TPASS  :  linkat succeeded as expected
linkat01   11  TPASS  :  linkat is functionality correct
linkat01   12  TPASS  :  linkat failed as expected: TEST_ERRNO=EBADF(9): Bad file descriptor
linkat01   13  TPASS  :  linkat failed as expected: TEST_ERRNO=EBADF(9): Bad file descriptor
linkat01   14  TPASS  :  linkat succeeded as expected
linkat01   15  TPASS  :  linkat is functionality correct
linkat01   16  TPASS  :  linkat failed as expected: TEST_ERRNO=ENOENT(2): No such file or directory
linkat01   17  TPASS  :  linkat failed as expected: TEST_ERRNO=ENOENT(2): No such file or directory
linkat01   18  TPASS  :  linkat succeeded as expected
linkat01   19  TPASS  :  linkat is functionality correct
linkat01   20  TPASS  :  linkat failed as expected: TEST_ERRNO=EXDEV(18): Cross-device link
linkat01   21  TPASS  :  linkat failed as expected: TEST_ERRNO=EPERM(1): Operation not permitted
linkat01   22  TPASS  :  linkat failed as expected: TEST_ERRNO=EINVAL(22): Invalid argument
[[  SGX-LKL ]] lkl_terminate(): terminating LKL (exit_status=0)
