### PR TITLE
CI: Add scripts to run samples automatically

### DIFF
--- a/.azure-pipelines/scripts/install_prerequisites.sh
+++ b/.azure-pipelines/scripts/install_prerequisites.sh
@@ -9,6 +9,7 @@ sudo apt-get install -y \
     autopoint pkgconf autoconf libtool libcurl4-openssl-dev libprotobuf-dev libprotobuf-c-dev protobuf-compiler protobuf-c-compiler libssl-dev \
     ninja-build ansible "linux-headers-$(uname -r)" \
     python3 python3-setuptools python3-pip unzip dkms debhelper apt-utils pax-utils openjdk-8-jdk-headless \
+    redis-tools \
     expect \
     gdb \
     shellcheck clang-format

--- a/.azure-pipelines/scripts/run_sample.sh
+++ b/.azure-pipelines/scripts/run_sample.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+if [ -z "$SGXLKL_ROOT" ]; then
+    echo "ERROR: 'SGXLKL_ROOT' is undefined. Please export SGXLKL_ROOT=<SGX-LKL-OE> source code repository"
+    exit 1
+fi
+if [ -z "$SGXLKL_BUILD_MODE" ]; then
+    echo "ERROR: 'SGXLKL_BUILD_MODE' is undefined. Please export SGXLKL_BUILD_MODE=<mode>"
+    exit 1
+fi
+
+#shellcheck source=.azure-pipelines/scripts/junit_utils.sh
+. "$SGXLKL_ROOT/.azure-pipelines/scripts/junit_utils.sh"
+#shellcheck source=.azure-pipelines/scripts/test_utils.sh
+. "$SGXLKL_ROOT/.azure-pipelines/scripts/test_utils.sh"
+
+# Initialize the variables and test case [mandatory].
+sample_mode=$1 # clean, init or run
+run_mode=$2 # run-hw or run-sw
+
+if [[ "$sample_mode" == "clean" ]]; then
+    ./test.sh clean
+    exit $?
+fi
+
+samples_dir=$SGXLKL_ROOT/samples
+sample_name="$(realpath --relative-to="$samples_dir" "$(pwd)")"
+sample_name="${sample_name//\//-}"
+sample_name+="-($SGXLKL_BUILD_MODE)-($run_mode)-($SGXLKL_ETHREADS-ethreads)"
+sample_class=$(realpath --relative-to="$samples_dir" "$(pwd)/..")
+test_suite="sgx-lkl-oe"
+
+if [[ -z $sample_name || -z $sample_class || -z $sample_mode ]]; then
+    echo -e "\n ERROR: sample_name sample_class or sample_mode not passed \n"
+    exit 1
+fi
+
+if [[ "$sample_mode" == "init" ]]; then
+    InitializeTestCase "$sample_name" "$sample_class" "$test_suite" "$run_mode"
+fi
+
+# Get the timeout from the test module
+DEFAULT_TIMEOUT=300
+if ! timeout=$(./test.sh gettimeout 2> /dev/null); then
+    timeout=$DEFAULT_TIMEOUT
+fi
+echo "Execution timeout: $timeout"
+
+case "$run_mode" in
+    "run-hw")
+       echo "Will run samples for run-hw"
+       ;;
+    "run-sw")
+       echo "Will run samples for run-sw"
+       ;;
+    *)
+       echo "Invalid run_mode parameter: $run_mode. Valid options: run-hw/run-sw"
+       exit 1;
+       ;;
+esac
+
+if [[ $sample_mode == "init" ]]; then
+    timeout --kill-after=$((timeout + 60)) $timeout ./test.sh init
+    script_exit=$?
+elif [[ $sample_mode == "run" ]]; then
+    timeout --kill-after=$((timeout + 60)) $timeout ./test.sh run "$run_mode"
+    script_exit=$?
+else
+    echo "Invalid sample_mode parameter: $sample_mode. Valid options: clean/init/run/gettimeout"
+    exit 1
+fi
+
+if [[ "$script_exit" == "124" ]]; then
+    echo "$run_mode: TIMED OUT after $timeout secs"
+elif [[ "$script_exit" != "0" ]]; then
+    echo "$run_mode: FAILED WITH EXIT CODE: $script_exit"
+fi
+
+if [[ $sample_mode == "init" ]]; then
+    echo "Sample initialization completed with EXIT CODE $script_exit"
+    return $script_exit
+fi
+
+echo "Sample run completed with EXIT CODE $script_exit"
+
+exit $script_exit

