### PR TITLE
Set mmaped memory as PROT_NONE after unmapping.

### DIFF
--- a/src/enclave/enclave_mem.c
+++ b/src/enclave/enclave_mem.c
@@ -351,6 +351,12 @@ long enclave_munmap(void* addr, size_t length)
     used_pages -= occupied_pages;
 
     bitmap_clear(mmap_bitmap, index_top, pages);
+
+#if DEBUG
+    int mprotect_ret;
+    sgxlkl_host_syscall_mprotect(&mprotect_ret, addr, length, PROT_NONE);
+#endif
+
     ticket_unlock(&mmaplock);
 
 #if DEBUG


### PR DESCRIPTION
No one should be using it.