### PR TITLE
Revert "Use correct file descriptor number for STDERR."

### DIFF
--- a/src/enclave/enclave_util.c
+++ b/src/enclave/enclave_util.c
@@ -9,7 +9,7 @@
 #include "openenclave/internal/backtrace.h"
 #endif
 
-#define OE_STDERR_FILENO 2
+#define OE_STDERR_FILENO 1
 
 void sgxlkl_fail(const char* msg, ...)
 {


### PR DESCRIPTION
Reverts lsds/sgx-lkl#763

Apparently OE indeed uses 1 for STDERR and 0 for STDOUT:
https://github.com/openenclave/openenclave/blob/02428b8e7b59f4c40050d6f1eaee1e0cbbb5cdf4/include/openenclave/internal/print.h#L38

Therefore lsds/sgx-lkl#763 breaks printing.
 