--- a/.azure-pipelines/scripts/run_test.sh
+++ b/.azure-pipelines/scripts/run_test.sh
@@ -15,7 +15,7 @@ fi
 . "$SGXLKL_ROOT/.azure-pipelines/scripts/test_utils.sh"
 
 # Initialize the variables and test case [mandatory].
-test_mode=$1 # init or run
+test_mode=$1 # clean, init or run
 run_mode=$2 # run-hw or run-sw
 
 # make clean

--- a/.azure-pipelines/scripts/test_runner.sh
+++ b/.azure-pipelines/scripts/test_runner.sh
@@ -181,6 +181,7 @@ disabled_tests_file="$SGXLKL_ROOT/.azure-pipelines/other/disabled_tests.txt"
 nightly_tests_file="$SGXLKL_ROOT/.azure-pipelines/other/nightly_run_only_tests.txt"
 # test which needs not to be executed as part of CI e.g (test_name1\|test_name2...)
 test_exception_list="ltp"
+sample_exception_list="openmp\|nodejs"
 
 failure_identifiers_file="$SGXLKL_ROOT/.azure-pipelines/other/failure_identifiers.txt"
 IFS=$'\n'
@@ -191,6 +192,12 @@ if [[ $1 == "ltp1" ]]; then
 elif [[ $1 == "ltp2" ]]; then
     file_list=("tests/ltp/ltp-batch2/Makefile")
     test_group_name="ltp-batch2"
+elif [[ $1 == "samples" ]]; then
+    test_folder_name="samples"
+    test_folder_identifier="test.sh"
+    test_runner_script="$SGXLKL_ROOT/.azure-pipelines/scripts/run_sample.sh"
+    file_list=( $(find $test_folder_name -name $test_folder_identifier | grep -v "$sample_exception_list") )
+    test_group_name="samples"
 elif [[ $1 == "core" ]]; then
     file_list=( $(find $test_folder_name -name $test_folder_identifier | grep -v "$test_exception_list") )
     test_group_name="core"

--- a/.azure-pipelines/template.yml
+++ b/.azure-pipelines/template.yml
@@ -22,6 +22,7 @@ parameters:
   - core
   - ltp1
   - ltp2
+  - samples
 - name: 'ethreads'
   type: object
   default:

--- a/samples/basic/attack/plain-docker.exp
+++ b/samples/basic/attack/plain-docker.exp
@@ -1,0 +1,13 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+
+spawn docker run --rm attackme /read_secret
+set dockerID $spawn_id
+expect -i $dockerID "Ready to be attacked..."
+
+spawn ./read_memory.sh read_secret Secret42!
+set readID $spawn_id
+expect -i $readID "Match found."
+
+send -i $dockerID -- "\r"

--- a/samples/basic/attack/read_memory.sh
+++ b/samples/basic/attack/read_memory.sh
@@ -21,7 +21,7 @@ sudo chown "$(id -u -n):$(id -g -n)" "$mem_file"
 
 echo "Searching memory for string \"${search_string}\" in \"${mem_file}\"..."
 
-if (strings "${mem_file}" | grep -i "${search_string}"); then
+if grep -Fxq "${search_string}" "${mem_file}"; then
         echo Match found.
 else
         echo No match found.

--- a/samples/basic/attack/sgx.exp
+++ b/samples/basic/attack/sgx.exp
@@ -1,0 +1,21 @@
+#!/usr/bin/expect -f
+
+set SGXLKL_STARTER "$env(SGXLKL_STARTER)"
+set SGXLKL_DISK_TOOL "$env(SGXLKL_DISK_TOOL)"
+
+set timeout -1
+
+spawn "$SGXLKL_DISK_TOOL" create --force --docker=attackme --size 5M --encrypt --key-file rootfs.img
+expect "Succesfully created rootfs.img"
+expect eof
+
+set env(SGXLKL_HD_KEY) rootfs.img.key
+spawn "$SGXLKL_STARTER" --hw-debug rootfs.img /read_secret
+set oeID $spawn_id
+expect -i $oeID "Ready to be attacked..."
+
+spawn ./read_memory.sh sgx-lkl-run-oe Secret42!
+set readID $spawn_id
+expect -i $readID "No match found."
+
+send -i $oeID -- "\r"

