### PR TITLE
Dump stack traces from all lthreads on SIGTERM

### DIFF
--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -399,3 +399,12 @@ void sgxlkl_free_enclave_state()
 
     _free_shared_memory();
 }
+
+void sgxlkl_debug_dump_stack_traces(void)
+{
+#ifdef DEBUG
+    SGXLKL_VERBOSE("Dumping all stack traces from threads...\n");
+    lthread_dump_all_threads(false);
+    oe_abort();
+#endif
+}

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -405,6 +405,5 @@ void sgxlkl_debug_dump_stack_traces(void)
 #ifdef DEBUG
     SGXLKL_VERBOSE("Dumping all stack traces from threads...\n");
     lthread_dump_all_threads(false);
-    oe_abort();
 #endif
 }

--- a/src/enclave/enclave_util.c
+++ b/src/enclave/enclave_util.c
@@ -19,7 +19,7 @@ void sgxlkl_fail(const char* msg, ...)
     oe_host_vfprintf(OE_STDERR_FILENO, msg, args);
 
 #ifdef DEBUG
-    lthread_dump_all_threads();
+    lthread_dump_all_threads(true);
 #endif
 
     oe_abort();

--- a/src/include/enclave/lthread.h
+++ b/src/include/enclave/lthread.h
@@ -321,10 +321,14 @@ extern "C"
      * pointers saved by the lthread scheduler. It shows the stack traces
      * at the time of the last context switch.
      *
+     * The argument is_lthread should be set to true if the function is
+     * called from an lthread (and not a regular pthread, e.g. after an
+     * ecall).
+     *
      * For the current lthread (marked with a '*'), it prints the active
-     * stack frames.
+     * stack frames (if called from an lthread).
      */
-    void lthread_dump_all_threads(void);
+    void lthread_dump_all_threads(bool is_lthread);
 #endif
 
 #ifdef __cplusplus

--- a/src/include/host/sgxlkl_params.h
+++ b/src/include/host/sgxlkl_params.h
@@ -51,7 +51,7 @@
 #ifndef SGXLKL_RELEASE
 /* These environment variables do not have config settings, they are
  * automatically passed through and imported in the enclave */
-extern const char* sgxlkl_auto_passthrough[11];
+extern const char* sgxlkl_auto_passthrough[12];
 #endif
 
 #endif /* SGXLKL_PARAMS_H */

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1220,6 +1220,10 @@ static void* lkl_termination_thread(void* args)
             lkl_strerror(ret));
     }
 
+#ifdef DEBUG
+    display_mount_table();
+#endif
+
     // Unmount mounts
     long res;
     for (int i = sgxlkl_enclave_state.num_disk_state - 1; i > 0; --i)
@@ -1239,10 +1243,6 @@ static void* lkl_termination_thread(void* args)
                 "Could not unmount disk %d, %s\n", i, lkl_strerror(res));
         }
 
-#ifdef DEBUG
-    display_mount_table();
-#endif
-
         if (!cfg->root.readonly)
         {
             // Not really necessary for mounts in /mnt since /mnt is
@@ -1261,10 +1261,6 @@ static void* lkl_termination_thread(void* args)
         }
     }
 
