### PR TITLE
Add proper tracing options, remove getenv calls from enclave code.

### DIFF
--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -12,7 +12,7 @@
 #include "enclave/lthread_int.h"
 #include "enclave/wireguard.h"
 #include "enclave/wireguard_util.h"
-#include "shared/env.h"
+#include "shared/util.h"
 
 #include "../../user/userargs.h"
 
@@ -179,7 +179,8 @@ static int app_main_thread(void* args_)
 
 static int kernel_main_thread(void* args)
 {
-    __init_libc(sgxlkl_enclave_state.elf64_stack.envp,
+    __init_libc(
+        sgxlkl_enclave_state.elf64_stack.envp,
         sgxlkl_enclave_state.elf64_stack.argv[0]);
     __libc_start_init();
     a_barrier();
@@ -252,7 +253,7 @@ int __libc_init_enclave(int argc, char** argv)
     max_lthreads = next_power_of_2(max_lthreads);
 
     newmpmcq(&__scheduler_queue, max_lthreads, 0);
-    
+
     init_ethread_tp();
 
     size_t espins = cfg->espins;

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -61,7 +61,11 @@ static void wipe_disk_keys()
     {
         if (disk_state[i].key)
         {
-            memset(disk_state[i].key, 0, disk_state[i].key_len);
+            oe_memset_s(
+                disk_state[i].key,
+                disk_state[i].key_len,
+                0,
+                disk_state[i].key_len);
             oe_free(disk_state[i].key);
         }
         disk_state[i].key = NULL;

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -56,6 +56,8 @@ static void get_disk_keys()
     }
 }
 
+/* Wipe copies of (currently local, in future remote) keys after we don't need
+ * them anymore, i.e. after mounting the respective file systems. */
 static void wipe_disk_keys()
 {
     sgxlkl_enclave_disk_state_t* disk_state = sgxlkl_enclave_state.disk_state;

--- a/src/enclave/enclave_init.c
+++ b/src/enclave/enclave_init.c
@@ -32,7 +32,9 @@ extern void init_sysconf(long nproc_conf, long nproc_onln);
 
 static void get_disk_keys()
 {
-    /* Here or earlier: get keys from remote key provider or auxv. */
+    /* Here or earlier: get keys from remote key provider or auxv. For now we
+     * only support plaintext keys in sgxlkl_enclave_state.config, which we copy
+     * into the right places here. */
     const sgxlkl_enclave_config_t* cfg = sgxlkl_enclave_state.config;
     sgxlkl_enclave_disk_state_t* disk_states = sgxlkl_enclave_state.disk_state;
     if (cfg->root.key)

--- a/src/enclave/enclave_mem.c
+++ b/src/enclave/enclave_mem.c
@@ -36,7 +36,6 @@ static size_t used_pages =
     0; // Tracks the number of used pages for the mmap tracing
 
 #if DEBUG
-extern int sgxlkl_trace_mmap;
 static size_t mmap_max_allocated = 0; // Maximum amount of memory used thus far
 #endif
 
@@ -139,7 +138,7 @@ void enclave_mman_init(const void* base, size_t num_pages, int _mmap_files)
 
     // Base address for range of pages available to mmap calls
     mmap_base = (char*)mmap_bitmap + (2 * bitmap_req_pages * PAGE_SIZE);
-    // Set mmap_end to one less page than we normally would to address 
+    // Set mmap_end to one less page than we normally would to address
     // https://github.com/lsds/sgx-lkl/issues/742
     mmap_end = (char*)mmap_base + (mmap_num_pages - 2) * PAGE_SIZE;
 
@@ -194,7 +193,7 @@ void* enclave_mmap(
             index_top = addr_to_index(addr) - (pages - 1);
 
 #if DEBUG
-            if (sgxlkl_trace_mmap)
+            if (sgxlkl_enclave_state.config->trace.mmap)
                 replaced_pages = bitmap_count_set_bits(
                     mmap_bitmap, mmap_num_pages, index_top, pages);
 #endif
@@ -296,7 +295,7 @@ void* enclave_mmap(
     }
 
 #if DEBUG
-    if (sgxlkl_trace_mmap)
+    if (sgxlkl_enclave_state.config->trace.mmap)
     {
         size_t requested = pages * PAGESIZE;
         size_t total = mmap_num_pages * PAGESIZE;
@@ -354,7 +353,7 @@ long enclave_munmap(void* addr, size_t length)
     ticket_unlock(&mmaplock);
 
 #if DEBUG
-    if (sgxlkl_trace_mmap)
+    if (sgxlkl_enclave_state.config->trace.mmap)
     {
         size_t requested = pages * PAGESIZE;
         size_t total = mmap_num_pages * PAGESIZE;

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -408,6 +408,10 @@ int sgxlkl_enclave_init(const sgxlkl_shared_memory_t* shared_memory)
     // point onwards
     sgxlkl_enclave_state.trace_enabled.verbose =
         sgxlkl_enclave_state.config->verbose;
+    sgxlkl_enclave_state.trace_enabled.internal_syscall =
+        sgxlkl_enclave_state.config->trace.internal_syscall;
+    sgxlkl_enclave_state.trace_enabled.lkl_syscall =
+        sgxlkl_enclave_state.config->trace.lkl_syscall;
 #endif
 
     SGXLKL_VERBOSE("enter\n");

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -12,8 +12,8 @@
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
 #include "enclave/lthread_int.h"
-#include "shared/env.h"
 #include "shared/timer_dev.h"
+#include "shared/util.h"
 
 #define AUXV_ENTRIES 13
 

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -397,7 +397,7 @@ int sgxlkl_enclave_init(const sgxlkl_shared_memory_t* shared_memory)
 #ifdef DEBUG
     /* Make sure verbosity is off before loading the config (we don't know
      * whether it's enabled yet).*/
-    sgxlkl_enclave_state.verbose = false;
+    sgxlkl_enclave_state.trace_enabled.verbose = false;
 #endif
 
     _read_eeid_config();
@@ -406,7 +406,8 @@ int sgxlkl_enclave_init(const sgxlkl_shared_memory_t* shared_memory)
 #ifdef DEBUG
     // Initialise verbosity setting, so SGXLKL_VERBOSE can be used from this
     // point onwards
-    sgxlkl_enclave_state.verbose = sgxlkl_enclave_state.config->verbose;
+    sgxlkl_enclave_state.trace_enabled.verbose =
+        sgxlkl_enclave_state.config->verbose;
 #endif
 
     SGXLKL_VERBOSE("enter\n");

--- a/src/enclave/enclave_oe.c
+++ b/src/enclave/enclave_oe.c
@@ -299,11 +299,25 @@ static void _read_eeid_config()
     const oe_eeid_t* eeid = (oe_eeid_t*)__oe_get_eeid();
     const char* config_json = (const char*)eeid->data;
 
-    sgxlkl_enclave_config_t* cfg = oe_malloc(sizeof(sgxlkl_enclave_config_t));
-    if (!cfg)
-        sgxlkl_fail("out of memory, cannot allocate enclave config.\n");
-    sgxlkl_read_enclave_config(config_json, cfg, true);
-    sgxlkl_enclave_state.config = cfg;
+    size_t num_pages = 0;
+    const sgxlkl_enclave_config_page_t* cfg_pages =
+        sgxlkl_read_enclave_config(config_json, true, &num_pages);
+
+    /* Make the config pages read-only */
+    for (size_t i = 0; i < num_pages; i++)
+    {
+        int mprotect_ret;
+        sgxlkl_host_syscall_mprotect(
+            &mprotect_ret,
+            (void*)&cfg_pages[i],
+            sizeof(sgxlkl_enclave_config_t),
+            PROT_READ);
+
+        if (mprotect_ret != 0)
+            sgxlkl_warn("Could not protect memory pages for config\n");
+    }
+
+    sgxlkl_enclave_state.config = &cfg_pages->config;
 }
 
 static void _copy_shared_memory(const sgxlkl_shared_memory_t* host)

--- a/src/enclave/enclave_signal.c
+++ b/src/enclave/enclave_signal.c
@@ -5,8 +5,8 @@
 
 #include <asm-generic/ucontext.h>
 
-#include <lkl_host.h>
 #include <lkl/setup.h>
+#include <lkl_host.h>
 #include <string.h>
 
 #include <openenclave/enclave.h>
@@ -16,7 +16,6 @@
 #include "enclave/enclave_util.h"
 #include "enclave/lthread.h"
 #include "enclave/sgxlkl_t.h"
-#include "shared/env.h"
 
 #define RDTSC_OPCODE 0x310F
 
@@ -151,7 +150,7 @@ static uint64_t sgxlkl_enclave_signal_handler(
             opcode);
 
 #ifdef DEBUG
-        if (sgxlkl_trace_signal)
+        if (sgxlkl_enclave_state.config->trace.signal)
         {
             sgxlkl_print_backtrace((void*)oe_ctx->rbp);
         }

--- a/src/host_interface/virtio_blkdev.c
+++ b/src/host_interface/virtio_blkdev.c
@@ -6,7 +6,7 @@
 #include <host/vio_host_event_channel.h>
 #include <host/virtio_blkdev.h>
 #include <host/virtio_debug.h>
-#include <shared/env.h>
+#include <shared/util.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>

--- a/src/host_interface/virtio_console.c
+++ b/src/host_interface/virtio_console.c
@@ -8,7 +8,7 @@
 #include <host/vio_host_event_channel.h>
 #include <host/virtio_console.h>
 #include <poll.h>
-#include <shared/env.h>
+#include <shared/util.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/host_interface/virtio_debug.c
+++ b/src/host_interface/virtio_debug.c
@@ -1,7 +1,6 @@
 #if DEBUG && VIRTIO_TEST_HOOK
 
 #include <host/virtio_debug.h>
-#include <shared/env.h>
 #include <string.h>
 
 /* Virtio debug module enables different debug options for virtio device

--- a/src/host_interface/virtio_netdev.c
+++ b/src/host_interface/virtio_netdev.c
@@ -24,7 +24,7 @@
 #include <host/virtio_debug.h>
 #include <host/virtio_netdev.h>
 #include <poll.h>
-#include <shared/env.h>
+#include <shared/util.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/include/enclave/enclave_state.h
+++ b/src/include/enclave/enclave_state.h
@@ -53,7 +53,9 @@ typedef struct sgxlkl_enclave_state
     /* Memory shared with the host */
     sgxlkl_shared_memory_t shared_memory;
 
-    /* Flags to track whether tracing macros are currently enabled */
+    /* Flags to track whether tracing macros are currently enabled (initialized
+     * according to the settings in `config`; the respective traces may be
+     * disabled temporarily and this flags track the current state) */
     struct
     {
         bool verbose;

--- a/src/include/enclave/enclave_state.h
+++ b/src/include/enclave/enclave_state.h
@@ -51,8 +51,13 @@ typedef struct sgxlkl_enclave_state
     /* Memory shared with the host */
     sgxlkl_shared_memory_t shared_memory;
 
-    /* This flag is used by the tracing macros */
-    bool verbose;
+    /* Flags to track whether tracing macros are currently enabled */
+    struct
+    {
+        bool verbose;
+        bool lkl_syscall;
+        bool internal_syscall;
+    } trace_enabled;
 } sgxlkl_enclave_state_t;
 
 extern sgxlkl_enclave_state_t sgxlkl_enclave_state;

--- a/src/include/enclave/enclave_state.h
+++ b/src/include/enclave/enclave_state.h
@@ -20,6 +20,8 @@ typedef struct sgxlkl_enclave_disk_state
     int fd;                 /* File descriptor of the disk */
     size_t capacity;        /* Capacity of the disk */
     bool mounted;           /* Tracks whether the disk has been mounted */
+    uint8_t* key;           /* Encryption key */
+    size_t key_len;         /* Length of encryption key */
 } sgxlkl_enclave_disk_state_t;
 
 typedef struct

--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -163,32 +163,33 @@ uint64_t next_power_of_2(uint64_t n);
     {                                                       \
         oe_host_printf("[[   MMAP   ]] " x, ##__VA_ARGS__); \
     }
-#define SGXLKL_TRACE_SYSCALL(type, x, ...)                                     \
-    if ((sgxlkl_enclave_state.config->trace.lkl_syscall &&                     \
-         sgxlkl_enclave_state.trace_enabled.lkl_syscall &&                     \
-         type == SGXLKL_LKL_SYSCALL))                                          \
-    {                                                                          \
-        oe_host_printf("[[ LKL SYSC ]] " x, ##__VA_ARGS__);                    \
-    }                                                                          \
-    else if ((sgxlkl_enclave_state.config->trace.internal_syscall &&           \
-              sgxlkl_enclave_state.trace_enabled.internal_syscall &&           \
-              type == SGXLKL_INTERNAL_SYSCALL))                                \
-    {                                                                          \
-        oe_host_printf("[[ INT SYSC ]] " x, ##__VA_ARGS__);                    \
-    }                                                                          \
-    else if ((sgxlkl_enclave_state.verbose && type == SGXLKL_IGNORED_SYSCALL)) \
-    {                                                                          \
-        oe_host_printf("[[ IGN SYSC ]] " x, ##__VA_ARGS__);                    \
-    }                                                                          \
-    else if ((sgxlkl_enclave_state.verbose &&                                  \
-              type == SGXLKL_UNSUPPORTED_SYSCALL))                             \
-    {                                                                          \
-        oe_host_printf("[[NO SYSC  !]] " x, ##__VA_ARGS__);                    \
-    }                                                                          \
-    else if ((sgxlkl_enclave_state.verbose &&                                  \
-              type == SGXLKL_REDIRECT_SYSCALL))                                \
-    {                                                                          \
-        oe_host_printf("[[REDIR SYSC]] " x, ##__VA_ARGS__);                    \
+#define SGXLKL_TRACE_SYSCALL(type, x, ...)                           \
+    if ((sgxlkl_enclave_state.config->trace.lkl_syscall &&           \
+         sgxlkl_enclave_state.trace_enabled.lkl_syscall &&           \
+         type == SGXLKL_LKL_SYSCALL))                                \
+    {                                                                \
+        oe_host_printf("[[ LKL SYSC ]] " x, ##__VA_ARGS__);          \
+    }                                                                \
+    else if ((sgxlkl_enclave_state.config->trace.internal_syscall && \
+              sgxlkl_enclave_state.trace_enabled.internal_syscall && \
+              type == SGXLKL_INTERNAL_SYSCALL))                      \
+    {                                                                \
+        oe_host_printf("[[ INT SYSC ]] " x, ##__VA_ARGS__);          \
+    }                                                                \
+    else if ((sgxlkl_enclave_state.config->trace.verbose &&          \
+              type == SGXLKL_IGNORED_SYSCALL))                       \
+    {                                                                \
+        oe_host_printf("[[ IGN SYSC ]] " x, ##__VA_ARGS__);          \
+    }                                                                \
+    else if ((sgxlkl_enclave_state.trace_enabled.verbose &&          \
+              type == SGXLKL_UNSUPPORTED_SYSCALL))                   \
+    {                                                                \
+        oe_host_printf("[[NO SYSC  !]] " x, ##__VA_ARGS__);          \
+    }                                                                \
+    else if ((sgxlkl_enclave_state.trace_enabled.verbose &&          \
+              type == SGXLKL_REDIRECT_SYSCALL))                      \
+    {                                                                \
+        oe_host_printf("[[REDIR SYSC]] " x, ##__VA_ARGS__);          \
     }
 
 #define SGXLKL_TRACE_SIGNAL(x, ...)                         \

--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -93,8 +93,9 @@ void* oe_calloc_or_die(size_t nmemb, size_t size, const char* fail_msg, ...);
 
 /**
  *
- * Note that generating a stack trace by unwinding stack frames could be exploited
- * by an attacker and therefore should only be possible in a DEBUG build.
+ * Note that generating a stack trace by unwinding stack frames could be
+ * exploited by an attacker and therefore should only be possible in a DEBUG
+ * build.
  */
 #ifdef DEBUG
 /**
@@ -129,7 +130,8 @@ uint64_t next_power_of_2(uint64_t n);
     } while (0)
 
 #define SGXLKL_VERBOSE(x, ...)                                               \
-    if (sgxlkl_enclave_state.verbose)                                        \
+    if (sgxlkl_enclave_state.config->verbose &&                              \
+        sgxlkl_enclave_state.trace_enabled.verbose)                          \
     {                                                                        \
         struct schedctx* _sgxlkl_verbose_self;                               \
         __asm__ __volatile__("mov %%gs:48,%0" : "=r"(_sgxlkl_verbose_self)); \
@@ -145,10 +147,11 @@ uint64_t next_power_of_2(uint64_t n);
             __func__,                                                        \
             ##__VA_ARGS__);                                                  \
     }
-#define SGXLKL_VERBOSE_RAW(x, ...)        \
-    if (sgxlkl_enclave_state.verbose)     \
-    {                                     \
-        oe_host_printf(x, ##__VA_ARGS__); \
+#define SGXLKL_VERBOSE_RAW(x, ...)                  \
+    if (sgxlkl_enclave_state.config->verbose &&     \
+        sgxlkl_enclave_state.trace_enabled.verbose) \
+    {                                               \
+        oe_host_printf(x, ##__VA_ARGS__);           \
     }
 #define SGXLKL_TRACE_THREAD(x, ...)                         \
     if (sgxlkl_enclave_state.config->trace.thread)          \
@@ -162,11 +165,13 @@ uint64_t next_power_of_2(uint64_t n);
     }
 #define SGXLKL_TRACE_SYSCALL(type, x, ...)                                     \
     if ((sgxlkl_enclave_state.config->trace.lkl_syscall &&                     \
+         sgxlkl_enclave_state.trace_enabled.lkl_syscall &&                     \
          type == SGXLKL_LKL_SYSCALL))                                          \
     {                                                                          \
         oe_host_printf("[[ LKL SYSC ]] " x, ##__VA_ARGS__);                    \
     }                                                                          \
     else if ((sgxlkl_enclave_state.config->trace.internal_syscall &&           \
+              sgxlkl_enclave_state.trace_enabled.internal_syscall &&           \
               type == SGXLKL_INTERNAL_SYSCALL))                                \
     {                                                                          \
         oe_host_printf("[[ INT SYSC ]] " x, ##__VA_ARGS__);                    \

--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -176,17 +176,20 @@ uint64_t next_power_of_2(uint64_t n);
     {                                                                \
         oe_host_printf("[[ INT SYSC ]] " x, ##__VA_ARGS__);          \
     }                                                                \
-    else if ((sgxlkl_enclave_state.config->trace.verbose &&          \
+    else if ((sgxlkl_enclave_state.config->verbose &&                \
+              sgxlkl_enclave_state.trace_enabled.verbose &&          \
               type == SGXLKL_IGNORED_SYSCALL))                       \
     {                                                                \
         oe_host_printf("[[ IGN SYSC ]] " x, ##__VA_ARGS__);          \
     }                                                                \
-    else if ((sgxlkl_enclave_state.trace_enabled.verbose &&          \
+    else if ((sgxlkl_enclave_state.config->verbose &&                \
+              sgxlkl_enclave_state.trace_enabled.verbose &&          \
               type == SGXLKL_UNSUPPORTED_SYSCALL))                   \
     {                                                                \
         oe_host_printf("[[NO SYSC  !]] " x, ##__VA_ARGS__);          \
     }                                                                \
-    else if ((sgxlkl_enclave_state.trace_enabled.verbose &&          \
+    else if ((sgxlkl_enclave_state.config->verbose &&                \
+              sgxlkl_enclave_state.trace_enabled.verbose &&          \
               type == SGXLKL_REDIRECT_SYSCALL))                      \
     {                                                                \
         oe_host_printf("[[REDIR SYSC]] " x, ##__VA_ARGS__);          \

--- a/src/include/enclave/enclave_util.h
+++ b/src/include/enclave/enclave_util.h
@@ -113,16 +113,6 @@ uint64_t next_power_of_2(uint64_t n);
 
 #include "openenclave/internal/print.h"
 
-extern int sgxlkl_trace_thread;
-extern int sgxlkl_trace_mmap;
-extern int sgxlkl_trace_signal;
-extern int sgxlkl_trace_disk;
-extern int sgxlkl_trace_lkl_syscall;
-extern int sgxlkl_trace_internal_syscall;
-extern int sgxlkl_trace_ignored_syscall;
-extern int sgxlkl_trace_unsupported_syscall;
-extern int sgxlkl_trace_redirect_syscall;
-
 #define SGXLKL_ASSERT(EXPR)                                   \
     do                                                        \
     {                                                         \
@@ -161,21 +151,22 @@ extern int sgxlkl_trace_redirect_syscall;
         oe_host_printf(x, ##__VA_ARGS__); \
     }
 #define SGXLKL_TRACE_THREAD(x, ...)                         \
-    if (sgxlkl_trace_thread)                                \
+    if (sgxlkl_enclave_state.config->trace.thread)          \
     {                                                       \
         oe_host_printf("[[  THREAD  ]] " x, ##__VA_ARGS__); \
     }
 #define SGXLKL_TRACE_MMAP(x, ...)                           \
-    if (sgxlkl_trace_mmap)                                  \
+    if (sgxlkl_enclave_state.config->trace.mmap)            \
     {                                                       \
         oe_host_printf("[[   MMAP   ]] " x, ##__VA_ARGS__); \
     }
 #define SGXLKL_TRACE_SYSCALL(type, x, ...)                                     \
-    if ((sgxlkl_trace_lkl_syscall && type == SGXLKL_LKL_SYSCALL))              \
+    if ((sgxlkl_enclave_state.config->trace.lkl_syscall &&                     \
+         type == SGXLKL_LKL_SYSCALL))                                          \
     {                                                                          \
         oe_host_printf("[[ LKL SYSC ]] " x, ##__VA_ARGS__);                    \
     }                                                                          \
-    else if ((sgxlkl_trace_internal_syscall &&                                 \
+    else if ((sgxlkl_enclave_state.config->trace.internal_syscall &&           \
               type == SGXLKL_INTERNAL_SYSCALL))                                \
     {                                                                          \
         oe_host_printf("[[ INT SYSC ]] " x, ##__VA_ARGS__);                    \
@@ -196,13 +187,13 @@ extern int sgxlkl_trace_redirect_syscall;
     }
 
 #define SGXLKL_TRACE_SIGNAL(x, ...)                         \
-    if (sgxlkl_trace_signal)                                \
+    if (sgxlkl_enclave_state.config->trace.signal)          \
     {                                                       \
         oe_host_printf("[[  SIGNAL  ]] " x, ##__VA_ARGS__); \
     }
 
 #define SGXLKL_TRACE_DISK(x, ...)                           \
-    if (sgxlkl_trace_disk)                                  \
+    if (sgxlkl_enclave_state.config->trace.disk)            \
     {                                                       \
         oe_host_printf("[[   DISK   ]] " x, ##__VA_ARGS__); \
     }

--- a/src/include/host/env.h
+++ b/src/include/host/env.h
@@ -1,7 +1,7 @@
 #ifndef _ENV_H
 #define _ENV_H
 
-#include "shared/oe_compat.h"
+#include <inttypes.h>
 
 uint64_t size_str_to_uint64(const char* str, uint64_t def, uint64_t max);
 

--- a/src/include/host/env.h
+++ b/src/include/host/env.h
@@ -3,8 +3,6 @@
 
 #include "shared/oe_compat.h"
 
-uint64_t hex_to_int(const char* digits, size_t num_digits);
-
 uint64_t size_str_to_uint64(const char* str, uint64_t def, uint64_t max);
 
 void size_uint64_to_str(uint64_t size, char* buf, uint64_t len);
@@ -14,15 +12,5 @@ uint64_t getenv_uint64(const char* var, uint64_t def, uint64_t max);
 char* getenv_str(const char* var, const char* def);
 
 int getenv_bool(const char* var, int def);
-
-uint64_t next_pow2(uint64_t x);
-
-ssize_t hex_to_bytes(const char* hex, uint8_t** result);
-
-char* bytes_to_hex(
-    char* str,
-    size_t str_size,
-    const void* data,
-    size_t data_size);
 
 #endif /* _ENV_H */

--- a/src/include/host/sgxlkl_params.h
+++ b/src/include/host/sgxlkl_params.h
@@ -51,7 +51,7 @@
 #ifndef SGXLKL_RELEASE
 /* These environment variables do not have config settings, they are
  * automatically passed through and imported in the enclave */
-extern const char* sgxlkl_auto_passthrough[12];
+extern const char* sgxlkl_auto_passthrough[1];
 #endif
 
 #endif /* SGXLKL_PARAMS_H */

--- a/src/include/shared/oe_compat.h
+++ b/src/include/shared/oe_compat.h
@@ -10,6 +10,7 @@
 #include <openenclave/corelibc/oemalloc.h>
 #include <openenclave/corelibc/oestdlib.h>
 #include <openenclave/corelibc/oestring.h>
+#include <openenclave/corelibc/stdlib.h>
 #include <openenclave/internal/safecrt.h>
 
 #define malloc oe_malloc
@@ -21,11 +22,13 @@
 #define strtok_r oe_strtok_r
 #define snprintf oe_snprintf
 #define strtoul oe_strtoul
+#define memalign oe_memalign
 
 #else
 
 #include <assert.h>
 #include <inttypes.h>
+#include <malloc.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/src/include/shared/oe_compat.h
+++ b/src/include/shared/oe_compat.h
@@ -28,7 +28,6 @@
 
 #include <assert.h>
 #include <inttypes.h>
-#include <malloc.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>

--- a/src/include/shared/oe_compat.h
+++ b/src/include/shared/oe_compat.h
@@ -3,8 +3,8 @@
 
 #ifdef SGXLKL_ENCLAVE
 
-/* Rewire some libc functions to oecorelibc equivalents, to avoid dependencies on
- * sgx-lkl-musl in SGX-LKL kernel space. */
+/* Rewire some libc functions to oecorelibc equivalents, to avoid dependencies
+ * on sgx-lkl-musl in SGX-LKL kernel space. */
 
 #include <openenclave/corelibc/bits/types.h>
 #include <openenclave/corelibc/oemalloc.h>
@@ -19,6 +19,8 @@
 #define strlen oe_strlen
 #define strcmp oe_strcmp
 #define strtok_r oe_strtok_r
+#define snprintf oe_snprintf
+#define strtoul oe_strtoul
 
 #else
 
@@ -26,6 +28,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/include/shared/sgxlkl_enclave_config.h
+++ b/src/include/shared/sgxlkl_enclave_config.h
@@ -7,14 +7,23 @@
 /* Maximum path length of mount points for secondary disks */
 #define SGXLKL_DISK_MNT_MAX_PATH_LEN 255
 
+#include <openenclave/bits/defs.h>
+
 #include <sgxlkl_enclave_config_gen.h>
 
-void sgxlkl_read_enclave_config(
-    const char* from,
-    sgxlkl_enclave_config_t* to,
-    bool enforce_format);
+struct config_page
+{
+    sgxlkl_enclave_config_t config;
+} __attribute__((__aligned__(OE_PAGE_SIZE)));
 
-void sgxlkl_free_enclave_config(sgxlkl_enclave_config_t* enclave_config);
+typedef struct config_page sgxlkl_enclave_config_page_t;
+
+const sgxlkl_enclave_config_page_t* sgxlkl_read_enclave_config(
+    const char* from,
+    bool enforce_format,
+    size_t* num_pages);
+
+void sgxlkl_free_enclave_config_page(sgxlkl_enclave_config_page_t* config_page);
 
 /* Check if a disk is configured for encrypted operation */
 bool is_encrypted(sgxlkl_enclave_mount_config_t* cfg);

--- a/src/include/shared/shared_memory.h
+++ b/src/include/shared/shared_memory.h
@@ -1,8 +1,6 @@
 #ifndef SGXLKL_SHARED_MEMORY_H
 #define SGXLKL_SHARED_MEMORY_H
 
-#include "shared/oe_compat.h"
-
 #include <shared/vio_event_channel.h>
 
 typedef struct sgxlkl_shared_memory

--- a/src/include/shared/util.h
+++ b/src/include/shared/util.h
@@ -1,0 +1,19 @@
+#ifndef _SHARED_UTIL_H
+#define _SHARED_UTIL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+uint64_t hex_to_int(const char* digits, size_t num_digits);
+
+uint64_t next_pow2(uint64_t x);
+
+ssize_t hex_to_bytes(const char* hex, uint8_t** result);
+
+char* bytes_to_hex(
+    char* str,
+    size_t str_size,
+    const void* data,
+    size_t data_size);
+
+#endif

--- a/src/lkl/lkl_util.c
+++ b/src/lkl/lkl_util.c
@@ -111,19 +111,20 @@ long __sgxlkl_log_syscall(
     int params_len,
     ...)
 {
+    const sgxlkl_trace_config_t* tcfg = &sgxlkl_enclave_state.config->trace;
     const char* name = NULL;
     char errmsg[255] = {0};
 
-    if (!sgxlkl_trace_ignored_syscall && type == SGXLKL_IGNORED_SYSCALL)
+    if (!tcfg->ignored_syscall && type == SGXLKL_IGNORED_SYSCALL)
         return res;
 
-    if (!sgxlkl_trace_unsupported_syscall && type == SGXLKL_UNSUPPORTED_SYSCALL)
+    if (!tcfg->unsupported_syscall && type == SGXLKL_UNSUPPORTED_SYSCALL)
         return res;
 
-    if (!sgxlkl_trace_lkl_syscall && type == SGXLKL_LKL_SYSCALL)
+    if (!tcfg->lkl_syscall && type == SGXLKL_LKL_SYSCALL)
         return res;
 
-    if (!sgxlkl_trace_internal_syscall && type == SGXLKL_INTERNAL_SYSCALL)
+    if (!tcfg->internal_syscall && type == SGXLKL_INTERNAL_SYSCALL)
         return res;
 
     long params[6] = {0};

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -646,9 +646,8 @@ static void lkl_mount_disk(
     if ((tcfg->lkl_syscall || tcfg->internal_syscall) &&
         (disk->roothash || is_encrypted_cfg(disk)))
     {
-        // Check: const-casts acceptable?
-        *((bool*)&tcfg->lkl_syscall) = 0;
-        *((bool*)&tcfg->internal_syscall) = 0;
+        sgxlkl_enclave_state.trace_enabled.lkl_syscall = false;
+        sgxlkl_enclave_state.trace_enabled.internal_syscall = false;
         SGXLKL_VERBOSE("Disk encryption/integrity enabled: Temporarily "
                        "disabling tracing to reduce noise.\n");
     }
@@ -696,9 +695,10 @@ static void lkl_mount_disk(
     {
         SGXLKL_VERBOSE(
             "Disk encryption/integrity enabled: Re-enabling tracing.\n");
-        // Check: const-casts acceptable?
-        *((bool*)&tcfg->lkl_syscall) = lkl_trace_lkl_syscall_bak;
-        *((bool*)&tcfg->internal_syscall) = lkl_trace_internal_syscall_bak;
+        sgxlkl_enclave_state.trace_enabled.lkl_syscall =
+            lkl_trace_lkl_syscall_bak;
+        sgxlkl_enclave_state.trace_enabled.internal_syscall =
+            lkl_trace_internal_syscall_bak;
     }
 
     if (disk->create)

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -408,13 +408,6 @@ static void* lkl_activate_crypto_disk_thread(struct lkl_crypt_device* lkl_cd)
 
     crypt_free(cd);
 
-    // The key is only needed during activation, so don't keep it around
-    // afterwards and free up space.
-    memset(lkl_cd->disk_config.key, 0, lkl_cd->disk_config.key_len);
-
-    lkl_cd->disk_config.key = NULL;
-    lkl_cd->disk_config.key_len = 0;
-
     return 0;
 }
 #endif
@@ -621,13 +614,11 @@ static void lkl_mount_disk(
     lkl_cd.readonly = disk->readonly;
     lkl_cd.disk_config = *disk;
 
-    (void)lkl_cd;
-
-    if (disk->create && disk->fresh_key)
+    if (disk->create && disk->fresh_key && !disk->key)
     {
         disk->key_len = CREATED_DISK_KEY_LENGTH / 8;
         SGXLKL_VERBOSE("Generating random disk encryption key\n");
-        disk->key = malloc(disk->key_len);
+        disk->key = oe_malloc(disk->key_len);
         if (disk->key == NULL)
             sgxlkl_fail("Could not allocate memory for disk encryption key\n");
         for (size_t i = 0; i < disk->key_len; i++)

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -114,6 +114,7 @@ static void lkl_prepare_rootfs(const char* dirname, int perm)
     {
         lkl_sys_chmod(dirname, perm);
     }
+    
 }
 
 static void lkl_copy_blkdev_nodes(const char* srcdir, const char* dstdir)
@@ -460,12 +461,15 @@ static void* lkl_create_crypto_disk_thread(struct lkl_crypt_device* lkl_cd)
 
     // As we generate our own key and don't use a simple "password" we use
     // the minimal kdf settings possible.
-    struct crypt_pbkdf_type pbkdf = {
+    struct crypt_pbkdf_type pbkdf =
+    {
         .type = "pbkdf2",
         .hash = "sha256",
         .iterations = MIN_LUKS2_ITERATIONS,
     };
-    struct crypt_params_luks2 params = {.sector_size = SECTOR_SIZE,
+    struct crypt_params_luks2 params =
+    {
+        .sector_size = SECTOR_SIZE,
         .pbkdf = &pbkdf,
 #ifdef ENABLE_INTEGRITY
         .integrity = "hmac(sha256)"

--- a/src/lkl/syscall-overrides.c
+++ b/src/lkl/syscall-overrides.c
@@ -204,7 +204,7 @@ void register_lkl_syscall_overrides()
 #define LKL_SYSCALL_DEFINE6(name, ...)                    \
     real_syscalls[__lkl__NR##name] = lkl_replace_syscall( \
         __lkl__NR##name, (lkl_syscall_handler_t)log##name);
-    if (sgxlkl_trace_lkl_syscall)
+    if (sgxlkl_enclave_state.config->trace.lkl_syscall)
     {
 #include <lkl/asm/syscall_defs.h>
     }
@@ -219,7 +219,7 @@ void register_lkl_syscall_overrides()
     // version that does the tracing and exits, otherwise replace them with a
     // version that silently returns success.
 #if SGXLKL_ENABLE_SYSCALL_TRACING
-    if (sgxlkl_trace_ignored_syscall)
+    if (sgxlkl_enclave_state.config->trace.ignored_syscall)
     {
 #define IGNORED_SYSCALL(name, args) \
     lkl_replace_syscall(            \
@@ -237,7 +237,7 @@ void register_lkl_syscall_overrides()
     // a version that does the tracing and exits, otherwise replace them with a
     // version that silently returns failure.
 #if SGXLKL_ENABLE_SYSCALL_TRACING
-    if (sgxlkl_trace_unsupported_syscall)
+    if (sgxlkl_enclave_state.config->trace.unsupported_syscall)
     {
 #define UNSUPPORTED_SYSCALL(name, args) \
     lkl_replace_syscall(                \
@@ -256,7 +256,8 @@ void register_lkl_syscall_overrides()
     // These are internal - use the trace versions if we are doing internal
     // syscall tracing.
 #if SGXLKL_ENABLE_SYSCALL_TRACING
-    syscall_register_mem_overrides(sgxlkl_trace_internal_syscall);
+    syscall_register_mem_overrides(
+        sgxlkl_enclave_state.config->trace.internal_syscall);
 #else
     syscall_register_mem_overrides(false);
 #endif

--- a/src/main-oe/env.c
+++ b/src/main-oe/env.c
@@ -23,12 +23,15 @@ uint64_t size_str_to_uint64(const char* str, uint64_t def, uint64_t max)
         case 'G':
         case 'g':
             m *= 1024;
+            __attribute__((fallthrough));
         case 'M':
         case 'm':
             m *= 1024;
+            __attribute__((fallthrough));
         case 'K':
         case 'k':
             m *= 1024;
+            __attribute__((fallthrough));
         default:
             break;
     }

--- a/src/main-oe/env.c
+++ b/src/main-oe/env.c
@@ -1,0 +1,84 @@
+#include "host/env.h"
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "shared/util.h"
+
+uint64_t size_str_to_uint64(const char* str, uint64_t def, uint64_t max)
+{
+    uint64_t r;
+    char* endptr;
+    errno = 0;
+    r = (uint64_t)strtoull(str, &endptr, 10);
+    if (r == ULONG_MAX && errno == ERANGE)
+    {
+        r = def;
+    }
+    int m = 1;
+    switch (*endptr)
+    {
+        case 'G':
+        case 'g':
+            m *= 1024;
+        case 'M':
+        case 'm':
+            m *= 1024;
+        case 'K':
+        case 'k':
+            m *= 1024;
+        default:
+            break;
+    }
+
+    // Check for potential overflow
+    if (r > (ULONG_MAX / m))
+        return max;
+    r *= m;
+
+    return (r > max) ? max : r;
+}
+
+void size_uint64_to_str(uint64_t size, char* buf, uint64_t len)
+{
+    int i = 0;
+    double bytes = size;
+    const char* units[] = {"B", "KB", "MB", "GB", "TB", "PB"};
+    while (bytes > 1024.0)
+    {
+        bytes /= 1024.0;
+        i++;
+    }
+    snprintf(buf, len, "%.*f %s", i, bytes, units[i]);
+}
+
+uint64_t getenv_uint64(const char* var, uint64_t def, uint64_t max)
+{
+    char* val;
+    if (!(val = getenv(var)))
+        return def;
+
+    return size_str_to_uint64(val, def, max);
+}
+
+char* getenv_str(const char* var, const char* def)
+{
+    char* val = getenv(var);
+    // Duplicate default value as it might not be allocated on the heap and to
+    // make API consistent, i.e. the memory pointed to by the return value
+    // should be freeable.
+    return (val != NULL) ? strdup(val) : ((def != NULL) ? strdup(def) : NULL);
+}
+
+int getenv_bool(const char* var, int def)
+{
+    char* val = getenv(var);
+    if (val == NULL)
+        return def;
+    if (def)
+        return (strncmp(val, "0", 1) != 0);
+    else
+        return (strncmp(val, "1", 1) == 0);
+}

--- a/src/main-oe/sgxlkl_host_config.c
+++ b/src/main-oe/sgxlkl_host_config.c
@@ -8,10 +8,10 @@
 
 #include <json.h>
 
+#include "host/env.h"
 #include "host/sgxlkl_host_config.h"
 #include "host/sgxlkl_params.h"
 #include "host/sgxlkl_util.h"
-#include "shared/env.h"
 
 #define FAIL sgxlkl_host_fail
 

--- a/src/main-oe/sgxlkl_params.c
+++ b/src/main-oe/sgxlkl_params.c
@@ -1,14 +1,3 @@
 #include "host/sgxlkl_params.h"
 
-const char* sgxlkl_auto_passthrough[12] = {"SGXLKL_DEBUGMOUNT",
-                                           "SGXLKL_PRINT_APP_RUNTIME",
-                                           "SGXLKL_TRACE_HOST_SYSCALL",
-                                           "SGXLKL_TRACE_INTERNAL_SYSCALL",
-                                           "SGXLKL_TRACE_LKL_SYSCALL",
-                                           "SGXLKL_TRACE_IGNORED_SYSCALL",
-                                           "SGXLKL_TRACE_UNSUPPORTED_SYSCALL",
-                                           "SGXLKL_TRACE_REDIRECT_SYSCALL",
-                                           "SGXLKL_TRACE_MMAP",
-                                           "SGXLKL_TRACE_SYSCALL",
-                                           "SGXLKL_TRACE_THREAD",
-                                           "SGXLKL_TRACE_SIGNAL"};
+const char* sgxlkl_auto_passthrough[1] = {"SGXLKL_DEBUGMOUNT"};

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -1488,7 +1488,9 @@ void enclave_config_from_file(const char* filename)
     if (ret < 0)
         sgxlkl_host_fail("Failed to read %s: %s.\n", filename, strerror(errno));
 
-    sgxlkl_read_enclave_config(buf, &sgxlkl_host_state.enclave_config, false);
+    const sgxlkl_enclave_config_page_t* config_page =
+        sgxlkl_read_enclave_config(buf, false, NULL);
+    sgxlkl_host_state.enclave_config = *(sgxlkl_enclave_config_t*)config_page;
 }
 
 void override_enclave_config(

--- a/src/main-oe/sgxlkl_run_oe.c
+++ b/src/main-oe/sgxlkl_run_oe.c
@@ -28,13 +28,13 @@
 #include <arpa/inet.h>
 #include <netinet/ip.h>
 
+#include "host/env.h"
 #include "host/host_state.h"
 #include "host/serialize_enclave_config.h"
 #include "host/sgxlkl_host_config.h"
 #include "host/sgxlkl_params.h"
 #include "host/sgxlkl_util.h"
 #include "host/vio_host_event_channel.h"
-#include "shared/env.h"
 #include "shared/sgxlkl_enclave_config.h"
 
 #include "lkl/linux/virtio_net.h"

--- a/src/shared/sgxlkl_enclave_config.c
+++ b/src/shared/sgxlkl_enclave_config.c
@@ -8,32 +8,34 @@
 #define WARN sgxlkl_host_warn
 #endif
 
+#include <openenclave/bits/defs.h>
+
 #include <json.h>
 #include <shared/oe_compat.h>
 #include <shared/sgxlkl_enclave_config.h>
 #include <shared/string_list.h>
 #include <shared/util.h>
 
-#define CHECKMEM(C) \
-    if (!C)         \
-        FAIL("out of memory\n");
-
 // Duplicate a string (including NULL)
-static int strdupz(char** to, const char* from)
+static int strdupz(
+    char** to,
+    const char* from,
+    uint8_t** bytes,
+    size_t* bytes_remaining)
 {
     if (!to)
         return 1;
     else if (!from)
-    {
         *to = NULL;
-        return 0;
-    }
     else
     {
-        size_t l = strlen(from);
-        *to = malloc(l + 1);
-        CHECKMEM(*to);
-        memcpy(*to, from, l + 1);
+        size_t sz = strlen(from) + 1;
+        if (*bytes_remaining < sz)
+            FAIL("out of memory\n");
+        memcpy(*bytes, from, sz);
+        *to = (char*)*bytes;
+        *bytes_remaining -= sz;
+        *bytes += sz;
     }
     return 0;
 }
@@ -44,6 +46,9 @@ typedef struct json_callback_data
     unsigned long index;
     string_list_t* seen;
     bool enforce_format;
+
+    uint8_t* bytes;
+    size_t bytes_remaining;
 } json_callback_data_t;
 
 static char* make_path(json_parser_t* parser)
@@ -67,8 +72,13 @@ static char* make_path(json_parser_t* parser)
         }
     }
 
-    char* r = NULL;
-    strdupz(&r, tmp);
+    size_t sz = strlen(tmp) + 1;
+    char* r = malloc(sz);
+    if (!r)
+        FAIL("out of memory\n");
+    char* t = r;
+    if (strdupz(&r, tmp, (uint8_t**)&t, &sz) != 0)
+        return NULL;
     return r;
 }
 
@@ -124,10 +134,16 @@ static char* make_path(json_parser_t* parser)
         return JSON_OK;                   \
     }
 
-#define JSTRING(PATH, DEST)                           \
-    JPATH2T(PATH, JSON_TYPE_STRING, JSON_TYPE_NULL, { \
-        if (strdupz(&(DEST), un ? un->string : NULL)) \
-            return JSON_FAILED;                       \
+#define JSTRING(PATH, DEST)                               \
+    JPATH2T(PATH, JSON_TYPE_STRING, JSON_TYPE_NULL, {     \
+        json_callback_data_t* cbd =                       \
+            (json_callback_data_t*)parser->callback_data; \
+        if (strdupz(                                      \
+                &(DEST),                                  \
+                un ? un->string : NULL,                   \
+                &cbd->bytes,                              \
+                &cbd->bytes_remaining))                   \
+            return JSON_FAILED;                           \
     });
 
 static json_result_t decode_safe_uint64_t(
@@ -229,10 +245,13 @@ static json_result_t decode_uint32_t(
             else                                                 \
             {                                                    \
                 DEST##_len = l / 2;                              \
-                DEST = calloc(1, DEST##_len);                    \
-                CHECKMEM(DEST);                                  \
+                if (data->bytes_remaining < DEST##_len)          \
+                    return JSON_OUT_OF_MEMORY;                   \
+                DEST = data->bytes;                              \
                 for (size_t i = 0; i < DEST##_len; i++)          \
                     DEST[i] = hex_to_int(un->string + 2 * i, 2); \
+                data->bytes_remaining -= DEST##_len;             \
+                data->bytes += DEST##_len;                       \
             }                                                    \
         }                                                        \
     });
@@ -243,12 +262,16 @@ static json_result_t decode_uint32_t(
 #define JU64(P, D) JPATH(P, return decode_uint64_t(parser, type, un, &D));
 #define JU32(P, D) JPATH(P, return decode_uint32_t(parser, type, un, &D));
 
-#define ALLOC_ARRAY(N, A, T)                              \
-    do                                                    \
-    {                                                     \
-        data->config->N = un->integer;                    \
-        data->config->A = calloc(un->integer, sizeof(T)); \
-        CHECKMEM(data->config->A);                        \
+#define ALLOC_ARRAY(N, A, T)                 \
+    do                                       \
+    {                                        \
+        data->config->N = un->integer;       \
+        size_t sz = un->integer * sizeof(T); \
+        if (data->bytes_remaining < sz)      \
+            return JSON_OUT_OF_MEMORY;       \
+        data->config->A = (T*)data->bytes;   \
+        data->bytes_remaining -= sz;         \
+        data->bytes += sz;                   \
     } while (0)
 
 static sgxlkl_enclave_mount_config_t* _mount(
@@ -382,13 +405,25 @@ static json_result_t json_read_callback(
 
             JSTRING("cwd", cfg->cwd);
             JPATHT("args", JSON_TYPE_STRING, {
-                strdupz(&cfg->args[i], un->string);
+                strdupz(
+                    &cfg->args[i],
+                    un->string,
+                    &data->bytes,
+                    &data->bytes_remaining);
             });
             JPATHT("env", JSON_TYPE_STRING, {
-                strdupz(&cfg->env[i], un->string);
+                strdupz(
+                    &cfg->env[i],
+                    un->string,
+                    &data->bytes,
+                    &data->bytes_remaining);
             });
             JPATHT("host_import_env", JSON_TYPE_STRING, {
-                strdupz(&cfg->host_import_env[i], un->string);
+                strdupz(
+                    &cfg->host_import_env[i],
+                    un->string,
+                    &data->bytes,
+                    &data->bytes_remaining);
             });
 
             JPATHT("exit_status", JSON_TYPE_STRING, {
@@ -488,10 +523,10 @@ void check_required_elements(string_list_t* seen)
     }
 }
 
-void sgxlkl_read_enclave_config(
+const sgxlkl_enclave_config_page_t* sgxlkl_read_enclave_config(
     const char* from,
-    sgxlkl_enclave_config_t* to,
-    bool enforce_format)
+    bool enforce_format,
+    size_t* num_pages_out)
 {
     // Catch modifications to sgxlkl_enclave_config_t early. If this fails,
     // the code above/below needs adjusting for the added/removed settings.
@@ -502,23 +537,35 @@ void sgxlkl_read_enclave_config(
     if (!from)
         FAIL("No config to read\n");
 
-    if (!to)
-        FAIL("No config to write to\n");
+    size_t num_pages = (strlen(from) / OE_PAGE_SIZE) + 1;
+    sgxlkl_enclave_config_page_t* config_page =
+        memalign(OE_PAGE_SIZE, num_pages * OE_PAGE_SIZE);
+    memset(config_page, 0, OE_PAGE_SIZE);
+    if (!config_page)
+        FAIL("out of memory\n");
+    config_page->config = sgxlkl_enclave_config_default;
 
-    *to = sgxlkl_enclave_config_default;
+    if (num_pages_out)
+        *num_pages_out = num_pages;
 
     json_parser_t parser;
     json_parser_options_t options;
     options.allow_whitespace = !enforce_format;
     json_result_t r = JSON_UNEXPECTED;
-    json_callback_data_t callback_data = {.config = to,
-                                          .index = 0,
-                                          .seen = NULL,
-                                          .enforce_format = enforce_format};
+    size_t config_size = sizeof(sgxlkl_enclave_config_t);
+    json_callback_data_t callback_data = {
+        .config = &config_page->config,
+        .index = 0,
+        .seen = NULL,
+        .enforce_format = enforce_format,
+        .bytes = (uint8_t*)(&config_page->config) + config_size,
+        .bytes_remaining = OE_PAGE_SIZE - config_size};
 
     // parser destroys `from`, so we copy it first.
     size_t json_len = strlen(from);
     char* json_copy = malloc(sizeof(char) * (json_len + 1));
+    if (!json_copy)
+        FAIL("out of memory\n");
     memcpy(json_copy, from, json_len);
 
     json_allocator_t allocator = {.ja_malloc = malloc, .ja_free = free};
@@ -544,61 +591,15 @@ void sgxlkl_read_enclave_config(
 
     if (enforce_format)
         check_required_elements(callback_data.seen);
-    check_config(to);
+    check_config(&config_page->config);
     string_list_free(callback_data.seen, true);
+    return config_page;
 }
 
-#define NONDEFAULT_FREE(X)              \
-    if (config->X != default_config->X) \
-        free(config->X);
-
-void sgxlkl_free_enclave_config(sgxlkl_enclave_config_t* config)
+void sgxlkl_free_enclave_config_page(sgxlkl_enclave_config_page_t* config_page)
 {
-    const sgxlkl_enclave_config_t* default_config =
-        &sgxlkl_enclave_config_default;
-
-    NONDEFAULT_FREE(net_ip4);
-    NONDEFAULT_FREE(net_gw4);
-    NONDEFAULT_FREE(net_mask4);
-    NONDEFAULT_FREE(hostname);
-
-    NONDEFAULT_FREE(wg.ip);
-    for (size_t i = 0; i < config->wg.num_peers; i++)
-    {
-        free(config->wg.peers[i].key);
-        free(config->wg.peers[i].allowed_ips);
-        free(config->wg.peers[i].endpoint);
-    }
-    NONDEFAULT_FREE(wg.peers);
-
-    NONDEFAULT_FREE(kernel_cmd);
-    NONDEFAULT_FREE(sysctl);
-    NONDEFAULT_FREE(cwd);
-
-    for (size_t i = 0; i < config->num_args; i++)
-        free(config->args[i]);
-    NONDEFAULT_FREE(args);
-
-    for (size_t i = 0; i < config->num_env; i++)
-        free(config->env[i]);
-    NONDEFAULT_FREE(env);
-
-    for (size_t i = 0; i < config->num_host_import_env; i++)
-        free(config->host_import_env[i]);
-    NONDEFAULT_FREE(host_import_env);
-
-    NONDEFAULT_FREE(root.key);
-    NONDEFAULT_FREE(root.key_id);
-    NONDEFAULT_FREE(root.roothash);
-
-    for (size_t i = 0; i < config->num_mounts; i++)
-    {
-        free(config->mounts[i].key);
-        free(config->mounts[i].key_id);
-        free(config->mounts[i].roothash);
-    }
-    NONDEFAULT_FREE(mounts);
-    free(config);
+    /* frees the entire config, including all strings */
+    free(config_page);
 }
 
 bool is_encrypted(sgxlkl_enclave_mount_config_t* cfg)

--- a/src/shared/sgxlkl_enclave_config.c
+++ b/src/shared/sgxlkl_enclave_config.c
@@ -539,8 +539,18 @@ const sgxlkl_enclave_config_page_t* sgxlkl_read_enclave_config(
 
     size_t num_pages = (strlen(from) / OE_PAGE_SIZE) + 1;
     sgxlkl_enclave_config_page_t* config_page =
+#ifdef SGXLKL_ENCLAVE
         memalign(OE_PAGE_SIZE, num_pages * OE_PAGE_SIZE);
+#else
+        malloc(num_pages * OE_PAGE_SIZE);
+#endif
+
+#ifdef SGXLKL_ENCLAVE
+    oe_memset_s(config_page, OE_PAGE_SIZE, 0, OE_PAGE_SIZE);
+#else
     memset(config_page, 0, OE_PAGE_SIZE);
+#endif
+
     if (!config_page)
         FAIL("out of memory\n");
     config_page->config = sgxlkl_enclave_config_default;

--- a/src/shared/sgxlkl_enclave_config.c
+++ b/src/shared/sgxlkl_enclave_config.c
@@ -10,9 +10,9 @@
 
 #include <json.h>
 #include <shared/oe_compat.h>
-#include <shared/env.h>
 #include <shared/sgxlkl_enclave_config.h>
 #include <shared/string_list.h>
+#include <shared/util.h>
 
 #define CHECKMEM(C) \
     if (!C)         \
@@ -431,6 +431,21 @@ static json_result_t json_read_callback(
             JBOOL("io.block", io->block);
             JBOOL("io.network", io->network);
 
+#ifndef SGXLKL_RELEASE
+            sgxlkl_trace_config_t* trace = &cfg->trace;
+            JBOOL("trace.print_app_runtime", trace->print_app_runtime);
+            JBOOL("trace.mmap", trace->mmap);
+            JBOOL("trace.signal", trace->signal);
+            JBOOL("trace.thread", trace->thread);
+            JBOOL("trace.disk", trace->disk);
+            JBOOL("trace.syscall", trace->syscall);
+            JBOOL("trace.lkl_syscall", trace->lkl_syscall);
+            JBOOL("trace.internal_syscall", trace->internal_syscall);
+            JBOOL("trace.ignored_syscall", trace->ignored_syscall);
+            JBOOL("trace.unsupported_syscall", trace->unsupported_syscall);
+            JBOOL("trace.redirect_syscall", trace->redirect_syscall);
+#endif
+
             FAIL(
                 "Invalid unknown json element '%s'; refusing to run with this "
                 "enclave config.\n",
@@ -481,7 +496,7 @@ void sgxlkl_read_enclave_config(
     // Catch modifications to sgxlkl_enclave_config_t early. If this fails,
     // the code above/below needs adjusting for the added/removed settings.
     _Static_assert(
-        sizeof(sgxlkl_enclave_config_t) == 464,
+        sizeof(sgxlkl_enclave_config_t) == 472,
         "sgxlkl_enclave_config_t size has changed");
 
     if (!from)

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -1,10 +1,9 @@
+#ifndef SGXLKL_ENCLAVE
 #include <errno.h>
-#include <limits.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include "shared/env.h"
+#endif
+
+#include <shared/oe_compat.h>
+#include <shared/util.h>
 
 uint64_t hex_to_int(const char* digits, size_t num_digits)
 {
@@ -21,82 +20,6 @@ uint64_t hex_to_int(const char* digits, size_t num_digits)
             r |= (0xA + (c - 'A')) & 0xFF;
     }
     return r;
-}
-
-uint64_t size_str_to_uint64(const char* str, uint64_t def, uint64_t max)
-{
-    uint64_t r;
-    char* endptr;
-    errno = 0;
-    r = (uint64_t)strtoull(str, &endptr, 10);
-    if (r == ULONG_MAX && errno == ERANGE)
-    {
-        r = def;
-    }
-    int m = 1;
-    switch (*endptr)
-    {
-        case 'G':
-        case 'g':
-            m *= 1024;
-        case 'M':
-        case 'm':
-            m *= 1024;
-        case 'K':
-        case 'k':
-            m *= 1024;
-        default:
-            break;
-    }
-
-    // Check for potential overflow
-    if (r > (ULONG_MAX / m))
-        return max;
-    r *= m;
-
-    return (r > max) ? max : r;
-}
-
-void size_uint64_to_str(uint64_t size, char* buf, uint64_t len)
-{
-    int i = 0;
-    double bytes = size;
-    const char* units[] = {"B", "KB", "MB", "GB", "TB", "PB"};
-    while (bytes > 1024.0)
-    {
-        bytes /= 1024.0;
-        i++;
-    }
-    snprintf(buf, len, "%.*f %s", i, bytes, units[i]);
-}
-
-uint64_t getenv_uint64(const char* var, uint64_t def, uint64_t max)
-{
-    char* val;
-    if (!(val = getenv(var)))
-        return def;
-
-    return size_str_to_uint64(val, def, max);
-}
-
-char* getenv_str(const char* var, const char* def)
-{
-    char* val = getenv(var);
-    // Duplicate default value as it might not be allocated on the heap and to
-    // make API consistent, i.e. the memory pointed to by the return value
-    // should be freeable.
-    return (val != NULL) ? strdup(val) : ((def != NULL) ? strdup(def) : NULL);
-}
-
-int getenv_bool(const char* var, int def)
-{
-    char* val = getenv(var);
-    if (val == NULL)
-        return def;
-    if (def)
-        return (strncmp(val, "0", 1) != 0);
-    else
-        return (strncmp(val, "1", 1) == 0);
 }
 
 uint64_t next_pow2(uint64_t x)
@@ -122,10 +45,12 @@ ssize_t hex_to_bytes(const char* hex, uint8_t** result)
     }
     len /= 2;
 
-    bytes = malloc(2*len);
+    bytes = malloc(2 * len);
     if (!bytes)
     {
+#ifndef SGXLKL_ENCLAVE
         errno = ENOMEM;
+#endif
         return -1;
     }
 
@@ -137,7 +62,9 @@ ssize_t hex_to_bytes(const char* hex, uint8_t** result)
         if (endp != &buf[2])
         {
             free(bytes);
+#ifndef SGXLKL_ENCLAVE
             errno = EINVAL;
+#endif
             return -1;
         }
         hex++;
@@ -152,7 +79,9 @@ ssize_t hex_to_bytes(const char* hex, uint8_t** result)
         if (endp != &buf[2])
         {
             free(bytes);
+#ifndef SGXLKL_ENCLAVE
             errno = EINVAL;
+#endif
             return -1;
         }
     }

--- a/tests/basic/eeid-config/Makefile
+++ b/tests/basic/eeid-config/Makefile
@@ -25,14 +25,16 @@ run: run-hw
 
 run-gdb: run-hw-gdb
 
+CONFIGS=--host-config host-config.json --enclave-config enclave_config.json
+
 run-hw: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) --enclave-config enclave_config.json $(SGXLKL_ROOTFS)
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(CONFIGS)  $(SGXLKL_ROOTFS)
 
 run-hw-gdb: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) --enclave-config enclave_config.json $(SGXLKL_ROOTFS)
+	  $(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) $(CONFIGS) $(SGXLKL_ROOTFS)
 
 run-sw: ${SGXLKL_ROOTFS}
-	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) --enclave-config enclave_config.json $(SGXLKL_ROOTFS)
+	  $(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) $(CONFIGS) $(SGXLKL_ROOTFS)
 
 clean:
 	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/tests/basic/eeid-config/host-config.json
+++ b/tests/basic/eeid-config/host-config.json
@@ -1,0 +1,5 @@
+{
+  "root": {
+    "image_path": "sgx-lkl-rootfs.img"
+  }
+}

--- a/tests/tools/sgx-lkl-cfg/create/enclave-config-complete-ref.json
+++ b/tests/tools/sgx-lkl-cfg/create/enclave-config-complete-ref.json
@@ -86,5 +86,18 @@
     "network": true,
     "block": true,
     "console": true
+  },
+  "trace": {
+    "print_app_runtime": false,
+    "mmap": false,
+    "signal": false,
+    "thread": false,
+    "disk": false,
+    "syscall": false,
+    "lkl_syscall": false,
+    "internal_syscall": false,
+    "ignored_syscall": false,
+    "unsupported_syscall": false,
+    "redirect_syscall": false
   }
 }

--- a/tools/schemas/enclave-config.schema.json
+++ b/tools/schemas/enclave-config.schema.json
@@ -314,6 +314,66 @@
         }
       }
     },
+    "sgxlkl_trace_config_t": {
+      "type": "object",
+      "properties": {
+        "print_app_runtime": {
+          "type": "boolean",
+          "description": "Print total runtime of the application excluding the enclave and SGX-LKL startup/shutdown time.",
+          "default": false
+        },
+        "mmap": {
+          "type": "boolean",
+          "description": "Trace in-enclave mmap/munmap operations.",
+          "default": false
+        },
+        "signal": {
+          "type": "boolean",
+          "description": "Trace signal handling.",
+          "default": false
+        },
+        "thread": {
+          "type": "boolean",
+          "description": "Trace in-enclave user level thread scheduling.",
+          "default": false
+        },
+        "disk": {
+          "type": "boolean",
+          "description": "Trace in-enclave disk setup.",
+          "default": false
+        },
+        "syscall": {
+          "type": "boolean",
+          "description": "Trace all system calls.",
+          "default": false
+        },
+        "lkl_syscall": {
+          "type": "boolean",
+          "description": "Trace in-enclave system calls handled by LKL.",
+          "default": false
+        },
+        "internal_syscall": {
+          "type": "boolean",
+          "description": "Trace in-enclave system calls not handled by LKL (in particular mmap/mremap/munmap and futex).",
+          "default": false
+        },
+        "ignored_syscall": {
+          "type": "boolean",
+          "description": "Trace ignored system calls.",
+          "default": false
+        },
+        "unsupported_syscall": {
+          "type": "boolean",
+          "description": "Trace unsupported system calls.",
+          "default": false
+        },
+        "redirect_syscall": {
+          "type": "boolean",
+          "description": "Trace redirected system calls.",
+          "default": false
+        }
+      }
+    },
     "sgxlkl_enclave_config_t": {
       "type": "object",
       "properties": {
@@ -541,6 +601,10 @@
         "io": {
           "$ref": "#/definitions/sgxlkl_io_config_t",
           "description": "I/O configuration."
+        },
+        "trace": {
+          "$ref": "#/definitions/sgxlkl_trace_config_t",
+          "description": "Tracing configuration (debug only)."
         }
       }
     }


### PR DESCRIPTION
This adds proper tracing options, which removes the need for `getenv` calls in the enclave. Fixes #780.

Goes with https://github.com/lsds/sgx-lkl-musl/pull/36.