--- a/samples/basic/attack/test.sh
+++ b/samples/basic/attack/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# shellcheck source=/dev/null
+source "../../common.sh"
+
+test_mode=$1
+run_mode=$2
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    rm -f rootfs.img rootfs.img.docker rootfs.img.key
+elif [[ "$test_mode" == "init" ]]; then
+    rm -f mem.dump.*
+    docker build -t attackme .
+elif [[ "$test_mode" == "run" ]]; then
+    if [[ "$run_mode" == "run-sw" ]]; then
+        ./plain-docker.exp
+    elif [[ "$run_mode" == "run-hw" ]]; then
+        ./sgx.exp
+    fi
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # 20 minutes
+    echo 1200
+fi
+
+exit 0

--- a/samples/basic/helloworld/Dockerfile
+++ b/samples/basic/helloworld/Dockerfile
@@ -1,25 +1,11 @@
-FROM alpine:3.8
+FROM alpine:3.6 AS builder
 
-ARG UID
-ARG GID
+RUN apk add --no-cache gcc musl-dev
 
-USER root
+ADD *.c /
+RUN gcc -g -o helloworld helloworld.c
 
-# Build packages: build-base gcc wget git curl
+FROM alpine:3.6
 
-RUN apk add --no-cache bash shadow sudo && \
-    addgroup -S alpine; \
-    adduser -S -G alpine -s /bin/bash user; \
-    echo "user ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/user && \
-    chmod 0440 /etc/sudoers.d/user
-
-WORKDIR /app
-RUN chown user:alpine /app
-USER user
-
-#ENV PS1="\[\033[31;40;1m\][\u@\h]\[\033[32;40;1m\] \W\[\033[33;40;1m\]>\[\033[0m\]"
-
-COPY --chown=user:alpine app/ .
-
-# Start from a Bash prompt
-CMD ["/bin/bash"]
+COPY --from=builder helloworld .
+ADD app /app

--- a/samples/basic/helloworld/Makefile
+++ b/samples/basic/helloworld/Makefile
@@ -1,57 +1,41 @@
+include ../../../tests/common.mk
 
-APP_ROOT=app
-PROG=${APP_ROOT}/helloworld
-PROG_NONPIE=${APP_ROOT}/helloworld-nonpie
-PROG_C=helloworld.c
+PROG=helloworld
+PROG_SRC=$(PROG).c
+IMAGE_SIZE=5M
 
-DISK_IMAGE=sgxlkl-helloworld.img
-IMAGE_SIZE=100M
+EXECUTION_TIMEOUT=60
 
-SGXLKL_ROOT=../../..
+SGXLKL_ENV=SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1
+SGXLKL_HW_PARAMS=--hw-debug
+SGXLKL_SW_PARAMS=--sw-debug
 
-MUSL_CC=${SGXLKL_ROOT}/build/host-musl/bin/musl-gcc
-
-SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
-
-ifeq ($(SGXLKL_VERBOSE),)
-SGXLKL_ENV=\
-   SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=0 SGXLKL_TRACE_SIGNAL=0\
-   SGXLKL_TRACE_HOST_SYSCALL=0 SGXLKL_TRACE_LKL_SYSCALL=0 SGXLKL_TRACE_MMAP=0
-else
-SGXLKL_ENV=
-endif
-
-SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
-SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
+SGXLKL_ROOTFS=sgx-lkl-rootfs.img
 
 .DELETE_ON_ERROR:
 .PHONY: all clean
 
-all: $(DISK_IMAGE)
+$(SGXLKL_ROOTFS): $(PROG_SRC)
+	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --docker=./Dockerfile ${SGXLKL_ROOTFS}
+
+gettimeout:
+	@echo ${EXECUTION_TIMEOUT}
+
+run: run-hw run-sw
+
+run-gdb: run-hw-gdb
+
+run-hw: ${SGXLKL_ROOTFS}
+	$(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) --enclave-config enclave_config.json $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw: ${SGXLKL_ROOTFS}
+	$(SGXLKL_ENV) $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) --enclave-config enclave_config.json $(SGXLKL_ROOTFS) $(PROG)
+
+run-hw-gdb: ${SGXLKL_ROOTFS}
+	$(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_HW_PARAMS) --enclave-config enclave_config.json $(SGXLKL_ROOTFS) $(PROG)
+
+run-sw-gdb: ${SGXLKL_ROOTFS}
+	$(SGXLKL_ENV) $(SGXLKL_GDB) --args $(SGXLKL_STARTER) $(SGXLKL_SW_PARAMS) --enclave-config enclave_config.json $(SGXLKL_ROOTFS) $(PROG)
 
 clean:
