### PR TITLE
Free enclave state when last ethread exits.

### DIFF
--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1300,8 +1300,6 @@ static void* lkl_termination_thread(void* args)
     /* Free the shutdown semaphore late in the shutdown sequence */
     sgxlkl_host_ops.sem_free(termination_sem);
 
-    sgxlkl_free_enclave_state();
-
     lthread_exit(NULL);
 }
 


### PR DESCRIPTION
### Summary
`sgxlkl_enclave_state state` is being cleaned up during `lkl_termination_thread`. This is too early for the lthread scheduler which relies on `state->config.mode` for context switches. According to @prp this is a cause of other failures as well.

This PR moves `sgxlkl_free_enclave_state` to run later, when the last ethread exits.