### PR TITLE
Disable rt_sigqueueinfo test which is failing with ethreads > 1

### DIFF
--- a/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
+++ b/tests/ltp/ltp-batch2/ltp_disabled_tests.txt
@@ -755,7 +755,7 @@
 #/ltp/testcases/kernel/syscalls/rt_sigaction/rt_sigaction03
 #/ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask01
 #/ltp/testcases/kernel/syscalls/rt_sigprocmask/rt_sigprocmask02
-#/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
+/ltp/testcases/kernel/syscalls/rt_sigqueueinfo/rt_sigqueueinfo01
 /ltp/testcases/kernel/syscalls/rt_sigsuspend/rt_sigsuspend01
 /ltp/testcases/kernel/syscalls/sbrk/sbrk01
 #/ltp/testcases/kernel/syscalls/sbrk/sbrk02


### PR DESCRIPTION
Revert change to one test made in https://github.com/lsds/sgx-lkl/pull/832 as it fails in the CI with ethreads > 1.