-	rm -f $(DISK_IMAGE) $(PROG) $(PROG_NONPIE)
-
-$(PROG): $(PROG_C)
-	${MUSL_CC} -fPIE -pie -o $@ $(PROG_C)
-
-# non-PIE executable are currently unsupported by SGX-LKL-OE
-$(PROG_NONPIE): $(PROG_C)
-	${MUSL_CC} -fno-pie -no-pie -o $@ $(PROG_C)
-
-$(DISK_IMAGE): $(PROG) $(PROG_NONPIE)
-	${SGXLKL_DISK_TOOL} create --size=${IMAGE_SIZE} --copy=./${APP_ROOT}/ ${DISK_IMAGE}
-
-run: run-hw
-
-run-hw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug --enclave-config enclave_config.json $(DISK_IMAGE)
-
-run-hw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --hw-debug --enclave-config enclave_config.json $(DISK_IMAGE)
-
-run-sw: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug --enclave-config enclave_config.json $(DISK_IMAGE)
-
-run-sw-gdb: $(DISK_IMAGE)
-	${SGXLKL_ENV} ${SGXLKL_GDB} --args ${SGXLKL_STARTER} --sw-debug --enclave-config enclave_config.json $(DISK_IMAGE)
+	rm -f $(SGXLKL_ROOTFS) $(PROG)

--- a/samples/basic/helloworld/helloworld.c
+++ b/samples/basic/helloworld/helloworld.c
@@ -13,6 +13,7 @@ int main(int argc, char** argv)
     {
         fprintf(
             stderr, "Could not open file %s: %s\n", HW_FILE, strerror(errno));
+        fprintf(stderr, "TEST_FAILED");
         exit(1);
     }
 
@@ -28,8 +29,8 @@ int main(int argc, char** argv)
             "Could not read first line of file %s: %s\n",
             HW_FILE,
             strerror(errno));
+        fprintf(stderr, "TEST_FAILED");
         exit(1);
     }
-
     return 0;
 }

--- a/samples/basic/helloworld/test.sh
+++ b/samples/basic/helloworld/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+test_mode=$1
+run_mode=$2
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    make clean
+elif [[ "$test_mode" == "init" ]]; then
+    make
+elif [[ "$test_mode" == "run" ]]; then
+    make "$run_mode"
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # Default
+    exit 1
+fi
+
+exit 0

--- a/samples/common.sh
+++ b/samples/common.sh
@@ -1,0 +1,20 @@
+samples_dir=$(dirname $(realpath "$BASH_SOURCE"))
+SGXLKL_ROOT=$(realpath "${samples_dir}/..")
+
+if [[ -z "${SGXLKL_PREFIX}" ]]; then
+	export SGXLKL_STARTER=${SGXLKL_ROOT}/build/sgx-lkl-run-oe
+	export SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
+	export SGXLKL_DOCKER_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-docker
+	export SGXLKL_CFG_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-cfg
+	export SGXLKL_SETUP_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-setup
+	export SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
+	export SGXLKL_JAVA_RUN=${SGXLKL_ROOT}/tools/sgx-lkl-java
+else
+	export SGXLKL_STARTER=${SGXLKL_PREFIX}/bin/sgx-lkl-run-oe
+	export SGXLKL_DISK_TOOL=${SGXLKL_PREFIX}/bin/sgx-lkl-disk
+	export SGXLKL_DOCKER_TOOL=${SGXLKL_PREFIX}/bin/sgx-lkl-docker
+	export SGXLKL_CFG_TOOL=${SGXLKL_PREFIX}/bin/sgx-lkl-cfg
+	export SGXLKL_SETUP_TOOL=${SGXLKL_PREFIX}/bin/sgx-lkl-setup
+	export SGXLKL_GDB=${SGXLKL_PREFIX}/bin/sgx-lkl-gdb
+	export SGXLKL_JAVA_RUN=${SGXLKL_PREFIX}/bin/sgx-lkl-java
+fi

