### PR TITLE
Fix some atomicity in VirtIO control status accesses.

### DIFF
--- a/src/include/lkl/virtio.h
+++ b/src/include/lkl/virtio.h
@@ -12,14 +12,14 @@ struct virtio_dev
     uint32_t device_id;
     uint32_t vendor_id;
     uint64_t device_features;
-    uint32_t device_features_sel;
+    _Atomic(uint32_t) device_features_sel;
     uint64_t driver_features;
-    uint32_t driver_features_sel;
-    uint32_t queue_sel;
+    _Atomic(uint32_t) driver_features_sel;
+    _Atomic(uint32_t) queue_sel;
     struct virtq* queue;
     uint32_t queue_notify;
-    uint32_t int_status;
-    uint32_t status;
+    _Atomic(uint32_t) int_status;
+    _Atomic(uint32_t) status;
     uint32_t config_gen;
 
     struct virtio_dev_ops* ops;

--- a/src/include/shared/virtio_ring_buff.h
+++ b/src/include/shared/virtio_ring_buff.h
@@ -47,13 +47,13 @@ struct virtq_used
 struct virtq
 {
     uint32_t num_max;
-    uint32_t num;
-    uint32_t ready;
+    _Atomic(uint32_t) num;
+    _Atomic(uint32_t) ready;
     uint32_t max_merge_len;
 
-    struct virtq_desc* desc;
-    struct virtq_avail* avail;
-    struct virtq_used* used;
+    _Atomic(struct virtq_desc*) desc;
+    _Atomic(struct virtq_avail*) avail;
+    _Atomic(struct virtq_used*) used;
     uint16_t last_avail_idx;
     uint16_t last_used_idx_signaled;
 };

--- a/src/lkl/virtio_console.c
+++ b/src/lkl/virtio_console.c
@@ -9,8 +9,6 @@
 #include "enclave/ticketlock.h"
 #include "lkl/virtio.h"
 
-static struct ticketlock __event_notifier_lock;
-
 /*
  * Function to generate an interrupt for LKL kernel to reap the virtQ data
  */
@@ -19,14 +17,9 @@ static void lkl_deliver_irq(uint64_t dev_id)
     struct virtio_dev* dev =
         sgxlkl_enclave_state.shared_memory.virtio_console_mem;
 
-    ticket_lock(&__event_notifier_lock);
-
-    __sync_synchronize();
     dev->int_status |= VIRTIO_MMIO_INT_VRING;
 
     lkl_trigger_irq(dev->irq);
-
-    ticket_unlock(&__event_notifier_lock);
 }
 
 /*
@@ -36,7 +29,6 @@ int lkl_virtio_console_add(struct virtio_dev* console)
 {
     int ret = -1;
 
-    memset(&__event_notifier_lock, 0, sizeof(struct ticketlock));
     int mmio_size = VIRTIO_MMIO_CONFIG + console->config_len;
 
     ret = lkl_virtio_dev_setup(console, mmio_size, &lkl_deliver_irq);


### PR DESCRIPTION
None of these updates were atomic, which may have caused problems.
Most notably, there was a potential race in the interrupt-status
flag: setting the flag was guarded by a ticket lock (which was still
held when the thread slept, which should never happen because ticket
locks are not sleepable locks) but clearing it was not guarded.