### PR TITLE
Extend kill delay after timeout to 60 secs

### DIFF
--- a/.azure-pipelines/scripts/run_test.sh
+++ b/.azure-pipelines/scripts/run_test.sh
@@ -61,7 +61,7 @@ case "$run_mode" in
        ;;
 esac
 
-timeout --kill-after=$((timeout + 15)) $timeout make "$run_mode"
+timeout --kill-after=$((timeout + 60)) $timeout make "$run_mode"
 make_exit=$?
 
 if [[ "$make_exit" == "124" ]]; then


### PR DESCRIPTION
This PR extends the kill delay after a timeout to 60 secs, so there is
enough time to output a thread dump.