### PR TITLE
Avoid possible overflow with enclave mmapped memory

### DIFF
--- a/src/enclave/enclave_mem.c
+++ b/src/enclave/enclave_mem.c
@@ -139,7 +139,9 @@ void enclave_mman_init(const void* base, size_t num_pages, int _mmap_files)
 
     // Base address for range of pages available to mmap calls
     mmap_base = (char*)mmap_bitmap + (2 * bitmap_req_pages * PAGE_SIZE);
-    mmap_end = (char*)mmap_base + (mmap_num_pages - 1) * PAGE_SIZE;
+    // Set mmap_end to one less page than we normally would to address 
+    // https://github.com/lsds/sgx-lkl/issues/742
+    mmap_end = (char*)mmap_base + (mmap_num_pages - 2) * PAGE_SIZE;
 
     // Initialise mmap allocation bitmap
     bitmap_clear(mmap_bitmap, 0, mmap_num_pages);


### PR DESCRIPTION
As Vikas noted in #742, certain assumptions about memory layout are made
by mounting code. Peter and David discussed and came up with the idea that
removing a page from the pool that enclave mmap can return should address
the problem.

This commit moves up the end of enclave mmap available space by 1 page
and should thereby, fix the possible overflow that Vikas identified.

Closes #742