### PR TITLE
Fix infinite loop in JSON parser triggered by comments. Fixes #684.

### DIFF
--- a/src/libjson/json.c
+++ b/src/libjson/json.c
@@ -1076,7 +1076,7 @@ static json_result_t _get_number(
         un->real = _strtod(start, &end, parser->options.allow_whitespace);
     }
 
-    if (!end || end != parser->ptr)
+    if (!end || end != parser->ptr || start == end)
         RAISE(JSON_BAD_SYNTAX);
 
 done:


### PR DESCRIPTION
The JSON parser would hang when it sees a comment (`//`, i.e. invalid characters) inside an array, where it would keep adding `_strtol`'d numbers over 0 characters (i.e. `start == end`). 