-#ifdef DEBUG
-    display_mount_table();
-#endif
-
     /* Unmount root.
      * We are calling umount with the MNT_DETACH flag for the root
      * file system, otherwise the call fails to unmount the file
@@ -1276,6 +1272,10 @@ static void* lkl_termination_thread(void* args)
     res = lkl_umount_timeout("/", MNT_DETACH, UMOUNT_DISK_TIMEOUT);
     if (res < 0)
         sgxlkl_warn("Could not unmount root disk, %s\n", lkl_strerror(res));
+
+#ifdef DEBUG
+    display_mount_table();
+#endif
 
     SGXLKL_VERBOSE("calling lkl_virtio_netdev_remove()\n");
     lkl_virtio_netdev_remove();

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1220,10 +1220,6 @@ static void* lkl_termination_thread(void* args)
             lkl_strerror(ret));
     }
 
-#ifdef DEBUG
-    display_mount_table();
-#endif
-
     // Unmount mounts
     long res;
     for (int i = sgxlkl_enclave_state.num_disk_state - 1; i > 0; --i)
@@ -1242,6 +1238,10 @@ static void* lkl_termination_thread(void* args)
             sgxlkl_warn(
                 "Could not unmount disk %d, %s\n", i, lkl_strerror(res));
         }
+
+#ifdef DEBUG
+    display_mount_table();
+#endif
 
         if (!cfg->root.readonly)
         {

--- a/src/main-oe/sgxlkl_params.c
+++ b/src/main-oe/sgxlkl_params.c
@@ -1,6 +1,6 @@
 #include "host/sgxlkl_params.h"
 
-const char* sgxlkl_auto_passthrough[11] = {"SGXLKL_DEBUGMOUNT",
+const char* sgxlkl_auto_passthrough[12] = {"SGXLKL_DEBUGMOUNT",
                                            "SGXLKL_PRINT_APP_RUNTIME",
                                            "SGXLKL_TRACE_HOST_SYSCALL",
                                            "SGXLKL_TRACE_INTERNAL_SYSCALL",
@@ -10,4 +10,5 @@ const char* sgxlkl_auto_passthrough[11] = {"SGXLKL_DEBUGMOUNT",
                                            "SGXLKL_TRACE_REDIRECT_SYSCALL",
                                            "SGXLKL_TRACE_MMAP",
                                            "SGXLKL_TRACE_SYSCALL",
-                                           "SGXLKL_TRACE_THREAD"};
+                                           "SGXLKL_TRACE_THREAD",
+                                           "SGXLKL_TRACE_SIGNAL"};

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -1382,7 +1382,8 @@ void _create_enclave(
         .num_heap_pages = econf->image_sizes.num_heap_pages,
         .num_stack_pages = econf->image_sizes.num_stack_pages,
 #ifdef DEBUG
-        // Add extra TCS in DEBUG build to support ecall for dumping stack traces
+        // Add extra TCS in DEBUG build to support ecall for dumping stack
+        // traces
         .num_tcs = econf->ethreads + 1,
 #else
         .num_tcs = econf->ethreads,

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -104,6 +104,10 @@ __gdb_hook_starter_ready(void* base_addr, int mode, char* libsgxlkl_path)
 {
     __asm__ volatile("nop" : : "m"(base_addr), "m"(mode), "m"(libsgxlkl_path));
 }
+
+// Store enclave handle for use in DEBUG signal handler
+static oe_enclave_t* sgxlkl_enclave = NULL;
+
 #endif
 
 /**************************************************************************************************************************/
@@ -331,14 +335,20 @@ static void help_enclave_config()
     }
 }
 
-#if DEBUG && VIRTIO_TEST_HOOK
-/* Control the event channel notification between host & guest */
-
-/* Signal handler to resume paused evt chn to resume guest */
+#ifdef DEBUG
+// Signal handler for thread stack dumps and virtio event channel tests
 static void sgxlkl_loader_signal_handler(int signo)
 {
     switch (signo)
     {
+        case SIGTERM:
+            sgxlkl_host_verbose("Dumping thread stack traces from enclave...\n");
+
+            assert(sgxlkl_enclave);
+            sgxlkl_debug_dump_stack_traces(sgxlkl_enclave);
+            sgxlkl_host_fail("Aborting after stack trace dump\n");
+            break;
+#ifdef VIRTIO_TEST_HOOK
         case SIGUSR2:
             /* Dump the event channel status */
             vio_host_dump_evt_chn();
@@ -353,11 +363,12 @@ static void sgxlkl_loader_signal_handler(int signo)
             /* clear the pause flag */
             virtio_debug_set_evt_chn_state(false);
             break;
+#endif // VIRTIO_TEST_HOOK
         default:
-            sgxlkl_host_info("Handling not required\n");
+            sgxlkl_host_fail("Unknown signal received (signo=%i)\n", signo);
     }
 }
-#endif // DEBUG && VIRTIO_TEST_HOOK
+#endif // DEBUG
 
 static void prepare_verity(
     sgxlkl_enclave_root_config_t* disk,
@@ -840,7 +851,7 @@ void set_tls(bool have_enclave_config)
         assert(econf->mode == SW_DEBUG_MODE);
         if (have_enclave_config && econf->fsgsbase != 0)
             sgxlkl_host_warn("disabling fsgsbase in sw-debug mode, despite it "
-                             "being enabled in enclave config.");
+                             "being enabled in enclave config.\n");
         econf->fsgsbase = 0;
     }
 
