### PR TITLE
Enable 15 new LTP tests

### DIFF
--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -47,7 +47,7 @@
 #/ltp/testcases/kernel/syscalls/chown/chown03
 #/ltp/testcases/kernel/syscalls/chown/chown04
 #/ltp/testcases/kernel/syscalls/chown/chown05
-/ltp/testcases/kernel/syscalls/chroot/chroot01
+#/ltp/testcases/kernel/syscalls/chroot/chroot01
 #/ltp/testcases/kernel/syscalls/chroot/chroot02
 #/ltp/testcases/kernel/syscalls/chroot/chroot03
 #/ltp/testcases/kernel/syscalls/chroot/chroot04
@@ -149,7 +149,7 @@
 #/ltp/testcases/kernel/syscalls/fadvise/posix_fadvise02
 #/ltp/testcases/kernel/syscalls/fadvise/posix_fadvise03
 #/ltp/testcases/kernel/syscalls/fadvise/posix_fadvise04
-/ltp/testcases/kernel/syscalls/fallocate/fallocate01
+#/ltp/testcases/kernel/syscalls/fallocate/fallocate01
 #/ltp/testcases/kernel/syscalls/fallocate/fallocate02
 #/ltp/testcases/kernel/syscalls/fallocate/fallocate03
 #/ltp/testcases/kernel/syscalls/fallocate/fallocate04
@@ -283,7 +283,7 @@
 #/ltp/testcases/kernel/syscalls/futex/futex_wake04
 /ltp/testcases/kernel/syscalls/futimesat/futimesat01
 /ltp/testcases/kernel/syscalls/get_mempolicy/get_mempolicy01
-/ltp/testcases/kernel/syscalls/get_robust_list/get_robust_list01
+#/ltp/testcases/kernel/syscalls/get_robust_list/get_robust_list01
 /ltp/testcases/kernel/syscalls/getcpu/getcpu01
 /ltp/testcases/kernel/syscalls/getcwd/getcwd01
 #/ltp/testcases/kernel/syscalls/getcwd/getcwd02
@@ -550,7 +550,7 @@
 #/ltp/testcases/kernel/syscalls/mmap/mmap07
 #/ltp/testcases/kernel/syscalls/mmap/mmap08
 #/ltp/testcases/kernel/syscalls/mmap/mmap09
-/ltp/testcases/kernel/syscalls/mmap/mmap10
+#/ltp/testcases/kernel/syscalls/mmap/mmap10
 /ltp/testcases/kernel/syscalls/mmap/mmap11
 /ltp/testcases/kernel/syscalls/mmap/mmap12
 /ltp/testcases/kernel/syscalls/mmap/mmap13
@@ -622,7 +622,7 @@
 /ltp/testcases/kernel/syscalls/open/open09
 /ltp/testcases/kernel/syscalls/open/open10
 /ltp/testcases/kernel/syscalls/open/open11
-/ltp/testcases/kernel/syscalls/open/open12
+#/ltp/testcases/kernel/syscalls/open/open12
 /ltp/testcases/kernel/syscalls/open/open12_child
 /ltp/testcases/kernel/syscalls/open/open13
 /ltp/testcases/kernel/syscalls/open/open14
@@ -948,7 +948,7 @@
 /ltp/testcases/kernel/syscalls/sync/sync02
 /ltp/testcases/kernel/syscalls/sync/sync03
 /ltp/testcases/kernel/syscalls/sync_file_range/sync_file_range01
-/ltp/testcases/kernel/syscalls/sync_file_range/sync_file_range02
+#/ltp/testcases/kernel/syscalls/sync_file_range/sync_file_range02
 /ltp/testcases/kernel/syscalls/syncfs/syncfs01
 /ltp/testcases/kernel/syscalls/syscall/syscall01
 /ltp/testcases/kernel/syscalls/sysconf/sysconf01
@@ -1054,5 +1054,5 @@
 /ltp/testcases/kernel/syscalls/writev/writev01
 /ltp/testcases/kernel/syscalls/writev/writev02
 /ltp/testcases/kernel/syscalls/writev/writev05
-/ltp/testcases/kernel/syscalls/writev/writev06
+#/ltp/testcases/kernel/syscalls/writev/writev06
 /ltp/testcases/kernel/syscalls/writev/writev07

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -1050,7 +1050,7 @@
 #/ltp/testcases/kernel/syscalls/write/write02
 /ltp/testcases/kernel/syscalls/write/write03
 #/ltp/testcases/kernel/syscalls/write/write04
-#/ltp/testcases/kernel/syscalls/write/write05
+/ltp/testcases/kernel/syscalls/write/write05
 #/ltp/testcases/kernel/syscalls/writev/writev01
 /ltp/testcases/kernel/syscalls/writev/writev02
 /ltp/testcases/kernel/syscalls/writev/writev05

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -1050,7 +1050,7 @@
 #/ltp/testcases/kernel/syscalls/write/write02
 /ltp/testcases/kernel/syscalls/write/write03
 #/ltp/testcases/kernel/syscalls/write/write04