--- a/samples/containers/alpine/test.sh
+++ b/samples/containers/alpine/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+test_mode=$1
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    make clean
+elif [[ "$test_mode" == "init" ]]; then
+    echo "Nothing to do"
+elif [[ "$test_mode" == "run" ]]; then
+    make
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # Default
+    exit 1
+fi
+
+exit 0

--- a/samples/containers/encrypted/Makefile
+++ b/samples/containers/encrypted/Makefile
@@ -1,5 +1,4 @@
-
-SGXLKL_ROOT=../../..
+include ../../../tests/common.mk
 
 CC_APP=/usr/bin/python3
 CC_APP_CMDLINE=${CC_APP} -c 'print("Hello SGX World from Encrypted Confidential Container!")'
@@ -38,10 +37,6 @@ ifeq ($(SGXLKL_VERBOSE),)
 	SGXLKL_ENV_INTEGRITY+=${VERBOSE_OPTS}
 	SGXLKL_ENV_APP_CONFIG+=${VERBOSE_OPTS}
 endif
-
-SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
-SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
-SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
 .DELETE_ON_ERROR:
 .PHONY: all clean run run-hw-verity run-sw-verity run-hw-integrity run-sw-integrity

--- a/samples/containers/encrypted/test.sh
+++ b/samples/containers/encrypted/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+test_mode=$1
+run_mode=$2
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    make clean
+elif [[ "$test_mode" == "init" ]]; then
+    make
+elif [[ "$test_mode" == "run" ]]; then
+    make "$run_mode"-verity
+    # TODO: This doesn't work
+    #make "$run_mode"-integrity
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # Default
+    exit 1
+fi
+
+exit 0

--- a/samples/containers/redis/Makefile
+++ b/samples/containers/redis/Makefile
@@ -1,14 +1,11 @@
+include ../../../tests/common.mk
 
 PROG=/usr/bin/redis-server
 
 DISK_IMAGE=sgxlkl-redis.img
 IMAGE_SIZE=128M
 
-SGXLKL_ROOT=../../..
-
 ENCLAVE_CMD=${PROG} --bind 10.0.1.1
-
-SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 
 SGXLKL_ENV=\
 SGXLKL_TAP=sgxlkl_tap0
@@ -18,9 +15,6 @@ SGXLKL_ENV+=\
    SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=0 SGXLKL_TRACE_SIGNAL=0\
    SGXLKL_TRACE_HOST_SYSCALL=0 SGXLKL_TRACE_LKL_SYSCALL=0 SGXLKL_TRACE_MMAP=0
 endif
-
-SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
-SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 
 .DELETE_ON_ERROR:
 .PHONY: all clean

--- a/samples/containers/redis/README.md
+++ b/samples/containers/redis/README.md
@@ -1,15 +1,18 @@
 Running Redis with SGX-LKL-OE
 =============================
 
-1. Ensure that you have set up netoworking and TLS support by running `tools/sgx-lkl-setup`.
+1. Make sure that you have installed ``redis-cli``. In Ubuntu, the package that
+   contains it is called ``redis-tools``.
 
-2. Build the Redis file sytem image:
+2. Ensure that you have set up netoworking and TLS support by running `tools/sgx-lkl-setup`.
+
+3. Build the Redis file sytem image:
 
 ```
 make
 ```
 
-3. Run the Redis service with:
+4. Run the Redis service with:
 
 ```
 make run-hw
@@ -21,7 +24,7 @@ or
 make run-sw
 ```
 
