### PR TITLE
[Test] Build only enabled LTP tests

### DIFF
--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -38,11 +38,7 @@ $(LTP_SOURCE_DIR)/.git:
 $(ALPINE_TAR):
 	curl -L -o "$@" "https://nl.alpinelinux.org/alpine/v$(ALPINE_MAJOR)/releases/$(ALPINE_ARCH)/alpine-minirootfs-$(ALPINE_VERSION)-$(ALPINE_ARCH).tar.gz"
 
-$(LTP_TEST_MNT_IMG):
-	dd if=/dev/zero of=$(LTP_TEST_MNT_IMG) count=$(LTP_TEST_MNT_IMG_SIZE) bs=1M
-	mkfs -t ext4 $(LTP_TEST_MNT_IMG)
-
-$(ROOT_FS): $(ALPINE_TAR) $(BUILDENV_SCRIPT) $(LTP_SOURCE_DIR)/.git $(LTP_TEST_MNT_IMG)
+$(ROOT_FS): $(ALPINE_TAR) $(BUILDENV_SCRIPT) $(LTP_SOURCE_DIR)/.git
 	dd if=/dev/zero of="$@" count=$(IMAGE_SIZE_MB) bs=1M
 	mkfs.ext4 "$@"
 	$(ESCALATE_CMD) mkdir -p $(MOUNTPOINT)
