### PR TITLE
LTP: Added a support to mount file system in tests

### DIFF
--- a/tests/ltp/Makefile
+++ b/tests/ltp/Makefile
@@ -36,6 +36,9 @@ $(ROOT_FS): $(ALPINE_TAR) buildenv.sh
 	$(ESCALATE_CMD) install buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
+	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp_tst_mnt_fs
+	$(ESCALATE_CMD) dd if=/dev/zero of=$(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img count=256 bs=1M
+	$(ESCALATE_CMD) mkfs -t ext4 $(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img
 
 
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -36,6 +36,9 @@ $(ROOT_FS): $(ALPINE_TAR) ../buildenv.sh
 	$(ESCALATE_CMD) install ../buildenv.sh $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
+	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp_tst_mnt_fs
+	$(ESCALATE_CMD) dd if=/dev/zero of=$(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img count=256 bs=1M
+	$(ESCALATE_CMD) mkfs -t ext4 $(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img
 
 
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'


### PR DESCRIPTION
Problem:
This test case causing oom killer to be invoked and causing
kernel panic. This is because the test case invokes test framework
function "tst_acquire_device" which creates a 256MB of .img file
and binds with a loop device. This is not supported because the
default size of LKL memory is set to 32M. This is kept low due to
the limited size of EPC (Enclave page cache) and to avoid page
cache being swapped out.
Also, the test case invokes "tst_mkfs" framework function which
inturn invokes mkfs utility command with the help of system() syscall.
It is recommended to use root file system, but, this test case
needs a read-only filesystem to test one of the sub-test case.
we don't have a read-only file system mounted in sgx-lkl.

To support the a formated ext4 filesystem image created in master
.img. Test case will pick this image and use it in test.
Test case changes link: https://github.com/lsds/ltp/pull/49