@@ -1362,7 +1373,12 @@ void _create_enclave(
     oe_enclave_size_settings_t oe_sizes = {
         .num_heap_pages = econf->image_sizes.num_heap_pages,
         .num_stack_pages = econf->image_sizes.num_stack_pages,
+#ifdef DEBUG
+        // Add extra TCS in DEBUG build to support ecall for dumping stack traces
+        .num_tcs = econf->ethreads + 1,
+#else
         .num_tcs = econf->ethreads,
+#endif
     };
 
     eeid->size_settings = oe_sizes;
@@ -1379,6 +1395,11 @@ void _create_enclave(
 
     if (result != OE_OK)
         sgxlkl_host_fail("Could not initialise enclave\n");
+
+#ifdef DEBUG
+    // Make enclave handle available to DEBUG signal handler
+    sgxlkl_enclave = *oe_enclave;
+#endif
 }
 
 void find_root_disk_file(int* argc, char*** argv, char** root_hd)
@@ -1676,11 +1697,14 @@ int main(int argc, char* argv[], char* envp[])
 
     int c;
 
-#if DEBUG && VIRTIO_TEST_HOOK
+#ifdef DEBUG
+    signal(SIGTERM, sgxlkl_loader_signal_handler);
+#ifdef VIRTIO_TEST_HOOK
     signal(SIGUSR2, sgxlkl_loader_signal_handler);
     signal(SIGCONT, sgxlkl_loader_signal_handler);
     virtio_debug_init();
-#endif // DEBUG && VIRTIO_TEST_HOOK
+#endif // VIRTIO_TEST_HOOK
+#endif // DEBUG
 
     static struct option long_options[] = {
         {"sw-debug", no_argument, 0, SW_DEBUG_MODE},

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -342,11 +342,19 @@ static void sgxlkl_loader_signal_handler(int signo)
     switch (signo)
     {
         case SIGTERM:
-            sgxlkl_host_verbose("Dumping thread stack traces from enclave...\n");
+            sgxlkl_host_verbose(
+                "Dumping thread stack traces from enclave (and aborting)...\n");
 
             assert(sgxlkl_enclave);
             sgxlkl_debug_dump_stack_traces(sgxlkl_enclave);
             sgxlkl_host_fail("Aborting after stack trace dump\n");
+            break;
+        case SIGUSR1:
+            sgxlkl_host_verbose("Dumping thread stack traces from enclave (and "
+                                "not aborting)...\n");
+
+            assert(sgxlkl_enclave);
+            sgxlkl_debug_dump_stack_traces(sgxlkl_enclave);
             break;
 #ifdef VIRTIO_TEST_HOOK
         case SIGUSR2:
@@ -1698,6 +1706,7 @@ int main(int argc, char* argv[], char* envp[])
     int c;
 
 #ifdef DEBUG
+    signal(SIGUSR1, sgxlkl_loader_signal_handler);
     signal(SIGTERM, sgxlkl_loader_signal_handler);
 #ifdef VIRTIO_TEST_HOOK
     signal(SIGUSR2, sgxlkl_loader_signal_handler);

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -895,8 +895,8 @@ int lthread_join(struct lthread* lt, void** ptr, uint64_t timeout)
         }
         _lthread_yield_cb(current, (void*)_lthread_unlock, lt);
 
-        // Reacquire the lthread lock before we start freeing the lthread. It may
-        // still be exiting concurrently.
+        // Reacquire the lthread lock before we start freeing the lthread. It
+        // may still be exiting concurrently.
         _lthread_lock(lt);
     }
     if (ptr)

--- a/src/sgxlkl.edl
+++ b/src/sgxlkl.edl
@@ -31,6 +31,11 @@ enclave {
         // Enclave call for initializing ethreads to enter enclave
         public void sgxlkl_ethread_init(void);
 
+        // Enclave call to dump stack traces for all lthreads (DEBUG only)
+        // TODO: This should only be included for a DEBUG build, but EDL doesn't seem to
+        // support #defines. Currently this ecall becomes a no-op in non-DEBUG builds.
+        public void sgxlkl_debug_dump_stack_traces(void);
+
     };
 
     untrusted {


### PR DESCRIPTION
This PR makes the lthread scheduler display stack traces for all lthreads after the launcher has received a SIGTERM. This means that CI tests that time out will now display stack traces because the timeout command sends a SIGTERM.

It works by installing a SIGTERM signal handler in the launcher and using a new ecall to output the stack traces. 

This is only supported in DEBUG builds.

In addition the PR also:
- fixes a merge conflict related to the outputting of mount tables;
- fixes the SGXLKL_TRACE_SIGNAL environment variable.

This is to help get more information when issue https://github.com/lsds/sgx-lkl/issues/748 occurs in the CI, as I find it hard to reproduce it locally.