### PR TITLE
LTP: Pass ext4 block device to enclave

### DIFF
--- a/tests/ltp/ltp_host_config.json
+++ b/tests/ltp/ltp_host_config.json
@@ -1,0 +1,9 @@
+{
+  "mounts": [
+    {
+      "image_path": "ltp_tst_mntfs.img",
+      "destination": "/data",
+      "readonly": false
+    }
+  ]
+}

--- a/tests/ltp/ltp_tstapp_enclave_config.json
+++ b/tests/ltp/ltp_tstapp_enclave_config.json
@@ -1,0 +1,15 @@
+{
+    "args": [
+       "arg"
+    ],
+    "env": [
+        "LTP_DEV=/dev/vdb",
+        "LTP_DEV_FS_TYPE=ext4"
+    ],
+    "mounts": [
+        {
+            "destination": "/data",
+            "readonly": false
+      	}
+    ]
+}

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -28,7 +28,10 @@ case "$test_mode" in
 esac
 test_class="ltp"
 
-SGX_LKL_RUN_CMD=( "$SGXLKL_STARTER" $run_flag sgxlkl-miniroot-fs.img )
+SGXLKL_LTP_TSTAPP_CFG="--enclave-config=../ltp_tstapp_enclave_config.json"
+SGXLKL_LTP_HOST_CFG="--host-config=../ltp_host_config.json"
+
+SGX_LKL_RUN_CMD=( "$SGXLKL_STARTER" "$SGXLKL_LTP_HOST_CFG" "$SGXLKL_LTP_TSTAPP_CFG" $run_flag sgxlkl-miniroot-fs.img )
 
 csv_filename="sgxlkl_oe_ltp_test_result_$(date +%d%m%y_%H%M%S).csv"
 echo "SI No, Test Name, Stdout logfile name, Stderr logfile name, Execution Status" > "$csv_filename"


### PR DESCRIPTION
This test case causing oom killer to be invoked and causing
kernel panic. This is because the test case invokes test framework
function "tst_acquire_device" which creates a 256MB of .img file
and binds with a loop device. This is not supported because the
default size of LKL memory is set to 32M. This is kept low due to
the limited size of EPC (Enclave page cache) and to avoid page
cache being swapped out.
Also, the test case invokes "tst_mkfs" framework function which
inturn invokes mkfs utility command with the help of system() syscall.
It is recommended to use root file system, but, this test case
needs a read-only filesystem to test one of the sub-test cases.
we don't have a read-only file system mounted in sgx-lkl.

To support the test cases which need a block device a formatted
ext4 filesystem image created and passed
to enclave as extended disk. The test case passes the details about this
new block disk image in the application configuration file. The test framework
will pick this image details in the environment variable and use it in test.
Test case changes link: lsds/ltp#49, lsds/ltp#59, lsds/ltp#65,
lsds/ltp#66.