### PR TITLE
Fixes #730. Call stacks dumps corrupt mem

### DIFF
--- a/src/enclave/enclave_util.c
+++ b/src/enclave/enclave_util.c
@@ -82,6 +82,7 @@ void* oe_calloc_or_die(size_t nmemb, size_t size, const char* fail_msg, ...)
  * other lthreads.
  */
 extern int oe_backtrace_impl(void** start_frame, void** buffer, int size);
+extern void oe_backtrace_symbols_free(char** ptr);
 
 void sgxlkl_print_backtrace(void** start_frame)
 {
@@ -99,7 +100,7 @@ void sgxlkl_print_backtrace(void** start_frame)
     for (i = 0; i < size; i++)
         sgxlkl_info("    #%ld: %p in %s(...)\n", i, buf[i], strings[i]);
 
-    oe_free(strings);
+    oe_backtrace_symbols_free(strings);
 }
 #endif
 


### PR DESCRIPTION
stack dumps were freeing memory incorrectly for symbols. Now call
correct function.
This caused certain failures to not display the correct lthread dumps.