### PR TITLE
Remove racy, memory corrupting enclave futex code

### DIFF
--- a/src/sched/futex.c
+++ b/src/sched/futex.c
@@ -273,14 +273,7 @@ int enclave_futex(
     int val3)
 {
     int rc;
-    static int init = 1;
     uint32_t bitset = FUTEX_BITSET_MATCH_ANY;
-
-    if (init)
-    {
-        memset((void*)&futex_q_lock, 0, sizeof(struct ticketlock));
-        init = 0;
-    }
 
     /* Ignore FUTEX_PRIVATE. We are single-process anyway. */
     op &= ~(FUTEX_PRIVATE);


### PR DESCRIPTION
If enclave futex is ever executed in a multithreaded fashion, it is
possible for the ticketlock to be initialized but for another thread
to come along and memset again leading to unknown results.