### PR TITLE
Add documentation for sem_up/sem_down interactions in posix-host.c

### DIFF
--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -234,7 +234,7 @@ static void sem_free(struct lkl_sem* sem)
 * - any waiters sleep using `enclave_futex_wait`
 * - when releasing, if there might be any waiters, wake them all using
 *     `enclave_futex_wake`
-* - any that waiter that suceeds in decrementing the count before it hits 0
+* - any waiter that succeeds in decrementing the count before it hits 0
 *     will acquire the semaphore and exit `sem_down`
 * - all others waiters will go back to sleep via `enclave_futex_wait`
 *

--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -215,7 +215,7 @@ static void sem_free(struct lkl_sem* sem)
 * sem->count is the number of flags available at the current time
 *
 * sem_up adds a flag back into the bucket.
-* sem_down removes a flag the bucket allowing an action to be taken
+* sem_down removes a flag from the bucket allowing an action to be taken
 *
 * That is:
 * - sem_down is ACQUIRE

--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -203,7 +203,7 @@ static void sem_free(struct lkl_sem* sem)
 /*
 * sem_up/sem_down interaction
 *
-* Because sem_up and sem_down underpin the a lot of sgx-lkl functionality, it is
+* Because sem_up and sem_down underpins a lot of sgx-lkl functionality, it is
 * very important that they interact correctly. However, that interact might
 * not be immediately obvious. What follows is a description of how they
 * interact.

--- a/src/lkl/posix-host.c
+++ b/src/lkl/posix-host.c
@@ -204,7 +204,7 @@ static void sem_free(struct lkl_sem* sem)
 * sem_up/sem_down interaction
 *
 * Because sem_up and sem_down underpins a lot of sgx-lkl functionality, it is
-* very important that they interact correctly. However, that interact might
+* very important that they interact correctly. However, that interaction might
 * not be immediately obvious. What follows is a description of how they
 * interact.
 *


### PR DESCRIPTION
Most everyone who has encountered the usage of sem_up/sem_down has
spent time puzzling over how it works. The current version is one
that was originally done by David Chisnall with some fixes for deadlock
issues by myself.

Most everyone, even the authors, spend time refreshing their memory
on how they work together. This commit adds documentation that should
hopefully quickly advance the knowledge of anyone new to the code
and bring those who have forgotten its intricacies back up to speed more
quickly.

Closes #434