-4. Execute client requests against this instance:
+5. Execute client requests against this instance:
 
 ```
 ./run-redis-client.sh

--- a/samples/containers/redis/run-hw.exp
+++ b/samples/containers/redis/run-hw.exp
@@ -1,0 +1,15 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+
+spawn make run-hw
+set serverID $spawn_id
+expect -i $serverID "Ready to accept connections"
+
+spawn ./run-redis-client.sh
+set clientID $spawn_id
+expect -i $clientID "Test succeeded"
+
+send -i $serverID -- ""
+
+exit 0

--- a/samples/containers/redis/run-redis-client.sh
+++ b/samples/containers/redis/run-redis-client.sh
@@ -2,14 +2,17 @@
 
 # printf '\033]2;%s\033\\' 'Redis Client'
 
+set -e
+
 COUNTER=0
 
-while :
+while [ $COUNTER -lt 10 ]
 do
   echo $ redis-cli -h 10.0.1.1 -p 6379 set samplekey value${COUNTER}
   redis-cli -h 10.0.1.1 -p 6379 set samplekey value${COUNTER}
   echo $ redis-cli -h 10.0.1.1 -p 6379 get samplekey
   redis-cli -h 10.0.1.1 -p 6379 get samplekey
-  sleep 1
   let COUNTER+=1
 done
+
+echo "Sample succeeded"

--- a/samples/containers/redis/run-sw.exp
+++ b/samples/containers/redis/run-sw.exp
@@ -1,0 +1,15 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+
+spawn make run-sw
+set serverID $spawn_id
+expect -i $serverID "Ready to accept connections"
+
+spawn ./run-redis-client.sh
+set clientID $spawn_id
+expect -i $clientID "Test succeeded"
+
+send -i $serverID -- ""
+
+exit 0

--- a/samples/containers/redis/test.sh
+++ b/samples/containers/redis/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# shellcheck source=/dev/null
+source "../../common.sh"
+
+test_mode=$1
+run_mode=$2
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    make clean
+elif [[ "$test_mode" == "init" ]]; then
+    "${SGXLKL_SETUP_TOOL}"
+    make
+elif [[ "$test_mode" == "run" ]]; then
+    if [[ "$run_mode" == "run-hw" ]]; then
+        ./run-hw.exp
+    elif [[ "$run_mode" == "run-sw" ]]; then
+        ./run-sw.exp
+    fi
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # Default
+    exit 1
+fi
+
+exit 0

--- a/samples/languages/dotnet/HelloWorld/runtimeconfig.template.json
+++ b/samples/languages/dotnet/HelloWorld/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "configProperties": {
+        "System.Globalization.Invariant": true
+    }
+}

--- a/samples/languages/dotnet/Makefile
+++ b/samples/languages/dotnet/Makefile
@@ -1,14 +1,11 @@
+include ../../../tests/common.mk
 
 PROG=/app/HelloWorld.dll
 
 DISK_IMAGE=sgxlkl-dotnet.img
 IMAGE_SIZE=250M
 
-SGXLKL_ROOT=../../..
-
 ENCLAVE_CMD=/usr/bin/dotnet ${PROG}
-
-SGXLKL_STARTER=$(SGXLKL_ROOT)/build/sgx-lkl-run-oe
 
 ifeq ($(SGXLKL_VERBOSE),)
 SGXLKL_ENV=\
@@ -17,8 +14,6 @@ SGXLKL_ENV=\
 else
 SGXLKL_ENV=
 endif
-
-SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 
 .DELETE_ON_ERROR:
 .PHONY: all clean

--- a/samples/languages/dotnet/README.md
+++ b/samples/languages/dotnet/README.md
@@ -1,6 +1,23 @@
 Running a DotNet application using SGX-LKL-OE
 =============================================
 
+It is possible to run this sample by typing:
+
+```
+make run-hw
+```
+
+or
+
+```
+make run-sw
+```
+
+Manual steps
+------------
+
+Alternatively, it is possible to run the sample by doing the following steps:
+
 1. Build the Docker container that contains the DotNet application:
 
 ```

--- a/samples/languages/dotnet/test.sh
+++ b/samples/languages/dotnet/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+test_mode=$1
+run_mode=$2
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    make clean
+elif [[ "$test_mode" == "init" ]]; then
+    echo "Nothing to do"
+elif [[ "$test_mode" == "run" ]]; then
+    make "$run_mode"
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # Default
+    exit 1
+fi
+
+exit 0

--- a/samples/languages/java/Makefile
+++ b/samples/languages/java/Makefile
@@ -18,6 +18,8 @@ else
 SGXLKL_ENV=
 endif
 
+SGXLKL_ENV += SGXLKL_ETHREADS=4
+
 .DELETE_ON_ERROR:
 .PHONY: all run run-hw run-sw clean
 

