### PR TITLE
Don't rebuild LTP LTP_TEST_MNT_IMG every time a test is run

### DIFF
--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -26,7 +26,7 @@ ESCALATE_CMD=sudo
 LTP_SOURCE_DIR=$(SGXLKL_ROOT)/ltp
 
 # file system image to be mount in ltp tests
-LTP_TEST_MNT_IMG="ltp_tst_mntfs.img"
+LTP_TEST_MNT_IMG=ltp_tst_mntfs.img
 LTP_TEST_MNT_IMG_SIZE=256
 
 .DELETE_ON_ERROR:


### PR DESCRIPTION
For the Makefile rule to correctly work and note that ltp_tst_mntfs.img has been created, it needs to not be in quotes. 
Otherwise it is looking for the existence of the file in quotes and causes the check to fail which results in root fs being rebuilt as well.