### PR TITLE
Fix shutdown bugs

### DIFF
--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1176,6 +1176,9 @@ static void* lkl_termination_thread(void* args)
         "Performed LKL syscall to get host task allocated (pid=%li)\n", pid);
     SGXLKL_ASSERT(pid);
 
+    lthread_set_funcname(lthread_self(), "sgx-lkl-terminate");
+    lthread_detach();
+
     /* Block on semaphore until shutdown */
     sgxlkl_host_ops.sem_down(termination_sem);
 
@@ -1294,15 +1297,7 @@ static void* lkl_termination_thread(void* args)
     /* Set termination flag to notify lthread scheduler to bail out. */
     lthread_notify_completion();
 
-    lthread_detach2(lthread_self());
-    SGXLKL_VERBOSE("lthread_detach2() done\n");
-
-    /* Free the shutdown semaphore late in the shutdown sequence */
-    sgxlkl_host_ops.sem_free(termination_sem);
-
-    sgxlkl_free_enclave_state();
-
-    lthread_exit(NULL);
+    return NULL;
 }
 
 /* Create the LKL termination thread */

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1227,7 +1227,7 @@ static void* lkl_termination_thread(void* args)
 
     // Unmount mounts
     long res;
-    for (int i = sgxlkl_enclave_state.num_disk_state - 1; i > 0; --i)
+    for (int i = cfg->num_mounts - 1; i >= 0; i--)
     {
         if (!sgxlkl_enclave_state.disk_state[i].mounted)
             continue;


### PR DESCRIPTION
This PR fixes two shutdown bugs:
- it fixes an off-by-one error that prevented the unmounting of additional file systems (see https://github.com/lsds/sgx-lkl/issues/766);
- it prevents the premature deallocation of the enclave configuration in the shutdown sequence. Instead, it lets the memory be reclaimed when we terminate the process (see https://github.com/lsds/sgx-lkl/pull/759).
