### PR TITLE
Enable tests rt_sigaction02, rt_sigqueuinfo01, sigwaitinfo01

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -898,7 +898,7 @@
 #/ltp/testcases/kernel/syscalls/sigprocmask/sigprocmask01
 /ltp/testcases/kernel/syscalls/sigrelse/sigrelse01
 /ltp/testcases/kernel/syscalls/sigsuspend/sigsuspend01
-ltp/testcases/kernel/syscalls/sigwaitinfo/sigwaitinfo01
+/ltp/testcases/kernel/syscalls/sigwaitinfo/sigwaitinfo01
 #/ltp/testcases/kernel/syscalls/socket/socket01
 #/ltp/testcases/kernel/syscalls/socket/socket02
 /ltp/testcases/kernel/syscalls/socketcall/socketcall01

--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -751,11 +751,11 @@
 #/ltp/testcases/kernel/syscalls/rmdir/rmdir02
 #/ltp/testcases/kernel/syscalls/rmdir/rmdir03
 #/ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction01
-/ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction02
+#/ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction02
 #/ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03
 #/ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 #/ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02
-/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
+#/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
 /ltp/testcases/kernel/syscalls/rt_sigsuspend/rt_sigsuspend01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
 #/ltp/testcases/kernel/syscalls/sbrk/sbrk02
@@ -898,7 +898,7 @@
 #/ltp/testcases/kernel/syscalls/sigprocmask/sigprocmask01
 /ltp/testcases/kernel/syscalls/sigrelse/sigrelse01
 /ltp/testcases/kernel/syscalls/sigsuspend/sigsuspend01
-/ltp/testcases/kernel/syscalls/sigwaitinfo/sigwaitinfo01
+ltp/testcases/kernel/syscalls/sigwaitinfo/sigwaitinfo01
 #/ltp/testcases/kernel/syscalls/socket/socket01
 #/ltp/testcases/kernel/syscalls/socket/socket02
 /ltp/testcases/kernel/syscalls/socketcall/socketcall01


### PR DESCRIPTION
Enable tests rt_sigaction02, rt_sigqueuinfo01, sigwaitinfo01 following signaling improvements (see issue 709).