### PR TITLE
Fix memory management for cloned threads.

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -343,8 +343,6 @@ static lkl_thread_t thread_create_host(void* pc, void* sp, void* tls, struct lkl
     // mechanism begin life in the kernel and so need to be associated with the
     // kernel task that created them.
     lthread_setspecific_remote(thread, task_key->key, task_value);
-    // Detach the thread.  Any join operations will be handled by LKL.
-    lthread_detach2(thread);
     // Mark the thread as runnable.  This must be done *after* the
     // `lthread_setspecific_remote` call, to ensure that the thread does not
     // run while we are modifying its TLS.

--- a/tests/basic/clone/Dockerfile
+++ b/tests/basic/clone/Dockerfile
@@ -4,7 +4,9 @@ RUN apk add --no-cache gcc musl-dev
 
 ADD *.c /
 RUN gcc -fPIE -pie -o clone clone.c -g
+RUN gcc -fPIE -pie -o clone_loop clone_loop.c -g
 
 FROM alpine:3.6
 
 COPY --from=builder clone .
+COPY --from=builder clone_loop .

--- a/tests/basic/clone/Makefile
+++ b/tests/basic/clone/Makefile
@@ -1,7 +1,10 @@
 include ../../common.mk
 
-PROG=clone
-PROG_SRC=$(PROG).c 
+PROG1=clone
+PROG1_SRC=$(PROG1).c
+
+PROG2=clone_loop
+PROG2_SRC=$(PROG1).c
 IMAGE_SIZE=5M
 
 EXECUTION_TIMEOUT=60
@@ -15,7 +18,7 @@ SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-$(SGXLKL_ROOTFS): $(PROG_SRC)
+$(SGXLKL_ROOTFS): $(PROG1_SRC) $(PROG2_SRC)
 	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
 
 gettimeout:
@@ -23,19 +26,35 @@ gettimeout:
 
 run: run-hw run-sw
 
-run-gdb: run-hw-gdb
+run-gdb: run-hw-gdb-clone
 
-run-hw: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+run-hw: ${SGXLKL_ROOTFS} run-hw-clone run-hw-clone-loop
 
-run-sw: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+run-hw-clone: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG1)
 
-run-hw-gdb: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
+run-hw-clone-loop: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG2)
 
-run-sw-gdb: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG)
 
+run-sw: ${SGXLKL_ROOTFS} run-sw-clone run-sw-clone-loop
+
+run-sw-clone: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG1)
+
+run-sw-clone-loop: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG2)
+
+run-hw-gdb-clone: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG1)
+
+run-sw-gdb-clone: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG1)
+
+run-hw-gdb-clone-loop: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(SGXLKL_ROOTFS) $(PROG2)
+
+run-sw-gdb-clone-loop: ${SGXLKL_ROOTFS}
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(SGXLKL_ROOTFS) $(PROG2)
 clean:
-	rm -f $(SGXLKL_ROOTFS) $(PROG)
+	rm -f $(SGXLKL_ROOTFS) $(PROG1)

--- a/tests/basic/clone/clone_loop.c
+++ b/tests/basic/clone/clone_loop.c
@@ -1,0 +1,50 @@
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+
+#define _GNU_SOURCE
+#include <sched.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/mman.h>
+
+#define RUNS 10000
+static char child_tls1[4069];
+
+static char child_stack1[8192];
+static char *child_stack_end1 = child_stack1 + 8192;
+
+__attribute__((weak)) int lkl_syscall(int, long*);
+
+static int futex_wait(volatile int *addr, int val)
+{
+	return syscall(SYS_futex, addr, 0 /* FUTEX_WAIT */, val, NULL, 0, 0);
+}
+
+int newthr(void* arg)
+{
+	int odd = (int)(intptr_t)arg;
+	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	unsigned flags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND
+		| CLONE_THREAD | CLONE_SYSVSEM | CLONE_SETTLS | CLONE_CHILD_SETTID
+		| CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID | CLONE_DETACHED;
+
+	pid_t ptid;
+	pid_t ctid_futex1, ctid_futex2;
+	for (int i = 0; i < RUNS; i++) {
+		pid_t ctid1 = clone(newthr, child_stack_end1, 
+							flags, (void*)0, &ptid, &child_tls1,
+							&ctid_futex1);
+		futex_wait(&ctid_futex1, ctid1);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Most of this fix is in the LKL changes but now that LKL is calling join
on the resulting threads, we need to not detach them.