### PR TITLE
chmod rootfs files when mounting.

### DIFF
--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -820,7 +820,6 @@ static void lkl_mount_root_disk(
 
     /* pivot */
     err = lkl_sys_chroot(mnt_point);
-    oe_host_printf("MOUNT POINT: %s\n", mnt_point);
     if (err != 0)
     {
         sgxlkl_fail("lkl_sys_chroot(%s): %s\n", mnt_point, lkl_strerror(err));


### PR DESCRIPTION
This fixes #236.

The problem was that we were setting "/" to be 700 for perms which doesn't allow any user other than root to access "/tmp" and other directories.

After some review and conversation with @prp, I believe that in general the existing code in lkl_prepare_rootfs was there as  "just in case" sanity check. It creates directories if they are missing and provides some permissions (which differ from normal Linux installs). However, those directories almost always existed.

This change will now chmod those directories (including "/") if they exit. Additionally it updates the perms to be set to be 755 to match a standard Linux environment.