@@ -59,8 +55,8 @@ $(ROOT_FS): $(ALPINE_TAR) $(BUILDENV_SCRIPT) $(LTP_SOURCE_DIR)/.git $(LTP_TEST_M
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk add bash
 	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp_tst_mnt_fs
-	$(ESCALATE_CMD) dd if=/dev/zero of=$(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img count=256 bs=1M
-	$(ESCALATE_CMD) mkfs -t ext4 $(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img
+	$(ESCALATE_CMD) dd if=/dev/zero of=$(MOUNTPOINT)/$(LTP_TEST_MNT_IMG) count=$(LTP_TEST_MNT_IMG_SIZE) bs=1M
+	$(ESCALATE_CMD) mkfs -t ext4 $(MOUNTPOINT)/$(LTP_TEST_MNT_IMG)
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)
@@ -100,7 +96,6 @@ run-sw-single-gdb: $(ROOT_FS)
 clean:
 	@test -f $(ALPINE_TAR) && rm $(ALPINE_TAR) || true
 	@test -f $(ROOT_FS) && rm $(ROOT_FS) || true
-	@test -f $(LTP_TEST_MNT_IMG) && rm $(LTP_TEST_MNT_IMG) || true
 	@test -f $(ROOT_FS_FRESH_COPY) && rm $(ROOT_FS_FRESH_COPY) || true
 	@rm -f .c_binaries_list
 

--- a/tests/ltp/batch.mk
+++ b/tests/ltp/batch.mk
@@ -50,6 +50,10 @@ $(ROOT_FS): $(ALPINE_TAR) $(BUILDENV_SCRIPT) $(LTP_SOURCE_DIR)/.git $(LTP_TEST_M
 	$(ESCALATE_CMD) tar -C $(MOUNTPOINT) -xvf $(ALPINE_TAR)
 	$(ESCALATE_CMD) cp /etc/resolv.conf $(MOUNTPOINT)/etc/resolv.conf
 	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp
+	$(ESCALATE_CMD) mkdir -p $(MOUNTPOINT)/tests/ltp/ltp-batch1
+	$(ESCALATE_CMD) mkdir -p $(MOUNTPOINT)/tests/ltp/ltp-batch2
+	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/tests/ltp/ltp-batch1/* $(MOUNTPOINT)/tests/ltp/ltp-batch1/
+	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/tests/ltp/ltp-batch2/* $(MOUNTPOINT)/tests/ltp/ltp-batch2/
 	$(ESCALATE_CMD) cp -R $(SGXLKL_ROOT)/ltp/* $(MOUNTPOINT)/ltp/
 	$(ESCALATE_CMD) install $(BUILDENV_SCRIPT) $(MOUNTPOINT)/usr/sbin
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /sbin/apk update
@@ -57,8 +61,6 @@ $(ROOT_FS): $(ALPINE_TAR) $(BUILDENV_SCRIPT) $(LTP_SOURCE_DIR)/.git $(LTP_TEST_M
 	$(ESCALATE_CMD) mkdir $(MOUNTPOINT)/ltp_tst_mnt_fs
 	$(ESCALATE_CMD) dd if=/dev/zero of=$(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img count=256 bs=1M
 	$(ESCALATE_CMD) mkfs -t ext4 $(MOUNTPOINT)/ltp_tst_mnt_fs/tstfs_ext4.img
-
-
 	$(ESCALATE_CMD) chroot $(MOUNTPOINT) /bin/bash /usr/sbin/buildenv.sh 'build' '/ltp/testcases/kernel/syscalls'
 	$(ESCALATE_CMD) cp $(MOUNTPOINT)/ltp/.c_binaries_list .
 	$(ESCALATE_CMD) umount $(MOUNTPOINT)

--- a/tests/ltp/buildenv.sh
+++ b/tests/ltp/buildenv.sh
@@ -16,15 +16,16 @@ function CreateNotEnabledLtpTestFoldersListFile()
     # Get the unique syscall list that LTP test suite addresses
     cur_folder=$(pwd)
     cd "/ltp/testcases/kernel/syscalls"
+    # shellcheck disable=SC2012,SC2035
     ls -ld */  | sed 's/.* \(.*\)\//\1/g' | sort | uniq > "/ltp_folders.txt"
-    cd $cur_folder
+    cd "$cur_folder"
 
     rm -fr "/ltp_folders_enabled_tmp.txt"
 
     # Get the unique syscall list that enabled in sgx-lkl
     while IFS= read -r line
     do
-       sed -e 's/#\/ltp\/testcases\/kernel\/syscalls\/\(.*\)\/.*/\1/g' <<< $line >>"/ltp_folders_enabled_tmp.txt"
+       sed -e 's/#\/ltp\/testcases\/kernel\/syscalls\/\(.*\)\/.*/\1/g' <<< "$line" >>"/ltp_folders_enabled_tmp.txt"
     done<"/enabled_ltp_tests.txt"
 
     # Get the difference of above 2 lists to get the syscall list that zero LTP test enabled
@@ -107,9 +108,9 @@ if [[ "$mode" == "build" ]]; then
         c_file_count=${#c_file_list[@]}
         c_binaries_total=$((c_binaries_total + c_file_count))
 
-        folder_name=$(sed -e 's/\/ltp\/testcases\/kernel\/syscalls\/\(.*\)/\1/g' <<< $current_test_directory)
+        folder_name=$(sed -e 's/\/ltp\/testcases\/kernel\/syscalls\/\(.*\)/\1/g' <<< "$current_test_directory")
         # if matches, this syscall folder will be skipped since no LTP test enabled in it
-        match_count=$(grep -c -w $folder_name "/ltp_folders_skipped.txt")
+        match_count=$(grep -c -w "$folder_name" "/ltp_folders_skipped.txt")
         if [[ $match_count -ge 1 ]]; then
 	    printf '%-70s' "Skipping $current_test_directory "
 	    printf '%-10s\n' "Skipped"

--- a/tests/ltp/buildenv.sh
+++ b/tests/ltp/buildenv.sh
@@ -5,7 +5,33 @@
 mode=$1
 test_directory=$2
 
+# All LTP test folders are under ltp/testcases/kernel/syscalls/
+# All enabled LTP tests are specified in ltp_disabled_tests.txt under tests/ltp/ltp-batch1 and tests/ltp/ltp-batch2
+# In this function we are creating /ltp_folders_skipped.txt which has folders that has no enabled LTP test
+function CreateNotEnabledLtpTestFoldersListFile()
+{
+    grep '#' "/tests/ltp/ltp-batch1/ltp_disabled_tests.txt" > "/enabled_ltp_tests.txt"
+    grep '#' "/tests/ltp/ltp-batch2/ltp_disabled_tests.txt" >> "/enabled_ltp_tests.txt"
 
+    # Get the unique syscall list that LTP test suite addresses
+    cur_folder=$(pwd)
+    cd "/ltp/testcases/kernel/syscalls"
+    ls -ld */  | sed 's/.* \(.*\)\//\1/g' | sort | uniq > "/ltp_folders.txt"
+    cd $cur_folder
+
+    rm -fr "/ltp_folders_enabled_tmp.txt"
+
+    # Get the unique syscall list that enabled in sgx-lkl
+    while IFS= read -r line
+    do
+       sed -e 's/#\/ltp\/testcases\/kernel\/syscalls\/\(.*\)\/.*/\1/g' <<< $line >>"/ltp_folders_enabled_tmp.txt"
+    done<"/enabled_ltp_tests.txt"
+
+    # Get the difference of above 2 lists to get the syscall list that zero LTP test enabled
+    # We will not build these folders since there will be no LTP test running against them
+    sort "/ltp_folders_enabled_tmp.txt" | uniq > "/ltp_folders_enabled.txt"
+    comm -3 "/ltp_folders.txt" "/ltp_folders_enabled.txt"  > "/ltp_folders_skipped.txt"
+}
 
 if [ -z "$test_directory" ]; then
     echo "Please provide ltp tests directory. Example: ltp.sh 'testcases/kernel/syscalls'"
@@ -50,52 +76,88 @@ if [[ "$mode" == "build" ]]; then
     echo "" > "$fail_file"
 
     IFS=$'\n'
-    file_list=( $(find "$test_directory" -name Makefile) )
+    file_list=( $(find "$test_directory" -maxdepth 2 -name Makefile) )
 
     makefile_counter=$(find "$test_directory" -name Makefile | wc -l)
-    counter=0
-    c_binaries_counter=0
-    c_binaries_failures=0
+    # syscall folder counts
+    counter_total=0
+    counter_skip=0
+    counter_fail=0
+    counter_success=0
+    # syscall test counts, a folder can have multiple tests (c files)
+    c_binaries_total=0
+    c_binaries_skip=0
+    c_binaries_fail=0
+    c_binaries_success=0
+
+    # This function will generate /ltp_folders_skipped.txt
+    # If a syscall folder exists in /ltp_folders_skipped.txt, it means there is no LTP test enabled
+    # and it will not be built, it will be skipped
+    CreateNotEnabledLtpTestFoldersListFile
 
     echo "Compling and generating binaries in $test_directory recursively"
     for file in "${file_list[@]}";
     do
         current_test_directory=$(dirname "$file")
-        counter=$((counter + 1))
-        printf '%-17s' "[Test #$counter/$makefile_counter]"
+        counter_total=$((counter_total + 1))
         cd "$current_test_directory"
-        c_file_list=( $(find . -name "*.c") )
-        printf '%-70s' "Building $current_test_directory "
-        if make 1> build.log 2>&1 ; then
+        printf '%-17s' "[Test #$counter_total/$makefile_counter]"
+
+        c_file_list=( $(find . -maxdepth 1 -name "*.c") )
+        c_file_count=${#c_file_list[@]}
+        c_binaries_total=$((c_binaries_total + c_file_count))
+
+        folder_name=$(sed -e 's/\/ltp\/testcases\/kernel\/syscalls\/\(.*\)/\1/g' <<< $current_test_directory)
+        # if matches, this syscall folder will be skipped since no LTP test enabled in it
+        match_count=$(grep -c -w $folder_name "/ltp_folders_skipped.txt")
+        if [[ $match_count -ge 1 ]]; then
+	    printf '%-70s' "Skipping $current_test_directory "
+	    printf '%-10s\n' "Skipped"
+	    counter_skip=$((counter_skip + 1))
+	    c_binaries_skip=$((c_binaries_skip + c_file_count))
+	    continue
+        else
+            printf '%-70s' "Building $current_test_directory "
+            if make 1> build.log 2>&1 ; then
+                counter_success=$((counter_success + 1))
                 printf '%-10s\n' "Success"
                 for c_file in "${c_file_list[@]}";
                 do
                         filename="${c_file%.*}"
                         if [ -f "$filename" ];then
-                            c_binaries_counter=$((c_binaries_counter + 1))
+                            c_binaries_success=$((c_binaries_success + 1))
                             echo "$current_test_directory/$filename" >> "$c_binaries_list_file_tmp"
                         else
+                            c_binaries_fail=$((c_binaries_fail + 1))
                             echo -e "\t \t WARNING !! $filename is not generated"
                         fi
                 done
-        else
+            else
                 printf '%-10s\n' "Failed"
                 echo "_________________________________________"
                 cat build.log
                 echo -e "_________________________________________\n"
-                c_binaries_failures=$((c_binaries_failures + 1))
-        fi
-        [ -f build.log ] && rm -f build.log
-        cd "$pwd"
+                counter_fail=$((counter_fail + 1))
+                c_binaries_fail=$((c_binaries_fail + c_file_count))
+            fi
+
+            [ -f build.log ] && rm -f build.log
+	fi
+	cd "$pwd"
     done
+
     sed 's/\.\///' -i "$c_binaries_list_file_tmp"
     cat "$c_binaries_list_file_tmp" | sort | uniq  > "$c_binaries_list_file"
     rm -f "$c_binaries_list_file_tmp"
-    echo "--------------------------------------------------------------"
-    echo "Generated $c_binaries_counter binaries in $test_directory"
-    echo $c_binaries_counter > .c_binaries_counter
-    echo "Failed to generate $c_binaries_failures binaries in $test_directory"
-    echo "--------------------------------------------------------------"
+    echo "---------------------------------------------------------------------------------"
+    echo "Syscalls/Folders => Total: $counter_total, Success: $counter_success, Fail: $counter_fail, Skip: $counter_skip"
+    echo "Tests/Binaries   => Total: $c_binaries_total, Success: $c_binaries_success, Fail: $c_binaries_fail, Skip: $c_binaries_skip"
+    echo ""
+    echo "Generated $c_binaries_success/$c_binaries_total binaries in $counter_success/$counter_total folders in $test_directory"
+    echo "Skipped $c_binaries_skip/$c_binaries_total binaries in $counter_skip/$counter_total folders since LTP tests not enabled"
+    echo "Failed to generate $c_binaries_fail/$c_binaries_total binaries in $counter_fail/$counter_total folders"
+    echo "---------------------------------------------------------------------------------"
+    echo $c_binaries_success > .c_binaries_counter
 fi
 
 if [[ "$mode" == "run" ]];then

--- a/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch1/ltp_disabled_tests.txt
@@ -49,7 +49,7 @@
 #/ltp/testcases/kernel/syscalls/chown/chown05
 #/ltp/testcases/kernel/syscalls/chroot/chroot01
 #/ltp/testcases/kernel/syscalls/chroot/chroot02
-#/ltp/testcases/kernel/syscalls/chroot/chroot03
+/ltp/testcases/kernel/syscalls/chroot/chroot03
 #/ltp/testcases/kernel/syscalls/chroot/chroot04
 #/ltp/testcases/kernel/syscalls/clock_adjtime/clock_adjtime01
 #/ltp/testcases/kernel/syscalls/clock_adjtime/clock_adjtime02
@@ -225,7 +225,7 @@
 /ltp/testcases/kernel/syscalls/fcntl/fcntl36
 #/ltp/testcases/kernel/syscalls/fdatasync/fdatasync01
 #/ltp/testcases/kernel/syscalls/fdatasync/fdatasync02
-#/ltp/testcases/kernel/syscalls/fdatasync/fdatasync03
+/ltp/testcases/kernel/syscalls/fdatasync/fdatasync03
 #/ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr01
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr02
 /ltp/testcases/kernel/syscalls/fgetxattr/fgetxattr03
@@ -257,7 +257,7 @@
 /ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr01
 /ltp/testcases/kernel/syscalls/fsetxattr/fsetxattr02
 #/ltp/testcases/kernel/syscalls/fstat/fstat02
-#/ltp/testcases/kernel/syscalls/fstat/fstat03
+/ltp/testcases/kernel/syscalls/fstat/fstat03
 #/ltp/testcases/kernel/syscalls/fstatat/fstatat01
 #/ltp/testcases/kernel/syscalls/fstatfs/fstatfs01
 #/ltp/testcases/kernel/syscalls/fstatfs/fstatfs02
@@ -948,7 +948,7 @@
 /ltp/testcases/kernel/syscalls/sync/sync02
 /ltp/testcases/kernel/syscalls/sync/sync03
 /ltp/testcases/kernel/syscalls/sync_file_range/sync_file_range01
-#/ltp/testcases/kernel/syscalls/sync_file_range/sync_file_range02
+/ltp/testcases/kernel/syscalls/sync_file_range/sync_file_range02
 /ltp/testcases/kernel/syscalls/syncfs/syncfs01
 /ltp/testcases/kernel/syscalls/syscall/syscall01
 /ltp/testcases/kernel/syscalls/sysconf/sysconf01

--- a/tests/ltp/run_ltp_test.sh
+++ b/tests/ltp/run_ltp_test.sh
@@ -84,8 +84,8 @@ for file in "${ltp_tests[@]}"; do
       exit 1
     fi
 
-    echo "SGXLKL_CMDLINE=mem=512m SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout ${SGX_LKL_RUN_CMD[*]} $file > $stdout_file 2>&1"
-    SGXLKL_CMDLINE="mem=512m" SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout "${SGX_LKL_RUN_CMD[@]}" "$file" > "$stdout_file" 2>&1
+    echo "SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout ${SGX_LKL_RUN_CMD[*]} $file > $stdout_file 2>&1"
+    SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 SGXLKL_TRACE_SIGNAL=1 timeout $timeout "${SGX_LKL_RUN_CMD[@]}" "$file" > "$stdout_file" 2>&1
     exit_code=$?
     if [[ $exit_code -eq  124 ]]; then
         echo "${SGX_LKL_RUN_CMD[*]} $file : TIMED OUT after $timeout secs"


### PR DESCRIPTION
Fixes #811

With this PR we will build only enabled LTP tests. Not enabled syscall folders are determined at run time by looking at enabled ltp tests files and ltp/testcases/kernel/syscalls folders. If a syscall folder doesn't have any enabled LTP test(s), this folder will be skipped during build and will be reported in skipped binaries and folders statistics.

Also improved the statistics reporting for syscall folders and test binaries.
In addition to Success, Failed status we have Skipped status as well for each syscall folder.

The current results stats is like that:
```
Syscalls/Folders => Total: 344, Success: 237, Fail: 1, Skip: 106
Tests/Binaries   => Total: 1046, Success: 774, Fail: 2, Skip: 270

Generated 774/1046 binaries in 237/344 folders in /ltp/testcases/kernel/syscalls
Skipped 270/1046 binaries in 106/344 folders since LTP tests not enabled
Failed to generate 2/1046 binaries in 1/344 folders
```
Here is the complete build log:
[ltp_build_log.txt](https://github.com/lsds/sgx-lkl/files/5101945/ltp_build_log.txt)

The only two failures are:
[Test #255/359]  Building /ltp/testcases/kernel/syscalls/ptrace                        Success
                 WARNING !! ./ptrace06 is not generated
                 WARNING !! ./simple_tracer is not generated
These two tests are not enabled and Makefile of ptrace returns 0 evenif these two binaries not generated. (There are enabled tests in this syscall folder, that's why it is built)