--- a/samples/languages/java/Makefile
+++ b/samples/languages/java/Makefile
@@ -1,3 +1,4 @@
+include ../../../tests/common.mk
 
 APP_ROOT=app
 PROG_SRC=${APP_ROOT}/HelloWorld.java
@@ -5,11 +6,6 @@ PROG=${APP_ROOT}/HelloWorld.class
 
 DISK_IMAGE=sgxlkl-java-fs.img
 IMAGE_SIZE=400M
-
-SGXLKL_ROOT=../../..
-
-SGXLKL_JAVA_RUN=${SGXLKL_ROOT}/tools/sgx-lkl-java
-SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 
 ifeq ($(SGXLKL_VERBOSE),)
 SGXLKL_ENV=\

--- a/samples/languages/java/README.md
+++ b/samples/languages/java/README.md
@@ -1,13 +1,19 @@
 SGX-LKL-OE Java Sample Application
 ==================================
 
-1. First build the OpenJDK file system image:
+1. Install OpenJRE and OpenJDK. In Ubuntu you can do:
+
+```
+sudo apt install default-jre default-jdk
+```
+
+2. First build the OpenJDK file system image:
 
 ```
 make
 ```
 
-2. Run the Java HelloWorld application using:
+3. Run the Java HelloWorld application using:
 
 ```
 make run-hw

--- a/samples/languages/java/test.sh
+++ b/samples/languages/java/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+test_mode=$1
+run_mode=$2
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    make clean
+elif [[ "$test_mode" == "init" ]]; then
+    make
+elif [[ "$test_mode" == "run" ]]; then
+    make "$run_mode"
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # Default
+    exit 1
+fi
+
+exit 0

--- a/samples/languages/python/test.sh
+++ b/samples/languages/python/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# shellcheck source=/dev/null
+source "../../common.sh"
+
+DISK_IMAGE=pythonapp.img
+
+test_mode=$1
+run_mode=$2
+
+set -e
+
+if [[ "$test_mode" == "clean" ]]; then
+    rm "$DISK_IMAGE"
+elif [[ "$test_mode" == "init" ]]; then
+    docker build -t pythonapp .
+    docker run --rm pythonapp
+elif [[ "$test_mode" == "run" ]]; then
+    "${SGXLKL_DISK_TOOL}" create --force --docker=pythonapp \
+            --size=300M "${DISK_IMAGE}"
+    "${SGXLKL_CFG_TOOL}" create --disk "${DISK_IMAGE}"
+    if [[ "$run_mode" == "run-hw" ]]; then
+        "${SGXLKL_STARTER}" --host-config=host-config.json \
+                --enclave-config=enclave-config.json --hw-debug
+    elif [[ "$run_mode" == "run-sw" ]]; then
+        "${SGXLKL_STARTER}" --host-config=host-config.json \
+                --enclave-config=enclave-config.json --sw-debug
+    fi
+elif [[ "$test_mode" == "gettimeout" ]]; then
+    # Default
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
The scripts are a mix of bash and a bit of GNU expect for flexibility, as each sample needs to be tested in slightly different ways.

Each sample must have a test.sh script in its folder so that the CI detects it and runs it. They are executed by run_sample.sh script, created using run_test.sh as an example.

This PR adds several samples to the CI, but not all of them:

- The ml folder samples, for example, take far too long to be part of a regular CI run, and need caching of docker images, which is a task on its own.

- The openmp and nodejs samples seem to be broken.

This PR also fixes the following samples:

- ``languages/dotnet``: The following error happened when trying to run it:

```
FailFast:
Couldn't find a valid ICU package installed on the system. Set the configuration flag
System.Globalization.Invariant to true if you want to run with no globalization support.
```

By adding a new file with this configuration flag set to true, the sample works again. https://github.com/dotnet/core/issues/2186#issuecomment-472629489

- ``basic/helloworld``: This PR also simplifies the sample so that it matches the helloworld test.

- ``languages/java``:  When the number of ethreads is 1 the java app hangs after printing the message. With a higher number of ethreads it exits as expected.

This is a partial fix for https://github.com/lsds/sgx-lkl/issues/231, and is intended to make https://github.com/lsds/sgx-lkl/issues/332 easier by adding this new bash/expect framework.