### PR TITLE
Increase LTP test timeout

### DIFF
--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # Set variables
-timeout=60
+timeout=120
 total_passed=0
 total_failed=0
 counter=0


### PR DESCRIPTION
We have some random failures that from the logs look like are
happening duing unmounting of disks. This commit increases the
timeout to give unmounting more time to handle writing out dirty
pages.