### PR TITLE
Make LTP a submodule

### DIFF
--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -117,8 +117,8 @@ stages:
 
             steps:
             - checkout: self
-              submodules: recursive
-              fetchDepth: 50
+              submodules: false
+              clean: true
 
             - task: DownloadBuildArtifacts@0
               displayName: Download Debian package

--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -117,8 +117,8 @@ stages:
 
             steps:
             - checkout: self
-              submodules: false
-              clean: true
+              submodules: recursive
+              fetchDepth: 50
 
             - task: DownloadBuildArtifacts@0
               displayName: Download Debian package

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,5 +19,5 @@
 	branch = master
 [submodule "ltp"]
 	path = ltp
-	url = https://github.com/lsds/ltp
+	url = https://github.com/lsds/ltp.git
 	branch= sgx-lkl

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,7 @@
 	path = third_party/argon2
 	url = https://github.com/P-H-C/phc-winner-argon2
 	branch = master
+[submodule "ltp"]
+	path = ltp
+	url = https://github.com/lsds/ltp
+	branch= sgx-lkl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ exclude = '''
     | openenclave
     | sgx-lkl-musl
     | third_party
+    | ltp
   )/
 )
 '''

--- a/scripts/format-c-code
+++ b/scripts/format-c-code
@@ -98,7 +98,7 @@ OPTIONS:
     -w, --whatif            Run the script without actually modifying the files
                             and display the diff of expected changes, if any.
     --exclude-dirs          Subdirectories to exclude. If unspecified, then
-                            ./host-musl ./lkl ./openenclave and ./sgx-lkl-musl
+                            ./host-musl ./lkl ./ltp ./openenclave and ./sgx-lkl-musl
                             are excluded.
                             All subdirectories are relative to the current path.
     --include-exts          File extensions to include for formatting. If
@@ -192,7 +192,7 @@ findargs='find .'
 
 get_find_args()
 {
-    local defaultExcludeDirs='./.git ./host-musl ./lkl ./openenclave ./sgx-lkl-musl ./build ./build_musl ./third_party'
+    local defaultExcludeDirs='./.git ./host-musl ./lkl ./ltp ./openenclave ./sgx-lkl-musl ./build ./build_musl ./third_party'
     local defaultIncludeExts='h c cpp'
 
     if [[ -z ${userExcludeDirs} ]]; then

--- a/scripts/format-py-code
+++ b/scripts/format-py-code
@@ -51,4 +51,4 @@ if [[ ${verbose} -eq 1 ]]; then
     args+=("--verbose")
 fi
 
-"${cmd[@]}" "${args[@]}" "$this_dir/.."
+"${cmd[@]}" "${args[@]}" "--exclude" 'ltp/|lkl/|openenclave/|host-musl/|sgx-lkl-musl/|build/|build_musl/|third_party/' "$this_dir/.."

--- a/scripts/format-py-code
+++ b/scripts/format-py-code
@@ -51,4 +51,4 @@ if [[ ${verbose} -eq 1 ]]; then
     args+=("--verbose")
 fi
 
-"${cmd[@]}" "${args[@]}" "--exclude" 'ltp/|lkl/|openenclave/|host-musl/|sgx-lkl-musl/|build/|build_musl/|third_party/' "$this_dir/.."
+"${cmd[@]}" "${args[@]}" "$this_dir/.."

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -29,6 +29,7 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) mount -t ext4 -o loop "$@" $(MOUNTPOINT)
 	$(ESCALATE_CMD) tar -C $(MOUNTPOINT) -xvf $(ALPINE_TAR)
 	$(ESCALATE_CMD) cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf
+	git submodule update --remote $(SGXLKL_ROOT)/ltp
 	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp
 	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/ltp/* $(MOUNTPOINT)/ltp/
 	$(ESCALATE_CMD) install buildenv.sh $(MOUNTPOINT)/usr/sbin

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -29,11 +29,11 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) mount -t ext4 -o loop "$@" $(MOUNTPOINT)
 	$(ESCALATE_CMD) tar -C $(MOUNTPOINT) -xvf $(ALPINE_TAR)
 	$(ESCALATE_CMD) cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf
+	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp
+	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/ltp/* $(MOUNTPOINT)/ltp/
 	$(ESCALATE_CMD) install buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
-
-
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -34,6 +34,8 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) install buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
+	
+	
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -34,8 +34,8 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) install buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
-	
-	
+
+
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -29,6 +29,7 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) mount -t ext4 -o loop "$@" $(MOUNTPOINT)
 	$(ESCALATE_CMD) tar -C $(MOUNTPOINT) -xvf $(ALPINE_TAR)
 	$(ESCALATE_CMD) cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf
+	git submodule init $(SGXLKL_ROOT)/ltp
 	git submodule update --remote $(SGXLKL_ROOT)/ltp
 	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp
 	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/ltp/* $(MOUNTPOINT)/ltp/

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -34,8 +34,8 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) install ../buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
-	
-	
+
+
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -34,6 +34,8 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) install ../buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
+	
+	
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -29,6 +29,7 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) mount -t ext4 -o loop "$@" $(MOUNTPOINT)
 	$(ESCALATE_CMD) tar -C $(MOUNTPOINT) -xvf $(ALPINE_TAR)
 	$(ESCALATE_CMD) cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf
+	git submodule update --remote $(SGXLKL_ROOT)/ltp
 	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp
 	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/ltp/* $(MOUNTPOINT)/ltp/
 	$(ESCALATE_CMD) install ../buildenv.sh $(MOUNTPOINT)/usr/sbin

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -29,6 +29,7 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) mount -t ext4 -o loop "$@" $(MOUNTPOINT)
 	$(ESCALATE_CMD) tar -C $(MOUNTPOINT) -xvf $(ALPINE_TAR)
 	$(ESCALATE_CMD) cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf
+	git submodule init $(SGXLKL_ROOT)/ltp
 	git submodule update --remote $(SGXLKL_ROOT)/ltp
 	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp
 	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/ltp/* $(MOUNTPOINT)/ltp/

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -29,11 +29,11 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) mount -t ext4 -o loop "$@" $(MOUNTPOINT)
 	$(ESCALATE_CMD) tar -C $(MOUNTPOINT) -xvf $(ALPINE_TAR)
 	$(ESCALATE_CMD) cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf
+	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp
+	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/ltp/* $(MOUNTPOINT)/ltp/
 	$(ESCALATE_CMD) install ../buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
-
-
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/buildenv.sh
+++ b/tests/ltp/buildenv.sh
@@ -14,7 +14,6 @@ fi
 
 if [[ "$mode" == "build" ]]; then
     cd /
-    rm -rf /ltp
     echo "Installing depencancies..."
     apk update
     apk add alpine-sdk
@@ -30,9 +29,7 @@ if [[ "$mode" == "build" ]]; then
     apk add xz
     touch .c_binaries_list
 
-    # Get the LTP source code
-    echo "Cloning https://github.com/linux-test-project/ltp.git"
-    git clone --branch sgx-lkl https://github.com/lsds/ltp.git
+    # LTP folder is a submodule and copied into image
     cd /ltp
     pwd=$(pwd)
     c_binaries_list_file_tmp="/$pwd/.c_binaries_list.tmp"


### PR DESCRIPTION
While creating image for LTP tests, we were clonning LTP code from  lsds/ltp.
We are making LTP a submodule and it is copied into image instead of cloning from repo.

Also excluding ltp from code check since it was causing check-ci to fail and we exluded them.