### PR TITLE
Perform sync syscall to persist file system contents

### DIFF
--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1215,12 +1215,22 @@ static void* lkl_termination_thread(void* args)
     }
 
     // Switch back to root so we can unmount all filesystems
-    SGXLKL_VERBOSE("calling lkl_sys_chdir(/)\n");
+    SGXLKL_VERBOSE("calling lkl_sys_chdir(\"/\")\n");
     int ret = lkl_sys_chdir("/");
     if (ret != 0)
     {
         sgxlkl_warn(
             "lkl_sys_chdir(\"/\") failed: ret=%i error=\"%s\"\n",
+            ret,
+            lkl_strerror(ret));
+    }
+
+    SGXLKL_VERBOSE("calling lkl_sys_sync()\n");
+    ret = lkl_sys_sync();
+    if (ret != 0)
+    {
+        sgxlkl_warn(
+            "lkl_sys_sync() failed: ret=%i error=\"%s\"\n",
             ret,
             lkl_strerror(ret));
     }

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1225,16 +1225,6 @@ static void* lkl_termination_thread(void* args)
             lkl_strerror(ret));
     }
 
-    SGXLKL_VERBOSE("calling lkl_sys_sync()\n");
-    ret = lkl_sys_sync();
-    if (ret != 0)
-    {
-        sgxlkl_warn(
-            "lkl_sys_sync() failed: ret=%i error=\"%s\"\n",
-            ret,
-            lkl_strerror(ret));
-    }
-
 #ifdef DEBUG
     display_mount_table();
 #endif
@@ -1274,6 +1264,16 @@ static void* lkl_termination_thread(void* args)
                     lkl_strerror(res));
             }
         }
+    }
+
+    SGXLKL_VERBOSE("calling lkl_sys_sync()\n");
+    ret = lkl_sys_sync();
+    if (ret != 0)
+    {
+        sgxlkl_warn(
+            "lkl_sys_sync() failed: ret=%i error=\"%s\"\n",
+            ret,
+            lkl_strerror(ret));
     }
 
     /* Unmount root.

--- a/tests/basic/disk_write/Dockerfile
+++ b/tests/basic/disk_write/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.10
+
+RUN apk add --no-cache \
+    python3
+    
+ENTRYPOINT ["python3"]

--- a/tests/basic/disk_write/Makefile
+++ b/tests/basic/disk_write/Makefile
@@ -14,7 +14,7 @@ print("File `test_file.txt` written to disk")'
 CC_APP_CMDLINE2=${CC_APP} -c 'import os; \
 f = open("test_file.txt", "r"); \
 content = f.read(); \
-print("TEST PASSED" if content == "TEST WRITE" else "TEST FAILED"); \
+print("File successfully read" if content == "TEST WRITE" else "Failed to read file"); \
 exit (0 if content == "TEST WRITE" else -1)'
 
 CC_IMAGE_SIZE=64M

--- a/tests/basic/disk_write/Makefile
+++ b/tests/basic/disk_write/Makefile
@@ -1,0 +1,45 @@
+include ../../common.mk
+
+# This test creates a file on the root file system and then checks if it has
+# been persisted properly by running SGX-LKL again and trying to read the file.
+
+CC_APP=/usr/bin/python3	
+
+CC_APP_CMDLINE1=${CC_APP} -c 'import os; \
+f = open("test_file.txt", "w+"); \
+f.write("TEST WRITE"); \
+f.close(); \
+print("File `test_file.txt` written to disk")'
+
+CC_APP_CMDLINE2=${CC_APP} -c 'import os; \
+f = open("test_file.txt", "r"); \
+content = f.read(); \
+print("TEST PASSED" if content == "TEST WRITE" else "TEST FAILED"); \
+exit (0 if content == "TEST WRITE" else -1)'
+
+CC_IMAGE_SIZE=64M
+
+CC_IMAGE=sgxlkl-alpine.img
+
+VERBOSE_OPTS=SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+
+ifeq ($(SGXLKL_VERBOSE),)
+	SGXLKL_ENV+=${VERBOSE_OPTS}
+endif
+
+.DELETE_ON_ERROR:
+.PHONY: all clean run-hw run-sw
+
+clean:
+	rm -f $(CC_IMAGE)
+
+$(CC_IMAGE):
+	${SGXLKL_DISK_TOOL} create --size=${CC_IMAGE_SIZE} --docker=./Dockerfile ${CC_IMAGE}
+
+run-hw: $(CC_IMAGE)
+	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(CC_IMAGE) $(CC_APP_CMDLINE1)
+	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(CC_IMAGE) $(CC_APP_CMDLINE2)
+
+run-sw: $(CC_IMAGE)
+	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug $(CC_IMAGE) $(CC_APP_CMDLINE1)
+	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug $(CC_IMAGE) $(CC_APP_CMDLINE2)


### PR DESCRIPTION
This commit adds a sync syscall to the shutdown sequence, which ensures
that the content of the buffer cache is flushed to disk. It also adds a
test that verifies that a file is persisted across SGX-LKL runs.

Fixes https://github.com/lsds/sgx-lkl/issues/713 and #754.