### PR TITLE
Update SGX-LKL to use LKL based on Linux v5.4.62

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ src/include/shared/sgxlkl_args.h
 src/main-oe/sgxlkl_u.c
 src/enclave/sgxlkl_t.c
 
+user/enter.o
+user/stubs.o
+
 *.tar.gz
 *.class
 *.log

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1510,8 +1510,12 @@ extern inline int lkl_access_ok(unsigned long addr, unsigned long size)
     /* Set default state as access_ok */
     int ret = 1;
 
-    /* size 0 access should not be treated as invalid access */
-    if (!size)
+    /**
+     * NULL access or size 0 should not be treated as an invalid kernel access.
+     * (We have Linux file system code that calls this with a NULL pointer and
+     * expects it to succeed.)
+     **/
+    if (!addr || !size)
         return ret;
 
     ret = oe_is_within_enclave((void*)addr, size);

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -190,7 +190,7 @@ static void lkl_mount_devtmpfs(const char* mntpoint)
 
 static void lkl_mount_shmtmpfs()
 {
-    int err = lkl_sys_mount("tmpfs", "/dev/shm", "tmpfs", 0, "rw,nodev");
+    int err = lkl_sys_mount("tmpfs", "/dev/shm", "tmpfs", 0, "mode=1777,rw");
     if (err != 0)
     {
         sgxlkl_fail("lkl_sys_mount(tmpfs) (/dev/shm): %s\n", lkl_strerror(err));
@@ -199,7 +199,7 @@ static void lkl_mount_shmtmpfs()
 
 static void lkl_mount_tmpfs()
 {
-    int err = lkl_sys_mount("tmpfs", "/tmp", "tmpfs", 0, "mode=0777");
+    int err = lkl_sys_mount("tmpfs", "/tmp", "tmpfs", 0, "mode=1777");
     if (err != 0)
     {
         sgxlkl_fail("lkl_sys_mount(tmpfs): %s\n", lkl_strerror(err));

--- a/src/lkl/setup.c
+++ b/src/lkl/setup.c
@@ -1510,12 +1510,8 @@ extern inline int lkl_access_ok(unsigned long addr, unsigned long size)
     /* Set default state as access_ok */
     int ret = 1;
 
-    /**
-     * NULL access or size 0 should not be treated as an invalid kernel access.
-     * (We have Linux file system code that calls this with a NULL pointer and
-     * expects it to succeed.)
-     **/
-    if (!addr || !size)
+    /* size 0 access should not be treated as invalid access */
+    if (!size)
         return ret;
 
     ret = oe_is_within_enclave((void*)addr, size);

--- a/src/sched/lthread.c
+++ b/src/sched/lthread.c
@@ -1010,8 +1010,8 @@ static void lthread_state_to_string(
     STRINGIFY_LT_STATE(EXPIRED)
     STRINGIFY_LT_STATE(DETACH)
     STRINGIFY_LT_STATE(PINNED)
-    STRINGIFY_LT_STATE(TERMINATE)
     STRINGIFY_LT_STATE(APP_MAIN)
+    STRINGIFY_LT_STATE(TERMINATE)
 
     lt_state_str[offset - 1] = '\0';
 }
@@ -1023,7 +1023,6 @@ void lthread_dump_all_threads(bool is_lthread)
     sgxlkl_info("Stack traces for all lthreads:\n");
 
     struct lthread* this_lthread = NULL;
-    char lt_state_str[1024] = "";
 
     // Is this called from an lthread?
     if (is_lthread)
@@ -1040,6 +1039,7 @@ void lthread_dump_all_threads(bool is_lthread)
         {
             int tid = lt->tid;
             char* funcname = lt->attr.funcname;
+            char lt_state_str[1024] = "";
 
             lthread_state_to_string(lt, lt_state_str, 1024);
 

--- a/third_party/Makefile
+++ b/third_party/Makefile
@@ -27,6 +27,7 @@ ${E2FSPROGS}:
 ${WIREGUARD}:
 	wget --retry-connrefused -O "${MAKE_ROOT}/wireguard.tar.gz" 'https://download.wireguard.com/monolithic-historical/WireGuard-0.0.20191219.tar.xz'
 	mkdir -p $@ && tar -C $@ --strip 1 -xf ${MAKE_ROOT}/wireguard.tar.gz
+	patch -p0 < wireguard-5.4.62.patch
 	rm ${MAKE_ROOT}/wireguard.tar.gz
 
 ${CURL}:

--- a/third_party/wireguard-5.4.62.patch
+++ b/third_party/wireguard-5.4.62.patch
@@ -1,0 +1,12 @@
+--- wireguard/src/queueing.h-orig	2020-09-04 22:06:22.035017800 +0000
++++ wireguard/src/queueing.h	2020-09-04 22:06:42.047326678 +0000
+@@ -97,8 +97,8 @@
+ 	skb->dev = NULL;
+ #ifdef CONFIG_NET_SCHED
+ 	skb->tc_index = 0;
+-	skb_reset_tc(skb);
+ #endif
++	skb_reset_redirect(skb);
+ 	skb->hdr_len = skb_headroom(skb);
+ 	skb_reset_mac_header(skb);
+ 	skb_reset_network_header(skb);


### PR DESCRIPTION
This PR updates SGX-LKL to use LKL based on the Linux longterm kernel release v5.4. It uses the latest released revision, which is 5.4.62. The v5.4 longterm release will be maintained until December 2025.

Fixes #821 