### PR TITLE
Remove stray verbose sem_free messages

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -193,13 +193,11 @@ static struct lkl_sem* sem_alloc(int count)
 
 static void sem_free(struct lkl_sem* sem)
 {
-    SGXLKL_VERBOSE("enter: %p\n", sem);
 #if LKL_SEM_UAF_CHECKS
     paranoid_dealloc(sem, sizeof(struct lkl_sem));
 #else
     oe_free(sem);
 #endif
-    SGXLKL_VERBOSE("exit\n");
 }
 
 static void sem_up(struct lkl_sem* sem)


### PR DESCRIPTION
They were being used during thread debugging but mostly noise now
that the issue is fixed (hopefully).