### PR TITLE
Label all newly opened issues as "needs-triage"

### DIFF
--- a/.github/label-issues.yml
+++ b/.github/label-issues.yml
@@ -1,4 +1,3 @@
-
 name: automate issue labels
 
 on:

--- a/.github/label-issues.yml
+++ b/.github/label-issues.yml
@@ -1,0 +1,15 @@
+
+name: automat issue labels
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  automate-issue-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs-triage labeling
+        uses: andymckay/labeler@467347716a3bdbca7f277cb6cd5fa9c5205c5412
+        with:
+          add-labels: "needs-triage"

--- a/.github/label-issues.yml
+++ b/.github/label-issues.yml
@@ -1,5 +1,5 @@
 
-name: automat issue labels
+name: automate issue labels
 
 on:
   issues:


### PR DESCRIPTION
This commit adds a GitHub action to label all newly opened issues with the "needs-triage" label.
This is the simplest way forward with automating this. This uses a 3rd party GitHub action that is pinned
to specific SHA hash.

A larger project would be to replace this with a custom written GitHub action that runs on a schedule using
the GitHub actions cron facilities. That action would iterate through all issues in the repo that don't have a `p*` priority 
label and add the `needs-triage` label. 

This approach which is much simpler and doesn't require any real investment of time.

For this to work, if GitHub actions (specifically running 3rd party ones) aren't enabled for the lsds/sgx-lkl repo,
they will need to be turned on.