### PR TITLE
Fix commented out code that shouldn't be commented out

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -664,13 +664,13 @@ static void *host_malloc(size_t size)
 	{
 		SGXLKL_ASSERT(kernel_mem == NULL);
 		kernel_mem = enclave_mmap(0, size, 0, PROT_READ | PROT_WRITE, 0);
-        /*if (kernel_mem < 0)
+        if (kernel_mem < 0)
         {
             // unable to mmap memory. return NULL that malloc returns on
             // failure
 
             return NULL;
-        }*/
+        }
 		kernel_mem_size = size;
 		return kernel_mem;
 	}


### PR DESCRIPTION
The commented out code came from a PR of mine, but shouldn't have been
commented out. I commented it out while trying to debug a problem and
apparently it snuck past everyone during review.