### PR TITLE
LTP: fix batch file issue

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -922,7 +922,7 @@
 #/ltp/testcases/kernel/syscalls/statfs/statfs03
 #/ltp/testcases/kernel/syscalls/statvfs/statvfs01
 #/ltp/testcases/kernel/syscalls/statvfs/statvfs02
-#/ltp/testcases/kernel/syscalls/statx/statx01
+/ltp/testcases/kernel/syscalls/statx/statx01
 #/ltp/testcases/kernel/syscalls/statx/statx02
 #/ltp/testcases/kernel/syscalls/statx/statx03
 /ltp/testcases/kernel/syscalls/statx/statx04
@@ -1016,7 +1016,7 @@
 /ltp/testcases/kernel/syscalls/utime/utime01
 #/ltp/testcases/kernel/syscalls/utime/utime02
 #/ltp/testcases/kernel/syscalls/utime/utime03
-#/ltp/testcases/kernel/syscalls/utime/utime04
+/ltp/testcases/kernel/syscalls/utime/utime04
 #/ltp/testcases/kernel/syscalls/utime/utime05
 /ltp/testcases/kernel/syscalls/utime/utime06
 /ltp/testcases/kernel/syscalls/utimensat/utimensat01


### PR DESCRIPTION
Fix Github issue "https://github.com/lsds/sgx-lkl/issues/685".
LTP tests utime04 and statx01 are enabled in both of the batch files
namely 'ltp-batch2/ltp_disabled_tests.txt' and
'ltp-batch1/ltp_disabled_tests.txt'.
Hence, disabling the tests in 'ltp-batch2/ltp_disabled_tests.txt'.