-/ltp/testcases/kernel/syscalls/write/write05
+#/ltp/testcases/kernel/syscalls/write/write05
 #/ltp/testcases/kernel/syscalls/writev/writev01
 /ltp/testcases/kernel/syscalls/writev/writev02
 /ltp/testcases/kernel/syscalls/writev/writev05

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -183,7 +183,7 @@
 /ltp/testcases/kernel/syscalls/fchown/fchown01
 /ltp/testcases/kernel/syscalls/fchown/fchown02
 /ltp/testcases/kernel/syscalls/fchown/fchown03
-/ltp/testcases/kernel/syscalls/fchown/fchown04
+#/ltp/testcases/kernel/syscalls/fchown/fchown04
 /ltp/testcases/kernel/syscalls/fchown/fchown05
 /ltp/testcases/kernel/syscalls/fchownat/fchownat01
 /ltp/testcases/kernel/syscalls/fchownat/fchownat02
@@ -458,7 +458,7 @@
 /ltp/testcases/kernel/syscalls/lchown/lchown02
 /ltp/testcases/kernel/syscalls/lchown/lchown03
 #/ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr01
-/ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
+#/ltp/testcases/kernel/syscalls/lgetxattr/lgetxattr02
 /ltp/testcases/kernel/syscalls/link/link02
 /ltp/testcases/kernel/syscalls/link/link03
 /ltp/testcases/kernel/syscalls/link/link04
@@ -564,9 +564,9 @@
 /ltp/testcases/kernel/syscalls/mount/mount02
 /ltp/testcases/kernel/syscalls/mount/mount03
 /ltp/testcases/kernel/syscalls/mount/mount03_setuid_test
-/ltp/testcases/kernel/syscalls/mount/mount04
+#/ltp/testcases/kernel/syscalls/mount/mount04
 /ltp/testcases/kernel/syscalls/mount/mount05
-/ltp/testcases/kernel/syscalls/mount/mount06
+#/ltp/testcases/kernel/syscalls/mount/mount06
 /ltp/testcases/kernel/syscalls/move_pages/move_pages01
 /ltp/testcases/kernel/syscalls/move_pages/move_pages02
 /ltp/testcases/kernel/syscalls/move_pages/move_pages03
@@ -699,7 +699,7 @@
 /ltp/testcases/kernel/syscalls/quotactl/quotactl02
 /ltp/testcases/kernel/syscalls/quotactl/quotactl03
 #/ltp/testcases/kernel/syscalls/read/read01
-/ltp/testcases/kernel/syscalls/read/read02
+#/ltp/testcases/kernel/syscalls/read/read02
 #/ltp/testcases/kernel/syscalls/read/read03
 #/ltp/testcases/kernel/syscalls/read/read04
 #/ltp/testcases/kernel/syscalls/readahead/readahead01
@@ -739,7 +739,7 @@
 #/ltp/testcases/kernel/syscalls/rename/rename12
 #/ltp/testcases/kernel/syscalls/rename/rename13
 /ltp/testcases/kernel/syscalls/rename/rename14
-/ltp/testcases/kernel/syscalls/renameat/renameat01
+#/ltp/testcases/kernel/syscalls/renameat/renameat01
 #/ltp/testcases/kernel/syscalls/renameat2/renameat201
 #/ltp/testcases/kernel/syscalls/renameat2/renameat202
 /ltp/testcases/kernel/syscalls/request_key/request_key01
@@ -1008,8 +1008,8 @@
 #/ltp/testcases/kernel/syscalls/unlink/unlink07
 #/ltp/testcases/kernel/syscalls/unlink/unlink08
 #/ltp/testcases/kernel/syscalls/unlinkat/unlinkat01
-/ltp/testcases/kernel/syscalls/unshare/unshare01
-/ltp/testcases/kernel/syscalls/unshare/unshare02
+#/ltp/testcases/kernel/syscalls/unshare/unshare01
+#/ltp/testcases/kernel/syscalls/unshare/unshare02
 /ltp/testcases/kernel/syscalls/userfaultfd/userfaultfd01
 #/ltp/testcases/kernel/syscalls/ustat/ustat01
 /ltp/testcases/kernel/syscalls/ustat/ustat02


### PR DESCRIPTION
Enabling 15 tests.
The bocking bugs for these tests fixed:

chroot01
writev06
get_robust_list01
PRs reviewed and merged for below tests:

open12 lsds/ltp#60
mmap10 lsds/ltp#62
fallocate01 (lsds/ltp#45) 
sync_file_range02 (lsds/ltp#66)
unshare01, unshare02 (lsds/ltp#64) 
renameat01 (lsds/ltp#63) 
mount04, mount06 (lsds/ltp#59)
lgetxattr02 (lsds/ltp#36)
fchown04 (lsds/ltp#49) 
read02 (lsds/ltp#61) 