### PR TITLE
samples: Fix openvino and pytorch samples

### DIFF
--- a/samples/ml/openvino/Makefile
+++ b/samples/ml/openvino/Makefile
@@ -19,6 +19,8 @@ else
 SGXLKL_ENV=
 endif
 
+SGXLKL_ENV += SGXLKL_ETHREADS=4
+
 SGXLKL_DISK_TOOL=${SGXLKL_ROOT}/tools/sgx-lkl-disk
 SGXLKL_GDB=${SGXLKL_ROOT}/tools/gdb/sgx-lkl-gdb
 

--- a/samples/ml/pytorch/Makefile
+++ b/samples/ml/pytorch/Makefile
@@ -15,6 +15,8 @@ else
 SGXLKL_ENV=
 endif
 
+SGXLKL_ENV += SGXLKL_ETHREADS=4
+
 APP=/usr/bin/python3
 APP_PARAMS=/app/sample.py
 


### PR DESCRIPTION
The samples weren't working because the number of ethreads was 1. Increasing it fixes the samples.

They will need to be added to the CI so that they don't break in the future.

This fixes part of https://github.com/lsds/sgx-lkl/issues/831