### PR TITLE
Ignore fd when doing MAP_ANONYMOUS for mmap

### DIFF
--- a/src/lkl/syscall-overrides-mem.c
+++ b/src/lkl/syscall-overrides-mem.c
@@ -58,7 +58,7 @@ long syscall_SYS_mmap(
         return -EINVAL;
     }
     // Anonymous mapping/allocation
-    else if (fd == -1 && (flags & MAP_ANONYMOUS))
+    else if (flags & MAP_ANONYMOUS)
     {
         return (long)enclave_mmap(addr, length, flags & MAP_FIXED, prot, 1);
     }


### PR DESCRIPTION
It's considered best practice for portable applications to provide -1
as the fd to mmap when doing MAP_ANONYMOUS. However, for Linux compatibility,
we want to ignore the fd entirely.Ignore fd when doing MAP_ANONYMOUS for mmap