### PR TITLE
Return error code when dev_register() fails

### DIFF
--- a/src/lkl/virtio_netdev.c
+++ b/src/lkl/virtio_netdev.c
@@ -72,9 +72,11 @@ int lkl_virtio_netdev_add(struct virtio_dev* netdev)
         return -1;
 
     ret = dev_register(netdev);
-
     if (ret < 0)
-        sgxlkl_info("Failed to register netdev \n");
+    {
+        sgxlkl_fail("Failed to register netdev\n");
+        return -1;
+    }
 
     return registered_dev_idx++;
 }


### PR DESCRIPTION
Instead of just printing an error message, return an error code so that
the caller of lkl_virtio_netdev_add() knows that it has failed.

Along with PR #753, this fixes #370.