### PR TITLE
Add MySQL sample application running large OLTP benchmark

### DIFF
--- a/samples/databases/mysql/Dockerfile
+++ b/samples/databases/mysql/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.7
+
+RUN apk add --no-cache \
+    mariadb mariadb-client
+
+RUN mysql_install_db --user=root --basedir=/usr --datadir=/var/lib/mysql
+
+COPY my.cnf /etc/mysql/my.cnf
+
+ENTRYPOINT ["mysqld"]

--- a/samples/databases/mysql/Makefile
+++ b/samples/databases/mysql/Makefile
@@ -1,0 +1,34 @@
+include ../../../tests/common.mk
+
+CC_APP=/usr/bin/mysqld
+CC_APP_CMDLINE=${CC_APP} --console --user=root --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mariadb/plugin \
+						 --pid-file=/run/mariadb.pid --socket=/run/mysqld.sock --innodb-use-native-aio=OFF
+
+CC_IMAGE_SIZE=5G
+
+CC_IMAGE=sgxlkl-alpine.img
+
+SGXLKL_ENV=SGXLKL_TAP=sgxlkl_tap0 SGXLKL_ETHREADS=4 SGXLKL_CMDLINE="mem=128mb"
+
+VERBOSE_OPTS=SGXLKL_VERBOSE=1 SGXLKL_KERNEL_VERBOSE=1 
+
+ifeq ($(SGXLKL_VERBOSE),)
+	SGXLKL_ENV+=${VERBOSE_OPTS}
+endif
+
+.DELETE_ON_ERROR:
+.PHONY: all clean run-hw run-sw
+
+all: $(CC_IMAGE)
+
+$(CC_IMAGE):
+	${SGXLKL_DISK_TOOL} create --size=${CC_IMAGE_SIZE} --docker="./Dockerfile" ${CC_IMAGE}
+
+run-hw: clean $(CC_IMAGE)
+	${SGXLKL_ENV} ${SGXLKL_STARTER} --hw-debug $(CC_IMAGE) $(CC_APP_CMDLINE)
+
+run-sw: clean $(CC_IMAGE)
+	${SGXLKL_ENV} ${SGXLKL_STARTER} --sw-debug $(CC_IMAGE) $(CC_APP_CMDLINE)
+
+clean:
+	rm -f $(CC_IMAGE)*

--- a/samples/databases/mysql/README.md
+++ b/samples/databases/mysql/README.md
@@ -1,0 +1,35 @@
+Running MySQL with SGX-LKL-OE
+=============================
+
+The following instructions launch a MySQL instance inside of an SGX enclave and then run the multi-threaded sysbench OLTP benchmark using that instance.
+
+1. Install the ``mariadb-client`` and ``sysbench`` Ubuntu packages on the host.
+
+2. Ensure that you have set up networking support for SGX-LKL by having run `tools/sgx-lkl-setup`.
+
+3. Launch MySQL in an SGX hardware enclave with:
+
+```
+make run-hw
+```
+or in software mode with:
+
+```
+make run-sw
+```
+
+4. After the MySQL instance is running, create a new benchmarking database:
+
+```
+mysql -h 10.0.1.1 -u root -e 'create database sbtest'
+```
+
+5. Prepare the sysbench OLTP data in the database. The following command creates an approx. 2.5 GB database spread across 10 tables:
+```
+sysbench oltp_read_write --threads=4 --db-driver=mysql --mysql-host=10.0.1.1 --mysql-user=root --tables=10 --table-size=1000000 prepare
+```
+
+6. Run the OLTP sysbench benchmark with 4 threads for 20 seconds:
+```
+sysbench oltp_read_write --threads=4 --events=0 --time=20 --db-driver=mysql --mysql-host=10.0.1.1 --mysql-user=root --tables=10 --table-size=1000000 --report-interval=1 run
+```

