### PR TITLE
[Test] Skip tests for dotnet, java and ml/openvino for ethreads=1

### DIFF
--- a/tests/languages/dotnet/Makefile
+++ b/tests/languages/dotnet/Makefile
@@ -31,6 +31,14 @@ $(DISK_IMAGE):
 
 run: run-hw
 
+ifeq ($(SGXLKL_ETHREADS),1)
+skip-run-hw:
+	@echo "true"
+
+skip-run-sw:
+	@echo "true"
+endif
+
 run-hw: $(DISK_IMAGE)
 	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
 

--- a/tests/languages/java/hello_world/Makefile
+++ b/tests/languages/java/hello_world/Makefile
@@ -21,6 +21,14 @@ $(DISK_IMAGE): $(PROG_SRC)
 
 run: run-hw run-sw
 
+ifeq ($(SGXLKL_ETHREADS),1)
+skip-run-hw:
+	@echo "true"
+
+skip-run-sw:
+	@echo "true"
+endif
+
 run-hw: $(DISK_IMAGE)
 	@echo "sgx-lkl-java --hw-debug ${DISK_IMAGE} HelloWorld"
 	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} HelloWorld

--- a/tests/languages/java/read_file/Makefile
+++ b/tests/languages/java/read_file/Makefile
@@ -22,6 +22,14 @@ $(DISK_IMAGE): $(MAINAPP_JAVA) $(FILEREADER_JAVA)
 
 run: run-hw run-sw
 
+ifeq ($(SGXLKL_ETHREADS),1)
+skip-run-hw:
+	@echo "true"
+
+skip-run-sw:
+	@echo "true"
+endif
+
 run-hw: $(DISK_IMAGE)
 	@echo "sgx-lkl-java --hw-debug ${DISK_IMAGE} ${PROG}"
 	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} ${PROG}

--- a/tests/languages/java/thread/Makefile
+++ b/tests/languages/java/thread/Makefile
@@ -20,6 +20,14 @@ $(DISK_IMAGE): app/SharedData.java app/SimpleThread.java app/MainApp.java
 
 run: run-hw run-sw
 
+ifeq ($(SGXLKL_ETHREADS),1)
+skip-run-hw:
+	@echo "true"
+
+skip-run-sw:
+	@echo "true"
+endif
+
 run-hw: $(DISK_IMAGE)
 	@echo "sgx-lkl-java --hw-debug ${DISK_IMAGE} ${PROG}"
 	@${SGXLKL_ENV} ${SGXLKL_JAVA_RUN} --hw-debug ${DISK_IMAGE} ${PROG}

--- a/tests/ml/openvino/Makefile
+++ b/tests/ml/openvino/Makefile
@@ -34,6 +34,14 @@ $(DISK_IMAGE): Dockerfile
 
 run: run-hw
 
+ifeq ($(SGXLKL_ETHREADS),1)
+skip-run-hw:
+	@echo "true"
+
+skip-run-sw:
+	@echo "true"
+endif
+
 run-hw: $(DISK_IMAGE)
 	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(DISK_IMAGE) $(ENCLAVE_CMD)
 


### PR DESCRIPTION
In sgx-lkl (nightly) build we run tests for different ethreads (SGXLKL_ETHREADS) values: 1, 4, 8 

5 tests are failing in sgx-lkl nightly build with SGXLKL_ETHREADS=1 ( 3 java, 1 dotnet, 1 ml/openvino)
 
https://github.com/lsds/sgx-lkl/issues/415 (ml/openvino)
https://github.com/lsds/sgx-lkl/issues/795 (java, helloworld)
https://github.com/lsds/sgx-lkl/issues/796 (java, read_file, thread)
https://github.com/lsds/sgx-lkl/issues/797 (dotnet)

We are skipping (disabling) these 5 tests for ETHREADS=1. They will continue to run for ETHREADS > 1 ( 4 and 8) 
We will enable these 5 tests after underlying bugs fixed. 