### PR TITLE
Add a brute-force temporal-safety checking allocator.

### DIFF
--- a/src/include/enclave/enclave_mem.h
+++ b/src/include/enclave/enclave_mem.h
@@ -6,6 +6,22 @@
 #include <sys/types.h>
 #include <time.h>
 
+#include "enclave/enclave_util.h"
+#include "enclave/sgxlkl_t.h"
+
+#ifndef PROT_NONE
+#    define PROT_NONE 0x0
+#endif
+#ifndef PROT_READ
+#    define PROT_READ 0x1
+#endif
+#ifndef PROT_WRITE
+#    define PROT_WRITE 0x2
+#endif
+#ifndef PROT_EXEC
+#    define PROT_EXEC 0x4
+#endif
+
 void enclave_mman_init(const void* base, size_t num_pages, int _mmap_files);
 
 void* enclave_mmap(
@@ -51,5 +67,34 @@ long syscall_SYS_mmap(
     off_t offset);
 
 int enclave_futex_wake(int* uaddr, int val);
+
+/**
+ * Paranoid allocator.  Allocates on a separate page.
+ */
+static inline void* paranoid_alloc(size_t sz)
+{
+    // round up to page size:
+    sz += 4096;
+    sz %= 4096;
+    void* ret =
+        enclave_mmap(NULL, sz, /*fixed*/ 0, PROT_READ | PROT_WRITE, /*zero*/ 1);
+    SGXLKL_ASSERT((intptr_t)ret > 0);
+
+    return ret;
+}
+
+/**
+ * Paranoid deallocate, marks the page as no-access and never reuses it.  This
+ * should not be used in production because it will exhaust enclave memory
+ * quite quickly, but can help tracking use-after-free bugs.
+ */
+static inline void paranoid_dealloc(void* p, size_t sz)
+{
+    // round up to page size:
+    sz += 4096;
+    sz %= 4096;
+    int ret;
+    sgxlkl_host_syscall_mprotect(&ret, p, sz, PROT_NONE);
+}
 
 #endif /* ENCLAVE_MEM_H */

--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -178,9 +178,13 @@ static struct lkl_sem* sem_alloc(int count)
 {
     struct lkl_sem* sem;
 
+#ifdef LKL_SEM_UAF_CHECKS
+    sem = paranoid_alloc(sizeof(struct lkl_sem));
+#else
     sem = oe_calloc(1, sizeof(*sem));
     if (!sem)
         return NULL;
+#endif
 
     sem->count = count;
 
@@ -189,7 +193,13 @@ static struct lkl_sem* sem_alloc(int count)
 
 static void sem_free(struct lkl_sem* sem)
 {
+    SGXLKL_VERBOSE("enter: %p\n", sem);
+#if LKL_SEM_UAF_CHECKS
+    paranoid_dealloc(sem, sizeof(struct lkl_sem));
+#else
     oe_free(sem);
+#endif
+    SGXLKL_VERBOSE("exit\n");
 }
 
 static void sem_up(struct lkl_sem* sem)

--- a/src/main-oe/serialize_enclave_config.c
+++ b/src/main-oe/serialize_enclave_config.c
@@ -4,7 +4,6 @@
 #include <string.h>
 
 #include <json.h>
-#include "enclave/enclave_mem.h"
 #include "enclave/wireguard.h"
 #include "host/sgxlkl_util.h"
 #include "shared/env.h"

--- a/src/main-oe/sgxlkl_evt_chn_cfg.c
+++ b/src/main-oe/sgxlkl_evt_chn_cfg.c
@@ -1,4 +1,3 @@
-#include <enclave/enclave_mem.h>
 #include <errno.h>
 #include <host/sgxlkl_util.h>
 #include <host/vio_host_event_channel.h>

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -28,7 +28,6 @@
 #include <arpa/inet.h>
 #include <netinet/ip.h>
 
-#include "enclave/enclave_mem.h"
 #include "host/host_state.h"
 #include "host/serialize_enclave_config.h"
 #include "host/sgxlkl_host_config.h"


### PR DESCRIPTION
Optionally enable it for lkl_sem and lthread structures.

This allocates each object on a separate page and uses mprotect on the
host to remove all permissions to access the object after it's
deallocated.  In production, this would quickly exhaust enclave memory,
but it can be useful when running tests.