--- a/samples/databases/mysql/my.cnf
+++ b/samples/databases/mysql/my.cnf
@@ -1,0 +1,152 @@
+# Example MariaDB config file for medium systems.
+#
+# This is for a system with little memory (32M - 64M) where MariaDB plays
+# an important part, or systems up to 128M where MariaDB is used together with
+# other programs (such as a web server)
+#
+# MariaDB programs look for option files in a set of
+# locations which depend on the deployment platform.
+# You can copy this option file to one of those
+# locations. For information about these locations, do:
+# 'my_print_defaults --help' and see what is printed under
+# Default options are read from the following files in the given order:
+# More information at: http://dev.mysql.com/doc/mysql/en/option-files.html
+#
+# In this file, you can use all long options that a program supports.
+# If you want to know which options a program supports, run the program
+# with the "--help" option.
+
+# The following options will be passed to all MariaDB clients
+[client]
+#password	= your_password
+port		= 3306
+socket		= /run/mysqld/mysqld.sock
+
+# Here follows entries for some specific programs
+
+# The MariaDB server
+[mysqld]
+port		= 3306
+socket		= /run/mysqld/mysqld.sock
+bind-address = 0.0.0.0
+skip-grant-tables
+skip-external-locking
+key_buffer_size = 16M
+max_allowed_packet = 1M
+table_open_cache = 64
+sort_buffer_size = 512K
+net_buffer_length = 8K
+read_buffer_size = 256K
+read_rnd_buffer_size = 512K
+myisam_sort_buffer_size = 8M
+
+# Point the following paths to different dedicated disks
+#tmpdir		= /tmp/
+
+# Don't listen on a TCP/IP port at all. This can be a security enhancement,
+# if all processes that need to connect to mysqld run on the same host.
+# All interaction with mysqld must be made via Unix sockets or named pipes.
+# Note that using this option without enabling named pipes on Windows
+# (via the "enable-named-pipe" option) will render mysqld useless!
+# 
+#skip-networking
+
+# Replication Master Server (default)
+# binary logging is required for replication
+log-bin=mysql-bin
+
+# binary logging format - mixed recommended
+binlog_format=mixed
+
+# required unique id between 1 and 2^32 - 1
+# defaults to 1 if master-host is not set
+# but will not function as a master if omitted
+server-id	= 1
+
+# Replication Slave (comment out master section to use this)
+#
+# To configure this host as a replication slave, you can choose between
+# two methods :
+#
+# 1) Use the CHANGE MASTER TO command (fully described in our manual) -
+#    the syntax is:
+#
+#    CHANGE MASTER TO MASTER_HOST=<host>, MASTER_PORT=<port>,
+#    MASTER_USER=<user>, MASTER_PASSWORD=<password> ;
+#
+#    where you replace <host>, <user>, <password> by quoted strings and
+#    <port> by the master's port number (3306 by default).
+#
+#    Example:
+#
+#    CHANGE MASTER TO MASTER_HOST='125.564.12.1', MASTER_PORT=3306,
+#    MASTER_USER='joe', MASTER_PASSWORD='secret';
+#
+# OR
+#
+# 2) Set the variables below. However, in case you choose this method, then
+#    start replication for the first time (even unsuccessfully, for example
+#    if you mistyped the password in master-password and the slave fails to
+#    connect), the slave will create a master.info file, and any later
+#    change in this file to the variables' values below will be ignored and
+#    overridden by the content of the master.info file, unless you shutdown
+#    the slave server, delete master.info and restart the slaver server.
+#    For that reason, you may want to leave the lines below untouched
+#    (commented) and instead use CHANGE MASTER TO (see above)
+#
+# required unique id between 2 and 2^32 - 1
+# (and different from the master)
+# defaults to 2 if master-host is set
+# but will not function as a slave if omitted
+#server-id       = 2
+#
+# The replication master for this slave - required
+#master-host     =   <hostname>
+#
+# The username the slave will use for authentication when connecting
+# to the master - required
+#master-user     =   <username>
+#
+# The password the slave will authenticate with when connecting to
+# the master - required
+#master-password =   <password>
+#
+# The port the master is listening on.
+# optional - defaults to 3306
+#master-port     =  <port>
+#
+# binary logging - not required for slaves, but recommended
+#log-bin=mysql-bin
+
+# Uncomment the following if you are using InnoDB tables
+#innodb_data_home_dir = /var/lib/mysql
+#innodb_data_file_path = ibdata1:10M:autoextend
+#innodb_log_group_home_dir = /var/lib/mysql
+# You can set .._buffer_pool_size up to 50 - 80 %
+# of RAM but beware of setting memory usage too high
+#innodb_buffer_pool_size = 16M
+#innodb_additional_mem_pool_size = 2M
+# Set .._log_file_size to 25 % of buffer pool size
+#innodb_log_file_size = 5M
+#innodb_log_buffer_size = 8M
+#innodb_flush_log_at_trx_commit = 1
+#innodb_lock_wait_timeout = 50
+
+[mysqldump]
+quick
+max_allowed_packet = 16M
+
+[mysql]
+no-auto-rehash
+# Remove the next comment character if you are not familiar with SQL
+#safe-updates
+
+[myisamchk]
+key_buffer_size = 20M
+sort_buffer_size = 20M
+read_buffer = 2M
+write_buffer = 2M
+
+[mysqlhotcopy]
+interactive-timeout
+[    0.050865] reboot: Restarting system

--- a/src/enclave/enclave_signal.c
+++ b/src/enclave/enclave_signal.c
@@ -229,6 +229,8 @@ static uint64_t sgxlkl_enclave_signal_handler(
 static void _sgxlkl_illegal_instr_hook(uint16_t opcode, oe_context_t* context)
 {
     uint32_t rax, rbx, rcx, rdx;
+    char* instruction_name = "";
+
     switch (opcode)
     {
         case OE_CPUID_OPCODE:
@@ -257,10 +259,18 @@ static void _sgxlkl_illegal_instr_hook(uint16_t opcode, oe_context_t* context)
             context->rdx = rdx;
             break;
         default:
+            switch (opcode)
+            {
+                case (0x50f):
+                    instruction_name = "syscall";
+                    break;
+            }
+
             sgxlkl_fail(
                 "Encountered an illegal instruction inside enclave "
-                "(opcode=0x%x)\n",
-                opcode);
+                "(opcode=0x%x [%s])\n",
+                opcode,
+                instruction_name);
     }
 
     /* Skip over the illegal instruction. */


### PR DESCRIPTION
This PR adds MySQL as a sample application, running the sysbench OLTP benchmark with a 2.5 GB database.

@AntonioND, after this has been merged, could you add this to the nightly CI using your expect scripts? Thanks.